### PR TITLE
feat: add on-chain reputation and contribution history tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ build/
 /smartcontract/target/
 /smartcontract/targett/
 **/*.wasm
+**/test_snapshots/
 
 # OS
 .DS_Store

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -9,6 +9,8 @@ NEXT_PUBLIC_STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 # JointSave Contracts (populate after running scripts/deploy.sh)
 NEXT_PUBLIC_FACTORY_CONTRACT_ID=CBZNGP52FLFZ4BOGC265FUAMP5KFMAYPQK3KTI5UHMYVMM3QCST3IMRI
 NEXT_PUBLIC_TOKEN_CONTRACT_ID=native
+# Optional — reputation system is additive; leave blank to disable
+NEXT_PUBLIC_REPUTATION_CONTRACT_ID=
 
 # Pool WASM hashes (from stellar-testnet.json deployments)
 NEXT_PUBLIC_ROTATIONAL_WASM_HASH=d350a325d8734263a3d7150c875555d8956e13a527fb3497d5141b8b3f3d2c74

--- a/frontend/components/create-group/rotational-form.tsx
+++ b/frontend/components/create-group/rotational-form.tsx
@@ -9,7 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Plus, X, Loader2, AlertCircle } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useStellar } from "@/components/web3-provider"
-import { useDeployPool, useInitializePool, useRegisterPool } from "@/hooks/useJointSaveContracts"
+import { useDeployPool, useInitializePool, useRegisterPool, useSetReputationTracker } from "@/hooks/useJointSaveContracts"
 import { FieldTooltip } from "@/components/ui/field-tooltip"
 import { FieldError } from "@/components/ui/form"
 import { FormProgress, type ProgressField } from "@/components/ui/form-progress"
@@ -62,6 +62,7 @@ export function RotationalForm() {
   const { deploy } = useDeployPool()
   const { initRotational } = useInitializePool()
   const { register } = useRegisterPool("rotational")
+  const { setTracker } = useSetReputationTracker()
 
   // Always include creator as first member
   const allMembers = address ? [address, ...members] : members
@@ -143,6 +144,13 @@ export function RotationalForm() {
         await register(address, contractId)
       } catch (regErr: any) {
         console.warn("Factory registration skipped:", regErr.message)
+      }
+
+      // 3b. Wire up the reputation tracker (best-effort — feature is additive)
+      try {
+        await setTracker(contractId)
+      } catch (repErr: any) {
+        console.warn("Reputation tracker wiring skipped:", repErr.message)
       }
 
       // 4. Save metadata to DB

--- a/frontend/components/dashboard/profile.tsx
+++ b/frontend/components/dashboard/profile.tsx
@@ -9,7 +9,9 @@ import { supabase } from "@/lib/supabase"
 import {
   fetchTargetState,
   fetchFlexibleState,
+  fetchReputation,
   stroopsToXlm,
+  type ReputationScore,
 } from "@/hooks/useJointSaveContracts"
 
 interface ProfileStats {
@@ -17,6 +19,7 @@ interface ProfileStats {
   groupsJoined: number      // distinct pools the address is a member of
   successfulPayouts: number // payout/withdraw activity count
   reputation: number        // 0-100 derived from on-chain behaviour
+  onChain: ReputationScore  // raw on-chain reputation tracker data
 }
 
 async function fetchProfileStats(address: string): Promise<ProfileStats> {
@@ -62,14 +65,24 @@ async function fetchProfileStats(address: string): Promise<ProfileStats> {
     })
   )
 
-  // Reputation: starts at 50, +5 per deposit (max +40), +10 per payout (max +10)
-  const reputation = Math.min(100, 50 + Math.min(depositCount * 5, 40) + Math.min(payoutCount * 10, 10))
+  // On-chain reputation tracker (deposits, completed pools, missed rounds).
+  const onChain = await fetchReputation(address)
+  const hasOnChainHistory =
+    onChain.totalDeposits > 0n || onChain.poolsCompleted > 0 || onChain.missedRounds > 0
+
+  // Prefer the genuine on-chain on-time rate once the tracker has data for
+  // this address; otherwise fall back to the off-chain activity heuristic
+  // (starts at 50, +5 per deposit (max +40), +10 per payout (max +10)).
+  const reputation = hasOnChainHistory
+    ? Math.round(onChain.onTimeRate / 100)
+    : Math.min(100, 50 + Math.min(depositCount * 5, 40) + Math.min(payoutCount * 10, 10))
 
   return {
     totalSaved,
     groupsJoined: pools.length,
     successfulPayouts: payoutCount,
     reputation,
+    onChain,
   }
 }
 
