### PR TITLE
feat: improve wallet connection UX - show truncated address with dropdown actions

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,3 +1,4 @@
+import { Toaster } from "@/components/ui/toaster"
 import type React from "react"
 import type { Metadata } from "next"
 import { GeistSans } from "geist/font/sans"
@@ -41,6 +42,7 @@ export default function RootLayout({
           <Web3Provider>{children}</Web3Provider>
         </Suspense>
         <Analytics />
+        <Toaster />
       </body>
     </html>
   )

--- a/frontend/components/dashboard/dashboard-header.tsx
+++ b/frontend/components/dashboard/dashboard-header.tsx
@@ -1,14 +1,49 @@
 "use client"
 
+import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import Link from "next/link"
 import Image from "next/image"
 import { useStellar } from "@/components/web3-provider"
-import { Menu } from "lucide-react"
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
+import { useRouter } from "next/navigation"
+import { useToast } from "@/hooks/use-toast"
+import { Copy, Check, ExternalLink, LogOut, ChevronDown } from "lucide-react"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 
 export function DashboardHeader() {
-  const { address, disconnect } = useStellar()
+  const { address, walletId, disconnect } = useStellar()
+  const router = useRouter()
+  const { toast } = useToast()
+  const [copied, setCopied] = useState(false)
+
+  const truncatedAddress = address
+    ? `${address.slice(0, 4)}...${address.slice(-4)}`
+    : ""
+
+  const explorerUrl =
+    address && walletId
+      ? `https://stellar.expert/explorer/testnet/account/${address}?tab=operations&network=${walletId}`
+      : address
+        ? `https://stellar.expert/explorer/testnet/account/${address}`
+        : "#"
+
+  const handleDisconnect = () => {
+    disconnect()
+    router.push("/")
+  }
+
+  const handleCopyAddress = async () => {
+    if (!address) return
+    await navigator.clipboard.writeText(address)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2500)
+  }
 
   return (
     <header className="sticky top-0 z-50 border-b border-border/40 bg-background/80 backdrop-blur-lg">
@@ -16,10 +51,10 @@ export function DashboardHeader() {
         <div className="flex h-16 items-center justify-between">
           <Link href="/" className="flex items-center gap-2">
             <div className="flex h-10 w-10 items-center justify-center rounded-xl overflow-hidden">
-              <Image 
-                src="/joint-save.jpg" 
-                alt="JointSave Logo" 
-                width={40} 
+              <Image
+                src="/joint-save.jpg"
+                alt="JointSave Logo"
+                width={40}
                 height={40}
                 className="object-cover"
               />
@@ -27,23 +62,51 @@ export function DashboardHeader() {
             <span className="text-xl font-bold">JointSave</span>
           </Link>
 
-          <div className="flex items-center gap-4">
-            <Button onClick={disconnect} variant="outline" className="hidden sm:flex">
-              {address?.slice(0, 6)}...{address?.slice(-4)}
-            </Button>
-
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon" className="sm:hidden">
-                  <Menu className="h-5 w-5" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={disconnect}>
-                  Disconnect: {address?.slice(0, 6)}...{address?.slice(-4)}
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+          <div className="flex items-center gap-2">
+            {address ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline" className="gap-2">
+                    <span className="hidden sm:inline">{truncatedAddress}</span>
+                    <span className="sm:hidden">{truncatedAddress}</span>
+                    <ChevronDown className="h-4 w-4 opacity-60" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-56">
+                  <DropdownMenuItem className="cursor-default font-mono text-xs">
+                    {address}
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={handleCopyAddress}>
+                    {copied ? <Check className="mr-2 h-4 w-4" /> : <Copy className="mr-2 h-4 w-4" />}
+                    {copied ? "Copied" : "Copy Address"}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem asChild>
+                    <a
+                      href={explorerUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex w-full cursor-pointer items-center"
+                    >
+                      <ExternalLink className="mr-2 h-4 w-4" />
+                      View on Explorer
+                    </a>
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onClick={handleDisconnect}
+                    variant="destructive"
+                  >
+                    <LogOut className="mr-2 h-4 w-4" />
+                    Disconnect Wallet
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : (
+              <Button asChild variant="outline">
+                <Link href="/">Back to Home</Link>
+              </Button>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/components/landing/header.tsx
+++ b/frontend/components/landing/header.tsx
@@ -1,12 +1,47 @@
 "use client"
 
+import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import Link from "next/link"
 import Image from "next/image"
 import { useStellar } from "@/components/web3-provider"
+import { useToast } from "@/hooks/use-toast"
+import { Copy, Check, ExternalLink, LogOut, ChevronDown } from "lucide-react"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 
 export function Header() {
-  const { address, isConnected, connect, disconnect } = useStellar()
+  const { address, walletId, connect, disconnect } = useStellar()
+  const { toast } = useToast()
+  const [copied, setCopied] = useState(false)
+
+  const truncatedAddress = address
+    ? `${address.slice(0, 4)}...${address.slice(-4)}`
+    : ""
+
+  const explorerUrl =
+    address && walletId
+      ? `https://stellar.expert/explorer/testnet/account/${address}?tab=operations&network=${walletId}`
+      : address
+        ? `https://stellar.expert/explorer/testnet/account/${address}`
+        : "#"
+
+  const handleDisconnect = () => {
+    disconnect()
+    window.location.href = "/"
+  }
+
+  const handleCopyAddress = async () => {
+    if (!address) return
+    await navigator.clipboard.writeText(address)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2500)
+  }
 
   return (
     <header className="fixed top-0 left-0 right-0 z-50 border-b border-border/40 bg-background/80 backdrop-blur-lg">
@@ -38,15 +73,44 @@ export function Header() {
           </nav>
 
           <div className="flex items-center gap-4">
-            {isConnected ? (
-              <>
-                <Button variant="ghost" asChild className="hidden sm:flex">
-                  <Link href="/dashboard">Dashboard</Link>
-                </Button>
-                <Button onClick={disconnect} variant="outline">
-                  {address?.slice(0, 6)}...{address?.slice(-4)}
-                </Button>
-              </>
+            {address ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline" className="gap-2">
+                    <span>{truncatedAddress}</span>
+                    <ChevronDown className="h-4 w-4 opacity-60" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-56">
+                  <DropdownMenuItem className="cursor-default font-mono text-xs">
+                    {address}
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={handleCopyAddress}>
+                    {copied ? <Check className="mr-2 h-4 w-4" /> : <Copy className="mr-2 h-4 w-4" />}
+                    {copied ? "Copied" : "Copy Address"}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem asChild>
+                    <a
+                      href={explorerUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex w-full cursor-pointer items-center"
+                    >
+                      <ExternalLink className="mr-2 h-4 w-4" />
+                      View on Explorer
+                    </a>
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onClick={handleDisconnect}
+                    variant="destructive"
+                  >
+                    <LogOut className="mr-2 h-4 w-4" />
+                    Disconnect Wallet
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             ) : (
               <Button onClick={connect} className="bg-primary hover:bg-primary/90">
                 Connect Wallet

--- a/frontend/components/ui/toast.tsx
+++ b/frontend/components/ui/toast.tsx
@@ -25,7 +25,7 @@ const ToastViewport = React.forwardRef<
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName
 
 const toastVariants = cva(
-  'group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full',
+  'group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border bg-foreground text-background p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full',
   {
     variants: {
       variant: {

--- a/frontend/components/web3-provider.tsx
+++ b/frontend/components/web3-provider.tsx
@@ -35,6 +35,7 @@ export const STELLAR_NETWORK_PASSPHRASE =
 interface StellarContextValue {
   kit: StellarWalletsKit | null
   address: string | null
+  walletId: string | null
   isConnected: boolean
   connect: () => Promise<void>
   disconnect: () => void
@@ -43,6 +44,7 @@ interface StellarContextValue {
 const StellarContext = createContext<StellarContextValue>({
   kit: null,
   address: null,
+  walletId: null,
   isConnected: false,
   connect: async () => {},
   disconnect: () => {},
@@ -57,6 +59,7 @@ export function useStellar() {
 export function Web3Provider({ children }: { children: ReactNode }) {
   const [kit, setKit] = useState<StellarWalletsKit | null>(null)
   const [address, setAddress] = useState<string | null>(null)
+  const [walletId, setWalletId] = useState<string | null>(null)
 
   // Initialise the kit once on the client
   useEffect(() => {
@@ -72,9 +75,10 @@ export function Web3Provider({ children }: { children: ReactNode }) {
     })
     setKit(walletKit)
 
-    // Restore session if previously connected
-    const saved = localStorage.getItem("jointsave_address")
-    if (saved) setAddress(saved)
+    const savedAddress = localStorage.getItem("jointsave_address")
+    const savedWalletId = localStorage.getItem("jointsave_wallet_id")
+    if (savedAddress) setAddress(savedAddress)
+    if (savedWalletId) setWalletId(savedWalletId)
   }, [])
 
   const connect = useCallback(async () => {
@@ -84,21 +88,29 @@ export function Web3Provider({ children }: { children: ReactNode }) {
         kit.setWallet(option.id)
         const { address: addr } = await kit.getAddress()
         setAddress(addr)
+        setWalletId(option.id)
         localStorage.setItem("jointsave_address", addr)
+        localStorage.setItem("jointsave_wallet_id", option.id)
       },
     })
   }, [kit])
 
   const disconnect = useCallback(() => {
+    if (kit) {
+      kit.disconnect().catch(() => {})
+    }
     setAddress(null)
+    setWalletId(null)
     localStorage.removeItem("jointsave_address")
-  }, [])
+    localStorage.removeItem("jointsave_wallet_id")
+  }, [kit])
 
   return (
     <StellarContext.Provider
       value={{
         kit,
         address,
+        walletId,
         isConnected: !!address,
         connect,
         disconnect,


### PR DESCRIPTION
### This PR improves the wallet connection experience in the header for both the landing page and the dashboard.

## What changed
- Truncated address display is now the default connected state instead of a plain disconnect button.
- Clicking the truncated address opens a dropdown with:
  - full wallet address,
  - copy-to-clipboard action,
  - link to view the account on Stellar Expert testnet explorer,
  - disconnect action that clears local state and redirects to the landing page.
- The connected wallet selection is now preserved in state, so the disconnect flow can clean up correctly.
- Keyboard accessibility is preserved: Escape closes the dropdown.
Why
- Users had no clear confirmation of which account was connected.
- The previous clickable disconnected immediately on second click.
- The dropdown provides a standard, discoverable wallet menu pattern.

## Visual image of implementation
<img width="1917" height="959" alt="Screenshot 2026-06-15 at 22 34 44" src="https://github.com/user-attachments/assets/609c59a3-fba2-45fd-8985-fff932e47e36" />

closes #15 