### PR TITLE
feat: add floating back-to-top button with smooth scroll and reduced-motion support (Closes #37)feat: add floating back-to-top button with smooth scroll and reduced-…

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,30 +1,28 @@
 "use client"
-
 import { useStellar } from "@/components/web3-provider"
 import { redirect } from "next/navigation"
 import { DashboardHeader } from "@/components/dashboard/dashboard-header"
 import { DashboardTabs } from "@/components/dashboard/dashboard-tabs"
+import { BackToTop } from "@/components/ui/back-to-top"
 import { useEffect } from "react"
 
 export default function DashboardPage() {
   const { isConnected } = useStellar()
-
   useEffect(() => {
     if (!isConnected) {
       redirect("/")
     }
   }, [isConnected])
-
   if (!isConnected) {
     return null
   }
-
   return (
     <div className="min-h-screen bg-background">
       <DashboardHeader />
       <main className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <DashboardTabs />
       </main>
+      <BackToTop />
     </div>
   )
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,10 +1,11 @@
-import { Hero } from "@/components/landing/hero"
+import import { Hero } from "@/components/landing/hero"
 import { Features } from "@/components/landing/features"
 import { HowItWorks } from "@/components/landing/how-it-works"
 import { Security } from "@/components/landing/security"
 import { CTA } from "@/components/landing/cta"
 import { Header } from "@/components/landing/header"
 import { Footer } from "@/components/landing/footer"
+import { BackToTop } from "@/components/ui/back-to-top"
 
 export default function LandingPage() {
   return (
@@ -18,6 +19,7 @@ export default function LandingPage() {
         <CTA />
       </main>
       <Footer />
+      <BackToTop />
     </div>
   )
 }

--- a/frontend/components/ui/back-to-top.tsx
+++ b/frontend/components/ui/back-to-top.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { ArrowUp } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+const SCROLL_THRESHOLD = 400
+
+export function BackToTop() {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const onScroll = () => {
+      setVisible(window.scrollY > SCROLL_THRESHOLD)
+    }
+    window.addEventListener("scroll", onScroll, { passive: true })
+    return () => window.removeEventListener("scroll", onScroll)
+  }, [])
+
+  const scrollToTop = () => {
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)"
+    ).matches
+    window.scrollTo({
+      top: 0,
+      behavior: prefersReducedMotion ? "instant" : "smooth",
+    })
+  }
+
+  return (
+    <button
+      onClick={scrollToTop}
+      aria-label="Back to top"
+      className={cn(
+        "fixed bottom-6 right-6 z-50 flex h-10 w-10 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg transition-opacity duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        "pb-[env(safe-area-inset-bottom)] pr-[env(safe-area-inset-right)]",
+        visible ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none"
+      )}
+    >
+      <ArrowUp className="h-5 w-5" />
+    </button>
+  )
+}


### PR DESCRIPTION
…## Summary
Adds a floating "Back to Top" button component as specified in Issue #37.

closes #37 

## Changes
- `frontend/components/ui/back-to-top.tsx` — new component with scroll threshold detection, fade animation, and prefers-reduced-motion support
- `frontend/app/page.tsx` — integrated into landing page
- `frontend/app/dashboard/page.tsx` — integrated into dashboard page

## Acceptance Criteria
- ✅ Button hidden by default, fades in after 400px scroll
- ✅ Smooth scroll to top on click
- ✅ Instant scroll when prefers-reduced-motion is enabled
- ✅ Positioned bottom-right with safe-area insets for mobile
- ✅ Does not obstruct other fixed UI elements (z-50, pointer-events-none when hidden)

Closes #37motion support