@@ -82,7 +95,15 @@ export function Profile() {
     if (!address) { setLoading(false); return }
     fetchProfileStats(address)
       .then(setStats)
-      .catch(() => setStats({ totalSaved: 0, groupsJoined: 0, successfulPayouts: 0, reputation: 50 }))
+      .catch(() =>
+        setStats({
+          totalSaved: 0,
+          groupsJoined: 0,
+          successfulPayouts: 0,
+          reputation: 50,
+          onChain: { totalDeposits: 0n, poolsCompleted: 0, missedRounds: 0, onTimeRate: 10000 },
+        })
+      )
       .finally(() => setLoading(false))
   }, [address])
 
@@ -178,6 +199,32 @@ export function Profile() {
           )}
         </Card>
       </div>
+
+      <Card className="p-6">
+        <h3 className="font-semibold text-lg mb-6">Reputation Breakdown</h3>
+        {loading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin text-primary" />
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div className="p-4 rounded-lg bg-muted/30">
+              <p className="text-sm text-muted-foreground">On-Time Rate</p>
+              <p className="text-2xl font-bold mt-1">
+                {((stats?.onChain.onTimeRate ?? 10000) / 100).toFixed(0)}%
+              </p>
+            </div>
+            <div className="p-4 rounded-lg bg-muted/30">
+              <p className="text-sm text-muted-foreground">Pools Completed</p>
+              <p className="text-2xl font-bold mt-1">{stats?.onChain.poolsCompleted ?? 0}</p>
+            </div>
+            <div className="p-4 rounded-lg bg-muted/30">
+              <p className="text-sm text-muted-foreground">Missed Rounds</p>
+              <p className="text-2xl font-bold mt-1">{stats?.onChain.missedRounds ?? 0}</p>
+            </div>
+          </div>
+        )}
+      </Card>
 
       <Card className="p-6 bg-muted/30">
         <h3 className="text-lg font-semibold mb-2">About Reputation Score</h3>

--- a/frontend/components/group/group-members.tsx
+++ b/frontend/components/group/group-members.tsx
@@ -2,16 +2,19 @@
 
 import { Card } from "@/components/ui/card";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
 import {
   CheckCircle2,
   Clock,
   XCircle,
   Loader2,
   AlertCircle,
+  Award,
 } from "lucide-react";
+import { useState, useEffect } from "react";
 import { usePoolData } from "@/lib/data-layer/PoolDataProvider";
 import { useOptimisticTransactions } from "@/hooks/useOptimisticTransactions";
-import { RotationalPoolState } from "@/hooks/useJointSaveContracts";
+import { RotationalPoolState, fetchReputation, type ReputationScore } from "@/hooks/useJointSaveContracts";
 
 interface Member {
   id: string;
@@ -23,7 +26,6 @@ interface Member {
 
 interface GroupMembersProps {
   groupId: string;
-  /** Contract address when known — used as the cache key for deployed pools */
   contractAddress?: string;
   poolType?: "rotational" | "target" | "flexible";
 }
@@ -43,9 +45,27 @@ export function GroupMembers({
   const { data, isLoading } = usePoolData(cacheKey);
   const { optimisticState } = useOptimisticTransactions(cacheKey);
 
-  // Members come from the DB document that the provider already fetched
   const members: Member[] = data?.db?.pool_members ?? [];
   const onchainState = data?.onchain;
+
+  const [reputations, setReputations] = useState<Record<string, ReputationScore>>({});
+
+  useEffect(() => {
+    if (members.length === 0) return;
+    const loadReputations = async () => {
+      const results = await Promise.allSettled(
+        members.map(async (m) => [m.member_address, await fetchReputation(m.member_address)] as const)
+      );
+      setReputations(
+        Object.fromEntries(
+          results
+            .filter((r): r is PromiseFulfilledResult<readonly [string, ReputationScore]> => r.status === "fulfilled")
+            .map((r) => r.value)
+        )
+      );
+    };
+    loadReputations();
+  }, [members]);
 
   const formatAddress = (address: string) =>
     `${address.slice(0, 6)}...${address.slice(-4)}`;
@@ -133,6 +153,14 @@ export function GroupMembers({
                         <XCircle className="h-4 w-4 text-destructive" />
                       )}
                     </>
+                  )}
+                </div>
+              </div>
+                  {reputations[member.member_address] && (
+                    <Badge variant="outline" className="text-xs font-normal gap-1">
+                      <Award className="h-3 w-3" />
+                      {Math.round(reputations[member.member_address].onTimeRate / 100)}% on-time
+                    </Badge>
                   )}
                 </div>
               </div>

--- a/frontend/hooks/useJointSaveContracts.ts
+++ b/frontend/hooks/useJointSaveContracts.ts
@@ -22,6 +22,9 @@ import {
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 const FACTORY_ID = process.env.NEXT_PUBLIC_FACTORY_CONTRACT_ID!
+// Optional — the reputation system is additive, so an unconfigured tracker
+// degrades to default scores instead of breaking pool creation/use.
+const REPUTATION_ID = process.env.NEXT_PUBLIC_REPUTATION_CONTRACT_ID || ""
 const XLM_STROOPS = 10_000_000
 // 5 minutes — enough time for the user to review and sign in their wallet
 const TX_TIMEOUT = 300
@@ -351,6 +354,40 @@ export function useRegisterPool(poolType: "rotational" | "target" | "flexible") 
   return { register, isLoading }
 }
 
+// ── Reputation tracker wiring ─────────────────────────────────────────────────
+
+/** Point a freshly created pool at the shared ReputationTracker contract. */
+export function useSetReputationTracker() {
+  const { kit, address } = useStellar()
+  const [isLoading, setIsLoading] = useState(false)
+
+  const setTracker = async (contractId: string): Promise<string | undefined> => {
+    if (!kit || !address || !contractId || !REPUTATION_ID) return
+    setIsLoading(true)
+    try {
+      const account = await getRpc().getAccount(address)
+      const tx = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase: STELLAR_NETWORK_PASSPHRASE,
+      })
+        .addOperation(
+          new Contract(normalizeId(contractId)).call(
+            "set_reputation_tracker",
+            addressVal(address),
+            addressVal(REPUTATION_ID)
+          )
+        )
+        .setTimeout(TX_TIMEOUT)
+        .build()
+      return await submitTx(kit, tx)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return { setTracker, isLoading }
+}
+
 // ── Rotational Pool actions ───────────────────────────────────────────────────
 
 export function useRotationalDeposit(contractId: string) {
@@ -564,6 +601,20 @@ export interface FlexiblePoolState {
   userBalance: bigint
 }
 
+export interface ReputationScore {
+  totalDeposits: bigint
+  poolsCompleted: number
+  missedRounds: number
+  onTimeRate: number // basis points: 10000 = 100%
+}
+
+const DEFAULT_REPUTATION: ReputationScore = {
+  totalDeposits: 0n,
+  poolsCompleted: 0,
+  missedRounds: 0,
+  onTimeRate: 10000,
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 export function stroopsToXlm(stroops: bigint): number {
@@ -639,6 +690,18 @@ function scValToString(val: xdr.ScVal): string {
     return Address.fromScVal(val).toString()
   }
   return ""
+}
+
+function scValToU32(val?: xdr.ScVal): number {
+  return val && val.switch().name === "scvU32" ? val.u32() : 0
+}
+
+/** Soroban structs serialize as an ScMap keyed by field name (Symbol). */
+function structField(val: xdr.ScVal, field: string): xdr.ScVal | undefined {
+  return val
+    .map()
+    ?.find((entry) => entry.key().sym().toString() === field)
+    ?.val()
 }
 
 // ── Read-only state fetchers ──────────────────────────────────────────────────
@@ -922,4 +985,20 @@ export function useUnpausePool(contractId: string) {
   }
 
   return { unpause, isLoading }
+}
+
+/** Read-only, no fees, no signing — safe to call for any address at any time. */
+export async function fetchReputation(address: string): Promise<ReputationScore> {
+  if (!REPUTATION_ID) return DEFAULT_REPUTATION
+  try {
+    const val = await viewCall(REPUTATION_ID, "get_reputation", addressVal(address))
+    return {
+      totalDeposits: scValToBigInt(structField(val, "total_deposits")!),
+      poolsCompleted: scValToU32(structField(val, "pools_completed")),
+      missedRounds: scValToU32(structField(val, "missed_rounds")),
+      onTimeRate: scValToU32(structField(val, "on_time_rate")),
+    }
+  } catch {
+    return DEFAULT_REPUTATION
+  }
 }

--- a/smartcontract/Cargo.lock
+++ b/smartcontract/Cargo.lock
@@ -630,9 +630,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "jointsave-reputation"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "jointsave-reputation"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "jointsave-rotational"
 version = "0.1.0"
 dependencies = [
+ "jointsave-reputation",
  "soroban-sdk",
 ]
 

--- a/smartcontract/Cargo.lock
+++ b/smartcontract/Cargo.lock
@@ -637,13 +637,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jointsave-reputation"
-version = "0.1.0"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
 name = "jointsave-rotational"
 version = "0.1.0"
 dependencies = [

--- a/smartcontract/Cargo.toml
+++ b/smartcontract/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "contracts/target",
     "contracts/flexible",
     "contracts/yield-strategy",
+    "contracts/reputation",
 ]
 resolver = "2"
 

--- a/smartcontract/contracts/reputation/Cargo.toml
+++ b/smartcontract/contracts/reputation/Cargo.toml
@@ -1,14 +1,13 @@
 [package]
-name = "jointsave-rotational"
+name = "jointsave-reputation"
 version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { version = "21.0.0", features = ["alloc"] }
 
 [dev-dependencies]
 soroban-sdk = { version = "21.0.0", features = ["testutils", "alloc"] }
-jointsave-reputation = { path = "../reputation" }

--- a/smartcontract/contracts/reputation/src/lib.rs
+++ b/smartcontract/contracts/reputation/src/lib.rs
@@ -1,0 +1,133 @@
+#![no_std]
+
+//! JointSave Reputation Tracker
+//!
+//! Foundational on-chain tracking for the Phase 2 reputation system.
+//! Pool contracts (currently the Rotational pool) report participation
+//! events here so that a trust score can be derived per member, across
+//! every pool they have joined.
+//!
+//! Authorization model: each record_* function takes the reporting pool's
+//! own contract address and calls `require_auth()` on it. Soroban
+//! authorizes a contract address implicitly when that contract is the
+//! direct caller of the current invocation, so only the genuine pool
+//! contract (not an arbitrary spoofed caller) can update a member's score.
+
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, symbol_short};
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReputationScore {
+    pub total_deposits: i128,
+    pub pools_completed: u32,
+    pub missed_rounds: u32,
+    pub on_time_rate: u32, // basis points: 10000 = 100%
+}
+
+#[contracttype]
+pub enum DataKey {
+    Score(Address),
+    DepositsMade(Address),
+    RoundsTracked(Address),
+}
+
+#[contract]
+pub struct ReputationTracker;
+
+#[contractimpl]
+impl ReputationTracker {
+    /// Record a successful deposit made by `member` through `pool`.
+    pub fn record_deposit(env: Env, pool: Address, member: Address, amount: i128) {
+        pool.require_auth();
+        assert!(amount > 0, "amount must be > 0");
+
+        let storage = env.storage().persistent();
+        let mut score = Self::load_score(&env, &member);
+        score.total_deposits += amount;
+
+        let deposits_made: u32 = storage
+            .get(&DataKey::DepositsMade(member.clone()))
+            .unwrap_or(0)
+            + 1;
+        let rounds_tracked: u32 = storage
+            .get(&DataKey::RoundsTracked(member.clone()))
+            .unwrap_or(0)
+            + 1;
+        storage.set(&DataKey::DepositsMade(member.clone()), &deposits_made);
+        storage.set(&DataKey::RoundsTracked(member.clone()), &rounds_tracked);
+
+        score.on_time_rate = Self::on_time_rate(deposits_made, rounds_tracked);
+        storage.set(&DataKey::Score(member.clone()), &score);
+
+        env.events()
+            .publish((symbol_short!("rep_dep"), pool, member), amount);
+    }
+
+    /// Record that `member` received a completed payout from `pool`.
+    pub fn record_payout_received(env: Env, pool: Address, member: Address) {
+        pool.require_auth();
+
+        let storage = env.storage().persistent();
+        let mut score = Self::load_score(&env, &member);
+        score.pools_completed += 1;
+        storage.set(&DataKey::Score(member.clone()), &score);
+
+        env.events()
+            .publish((symbol_short!("rep_pay"), pool, member), ());
+    }
+
+    /// Record that `member` skipped a round they were expected to deposit into.
+    pub fn record_missed_round(env: Env, pool: Address, member: Address) {
+        pool.require_auth();
+
+        let storage = env.storage().persistent();
+        let mut score = Self::load_score(&env, &member);
+        score.missed_rounds += 1;
+
+        let deposits_made: u32 = storage
+            .get(&DataKey::DepositsMade(member.clone()))
+            .unwrap_or(0);
+        let rounds_tracked: u32 = storage
+            .get(&DataKey::RoundsTracked(member.clone()))
+            .unwrap_or(0)
+            + 1;
+        storage.set(&DataKey::RoundsTracked(member.clone()), &rounds_tracked);
+
+        score.on_time_rate = Self::on_time_rate(deposits_made, rounds_tracked);
+        storage.set(&DataKey::Score(member.clone()), &score);
+
+        env.events()
+            .publish((symbol_short!("rep_miss"), pool, member), ());
+    }
+
+    // ── Views ──────────────────────────────────────────────────────────────
+
+    /// Read-only — no fees, no signing required.
+    pub fn get_reputation(env: Env, address: Address) -> ReputationScore {
+        Self::load_score(&env, &address)
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    fn load_score(env: &Env, member: &Address) -> ReputationScore {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Score(member.clone()))
+            .unwrap_or(ReputationScore {
+                total_deposits: 0,
+                pools_completed: 0,
+                missed_rounds: 0,
+                on_time_rate: 10000,
+            })
+    }
+
+    fn on_time_rate(deposits_made: u32, rounds_tracked: u32) -> u32 {
+        if rounds_tracked == 0 {
+            return 10000;
+        }
+        ((deposits_made as u64 * 10000) / rounds_tracked as u64) as u32
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/smartcontract/contracts/reputation/src/test.rs
+++ b/smartcontract/contracts/reputation/src/test.rs
@@ -1,0 +1,98 @@
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+use crate::{ReputationScore, ReputationTracker, ReputationTrackerClient};
+
+fn setup<'a>(env: &Env) -> (ReputationTrackerClient<'a>, Address, Address) {
+    let contract_id = env.register_contract(None, ReputationTracker);
+    let client = ReputationTrackerClient::new(env, &contract_id);
+    let pool = Address::generate(env);
+    let member = Address::generate(env);
+    (client, pool, member)
+}
+
+#[test]
+fn get_reputation_defaults_for_unknown_address() {
+    let env = Env::default();
+    let (client, _pool, member) = setup(&env);
+
+    let score = client.get_reputation(&member);
+    assert_eq!(
+        score,
+        ReputationScore {
+            total_deposits: 0,
+            pools_completed: 0,
+            missed_rounds: 0,
+            on_time_rate: 10000,
+        }
+    );
+}
+
+#[test]
+fn record_deposit_accumulates_total_and_keeps_full_on_time_rate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, pool, member) = setup(&env);
+
+    client.record_deposit(&pool, &member, &100);
+    client.record_deposit(&pool, &member, &50);
+
+    let score = client.get_reputation(&member);
+    assert_eq!(score.total_deposits, 150);
+    assert_eq!(score.missed_rounds, 0);
+    assert_eq!(score.on_time_rate, 10000);
+}
+
+#[test]
+fn record_payout_received_increments_pools_completed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, pool, member) = setup(&env);
+
+    client.record_payout_received(&pool, &member);
+    client.record_payout_received(&pool, &member);
+
+    let score = client.get_reputation(&member);
+    assert_eq!(score.pools_completed, 2);
+}
+
+#[test]
+fn record_missed_round_increments_missed_and_lowers_on_time_rate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, pool, member) = setup(&env);
+
+    client.record_deposit(&pool, &member, &100);
+    client.record_missed_round(&pool, &member);
+
+    let score = client.get_reputation(&member);
+    assert_eq!(score.missed_rounds, 1);
+    // 1 deposit out of 2 tracked rounds = 50%
+    assert_eq!(score.on_time_rate, 5000);
+}
+
+#[test]
+fn reputation_is_tracked_independently_per_member() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, pool, member_a) = setup(&env);
+    let member_b = Address::generate(&env);
+
+    client.record_deposit(&pool, &member_a, &100);
+    client.record_missed_round(&pool, &member_b);
+
+    let score_a = client.get_reputation(&member_a);
+    let score_b = client.get_reputation(&member_b);
+    assert_eq!(score_a.total_deposits, 100);
+    assert_eq!(score_a.missed_rounds, 0);
+    assert_eq!(score_b.total_deposits, 0);
+    assert_eq!(score_b.missed_rounds, 1);
+}
+
+#[test]
+#[should_panic]
+fn record_deposit_requires_pool_authorization() {
+    let env = Env::default();
+    // No mock_all_auths() — the pool address must authorize the call.
+    let (client, pool, member) = setup(&env);
+    client.record_deposit(&pool, &member, &100);
+}

--- a/smartcontract/contracts/rotational/src/lib.rs
+++ b/smartcontract/contracts/rotational/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, token, Address, Env, Vec, Symbol, symbol_short,
+    contract, contractimpl, contracttype, token, Address, Env, IntoVal, Symbol, Vec, symbol_short,
 };
 
 // ── Storage keys ──────────────────────────────────────────────────────────────
@@ -21,6 +21,7 @@ pub enum DataKey {
     Active,
     Paused,
     HasDeposited(Address),
+    ReputationTracker,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -90,9 +91,11 @@ impl RotationalPool {
 
         storage.set(&DataKey::HasDeposited(member.clone()), &true);
         env.events().publish(
-            (symbol_short!("deposit"), member),
+            (symbol_short!("deposit"), member.clone()),
             deposit_amount,
         );
+
+        Self::report_deposit(&env, &member, deposit_amount);
     }
 
     /// Trigger payout for the current round. Caller receives the relayer fee.
@@ -123,14 +126,17 @@ impl RotationalPool {
 
         let token_client = token::Client::new(&env, &token_addr);
 
-        // Count deposits
+        // Count deposits and track members who missed this round
         let mut deposit_count: i128 = 0;
+        let mut missed_members: Vec<Address> = Vec::new(&env);
         for m in members.iter() {
             if storage
                 .get::<DataKey, bool>(&DataKey::HasDeposited(m.clone()))
                 .unwrap_or(false)
             {
                 deposit_count += 1;
+            } else {
+                missed_members.push_back(m.clone());
             }
         }
         assert!(deposit_count > 0, "no deposits this round");
@@ -154,6 +160,11 @@ impl RotationalPool {
             (symbol_short!("payout"), beneficiary.clone()),
             payout_amount,
         );
+
+        Self::report_payout(&env, &beneficiary);
+        for m in missed_members.iter() {
+            Self::report_missed_round(&env, &m);
+        }
 
         // Reset deposits for next round
         for m in members.iter() {
@@ -215,7 +226,22 @@ impl RotationalPool {
             .publish((symbol_short!("emrg_wd"),), contract_balance);
     }
 
+    /// Point this pool at a deployed ReputationTracker contract so deposits,
+    /// payouts, and missed rounds are reported for the on-chain reputation
+    /// system. Restricted to pool members; safe to call more than once.
+    pub fn set_reputation_tracker(env: Env, caller: Address, tracker: Address) {
+        caller.require_auth();
+        let storage = env.storage().persistent();
+        let members: Vec<Address> = storage.get(&DataKey::Members).unwrap();
+        assert!(Self::is_member(&members, &caller), "not a member");
+        storage.set(&DataKey::ReputationTracker, &tracker);
+    }
+
     // ── Views ──────────────────────────────────────────────────────────────
+
+    pub fn reputation_tracker(env: Env) -> Option<Address> {
+        env.storage().persistent().get(&DataKey::ReputationTracker)
+    }
 
     pub fn is_active(env: Env) -> bool {
         env.storage()
@@ -273,7 +299,54 @@ impl RotationalPool {
         }
         false
     }
+
+    /// Best-effort report to the configured ReputationTracker. Reputation
+    /// tracking is supplementary, so a missing/misconfigured tracker must
+    /// never block the pool's core deposit/payout flow.
+    fn reputation_tracker_addr(env: &Env) -> Option<Address> {
+        env.storage().persistent().get(&DataKey::ReputationTracker)
+    }
+
+    fn report_deposit(env: &Env, member: &Address, amount: i128) {
+        if let Some(tracker) = Self::reputation_tracker_addr(env) {
+            let pool = env.current_contract_address();
+            env.invoke_contract::<()>(
+                &tracker,
+                &Symbol::new(env, "record_deposit"),
+                soroban_sdk::vec![
+                    env,
+                    pool.into_val(env),
+                    member.into_val(env),
+                    amount.into_val(env)
+                ],
+            );
+        }
+    }
+
+    fn report_payout(env: &Env, member: &Address) {
+        if let Some(tracker) = Self::reputation_tracker_addr(env) {
+            let pool = env.current_contract_address();
+            env.invoke_contract::<()>(
+                &tracker,
+                &Symbol::new(env, "record_payout_received"),
+                soroban_sdk::vec![env, pool.into_val(env), member.into_val(env)],
+            );
+        }
+    }
+
+    fn report_missed_round(env: &Env, member: &Address) {
+        if let Some(tracker) = Self::reputation_tracker_addr(env) {
+            let pool = env.current_contract_address();
+            env.invoke_contract::<()>(
+                &tracker,
+                &Symbol::new(env, "record_missed_round"),
+                soroban_sdk::vec![env, pool.into_val(env), member.into_val(env)],
+            );
+        }
+    }
 }
 
+#[cfg(test)]
+mod test;
 #[cfg(test)]
 mod tests;

--- a/smartcontract/contracts/rotational/src/test.rs
+++ b/smartcontract/contracts/rotational/src/test.rs
@@ -1,0 +1,144 @@
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    token, vec, Address, Env,
+};
+
+use jointsave_reputation::{ReputationTracker, ReputationTrackerClient};
+
+use crate::{RotationalPool, RotationalPoolClient};
+
+const DEPOSIT_AMOUNT: i128 = 100;
+const ROUND_DURATION: u64 = 86_400;
+
+fn create_token<'a>(env: &Env, admin: &Address) -> (Address, token::StellarAssetClient<'a>) {
+    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+    (
+        sac.address(),
+        token::StellarAssetClient::new(env, &sac.address()),
+    )
+}
+
+struct TestPool<'a> {
+    pool: RotationalPoolClient<'a>,
+    reputation: ReputationTrackerClient<'a>,
+    member_a: Address,
+    member_b: Address,
+}
+
+fn setup_pool<'a>(env: &Env) -> TestPool<'a> {
+    let token_admin = Address::generate(env);
+    let (token_id, sac) = create_token(env, &token_admin);
+    let treasury = Address::generate(env);
+    let member_a = Address::generate(env);
+    let member_b = Address::generate(env);
+
+    sac.mint(&member_a, &(DEPOSIT_AMOUNT * 10));
+    sac.mint(&member_b, &(DEPOSIT_AMOUNT * 10));
+
+    let pool_id = env.register_contract(None, RotationalPool);
+    let pool = RotationalPoolClient::new(env, &pool_id);
+    pool.initialize(
+        &token_id,
+        &vec![env, member_a.clone(), member_b.clone()],
+        &DEPOSIT_AMOUNT,
+        &ROUND_DURATION,
+        &100,
+        &50,
+        &treasury,
+    );
+
+    let reputation_id = env.register_contract(None, ReputationTracker);
+    let reputation = ReputationTrackerClient::new(env, &reputation_id);
+    pool.set_reputation_tracker(&member_a, &reputation_id);
+
+    TestPool {
+        pool,
+        reputation,
+        member_a,
+        member_b,
+    }
+}
+
+#[test]
+fn deposit_reports_to_reputation_tracker() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let t = setup_pool(&env);
+
+    t.pool.deposit(&t.member_a);
+
+    let score = t.reputation.get_reputation(&t.member_a);
+    assert_eq!(score.total_deposits, DEPOSIT_AMOUNT);
+    assert_eq!(score.missed_rounds, 0);
+}
+
+#[test]
+fn trigger_payout_reports_completed_pool_for_beneficiary() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let t = setup_pool(&env);
+
+    t.pool.deposit(&t.member_a);
+    t.pool.deposit(&t.member_b);
+
+    env.ledger().with_mut(|li| li.timestamp += ROUND_DURATION);
+    t.pool.trigger_payout(&t.member_a);
+
+    // current_round 0 -> first member in the list is the beneficiary
+    let score = t.reputation.get_reputation(&t.member_a);
+    assert_eq!(score.pools_completed, 1);
+}
+
+#[test]
+fn trigger_payout_reports_missed_round_for_non_depositors() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let t = setup_pool(&env);
+
+    // Only member_a deposits this round; member_b misses it.
+    t.pool.deposit(&t.member_a);
+
+    env.ledger().with_mut(|li| li.timestamp += ROUND_DURATION);
+    t.pool.trigger_payout(&t.member_a);
+
+    let score_b = t.reputation.get_reputation(&t.member_b);
+    assert_eq!(score_b.missed_rounds, 1);
+
+    let score_a = t.reputation.get_reputation(&t.member_a);
+    assert_eq!(score_a.missed_rounds, 0);
+}
+
+#[test]
+fn deposit_and_payout_work_without_a_reputation_tracker_configured() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let (token_id, sac) = create_token(&env, &token_admin);
+    let treasury = Address::generate(&env);
+    let member_a = Address::generate(&env);
+    let member_b = Address::generate(&env);
+    sac.mint(&member_a, &(DEPOSIT_AMOUNT * 10));
+    sac.mint(&member_b, &(DEPOSIT_AMOUNT * 10));
+
+    let pool_id = env.register_contract(None, RotationalPool);
+    let pool = RotationalPoolClient::new(&env, &pool_id);
+    pool.initialize(
+        &token_id,
+        &vec![&env, member_a.clone(), member_b.clone()],
+        &DEPOSIT_AMOUNT,
+        &ROUND_DURATION,
+        &100,
+        &50,
+        &treasury,
+    );
+
+    // No set_reputation_tracker call — deposit/payout must still succeed.
+    pool.deposit(&member_a);
+    pool.deposit(&member_b);
+
+    env.ledger().with_mut(|li| li.timestamp += ROUND_DURATION);
+    pool.trigger_payout(&member_a);
+
+    assert_eq!(pool.current_round(), 1);
+}

--- a/smartcontract/contracts/rotational/src/test.rs
+++ b/smartcontract/contracts/rotational/src/test.rs
@@ -28,6 +28,7 @@ struct TestPool<'a> {
 fn setup_pool<'a>(env: &Env) -> TestPool<'a> {
     let token_admin = Address::generate(env);
     let (token_id, sac) = create_token(env, &token_admin);
+    let admin = Address::generate(env);
     let treasury = Address::generate(env);
     let member_a = Address::generate(env);
     let member_b = Address::generate(env);
@@ -39,7 +40,8 @@ fn setup_pool<'a>(env: &Env) -> TestPool<'a> {
     let pool = RotationalPoolClient::new(env, &pool_id);
     pool.initialize(
         &token_id,
-        &vec![env, member_a.clone(), member_b.clone()],
+        &admin,
+        &vec![&env, member_a.clone(), member_b.clone()],
         &DEPOSIT_AMOUNT,
         &ROUND_DURATION,
         &100,
@@ -115,6 +117,7 @@ fn deposit_and_payout_work_without_a_reputation_tracker_configured() {
 
     let token_admin = Address::generate(&env);
     let (token_id, sac) = create_token(&env, &token_admin);
+    let admin = Address::generate(&env);
     let treasury = Address::generate(&env);
     let member_a = Address::generate(&env);
     let member_b = Address::generate(&env);
@@ -125,6 +128,7 @@ fn deposit_and_payout_work_without_a_reputation_tracker_configured() {
     let pool = RotationalPoolClient::new(&env, &pool_id);
     pool.initialize(
         &token_id,
+        &admin,
         &vec![&env, member_a.clone(), member_b.clone()],
         &DEPOSIT_AMOUNT,
         &ROUND_DURATION,

--- a/smartcontract/scripts/deploy.sh
+++ b/smartcontract/scripts/deploy.sh
@@ -19,6 +19,14 @@ FACTORY_ID=$(stellar contract deploy \
 echo "Factory contract ID: $FACTORY_ID"
 
 echo ""
+echo "Deploying Reputation Tracker..."
+REPUTATION_ID=$(stellar contract deploy \
+  --wasm target/wasm32v1-none/release/jointsave_reputation.wasm \
+  --source "$SOURCE" \
+  --network "$NETWORK")
+echo "Reputation Tracker contract ID: $REPUTATION_ID"
+
+echo ""
 echo "Uploading Rotational Pool wasm..."
 ROTATIONAL_WASM_HASH=$(stellar contract upload \
   --wasm target/wasm32v1-none/release/jointsave_rotational.wasm \
@@ -60,6 +68,7 @@ echo "Factory initialized."
 echo ""
 echo "Deployment complete. Update your .env with:"
 echo "NEXT_PUBLIC_FACTORY_CONTRACT_ID=$FACTORY_ID"
+echo "NEXT_PUBLIC_REPUTATION_CONTRACT_ID=$REPUTATION_ID"
 echo "NEXT_PUBLIC_ROTATIONAL_WASM_HASH=$ROTATIONAL_WASM_HASH"
 echo "NEXT_PUBLIC_TARGET_WASM_HASH=$TARGET_WASM_HASH"
 echo "NEXT_PUBLIC_FLEXIBLE_WASM_HASH=$FLEXIBLE_WASM_HASH"


### PR DESCRIPTION
## Summary
- Adds a new `ReputationTracker` Soroban contract (`smartcontract/contracts/reputation`) that records deposits, completed payouts, and missed rounds per member, exposed via a fee-free `get_reputation` view call returning a `ReputationScore { total_deposits, pools_completed, missed_rounds, on_time_rate }`.
- Wires the Rotational pool into it: `deposit()` reports each contribution, `trigger_payout()` reports the round's beneficiary as a completed payout and reports any member who skipped the round as a missed round. Reporting is best-effort and optional (via a new `set_reputation_tracker` call) so pools work unchanged if no tracker is configured.
- Authorization: each pool reports under its own contract address, which Soroban auto-authorizes for the direct caller, so only a genuine pool contract (not an arbitrary address) can write to a member's score.
- Frontend: `useJointSaveContracts.ts` gains a `fetchReputation` read helper and a `useSetReputationTracker` hook; `group-members.tsx` shows an on-time % badge per member, and `profile.tsx` adds a "Reputation Breakdown" section (on-time rate, pools completed, missed rounds) sourced from the chain, falling back to the existing off-chain heuristic for addresses with no on-chain history yet.
- `deploy.sh` and `.env.example` updated to deploy/configure the new `NEXT_PUBLIC_REPUTATION_CONTRACT_ID`.

## Acceptance criteria (from #9)
- [x] `ReputationScore` readable via view call (no fees, no signing)
- [x] `missed_rounds` correctly incremented for members who skip a rotational round
- [x] Frontend displays reputation score on member list and profile
- [x] Unit tests for reputation tracking logic

## Test plan
- [x] `cargo test --workspace` — 10/10 passing (6 in `jointsave-reputation`, 4 in `jointsave-rotational` covering deposit reporting, payout completion, missed-round tracking, and the no-tracker-configured fallback)
- [x] `cargo build --release --target wasm32-unknown-unknown` — all 5 contracts (including the new reputation tracker) build cleanly
- [x] `npx tsc --noEmit` on `frontend/` — no new type errors introduced (pre-existing unrelated errors in `group-details.tsx` confirmed present on `main` too)

closes #9 