### PR TITLE
feat: Improve Pool Creation Form Validation and UX

### DIFF
--- a/frontend/components/create-group/flexible-form.tsx
+++ b/frontend/components/create-group/flexible-form.tsx
@@ -1,15 +1,23 @@
 "use client"
 
 import type React from "react"
-import { useState } from "react"
+import { useState, useCallback, useRef, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { Plus, X, Loader2, AlertCircle } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useStellar } from "@/components/web3-provider"
 import { useDeployPool, useInitializePool, useRegisterPool } from "@/hooks/useJointSaveContracts"
+import { FieldTooltip } from "@/components/ui/field-tooltip"
+import { FieldError } from "@/components/ui/form"
+import { FormProgress, type ProgressField } from "@/components/ui/form-progress"
+import {
+  validateGroupName,
+  validateStellarAddress,
+  validatePositiveAmount,
+  validateWithdrawalFee,
+} from "@/lib/form-validation"
 
 function isValidStellarAddress(addr: string) {
   return /^G[A-Z2-7]{55}$/.test(addr)
@@ -18,15 +26,26 @@ function isValidStellarAddress(addr: string) {
 const TREASURY = process.env.NEXT_PUBLIC_FACTORY_CONTRACT_ID || ""
 const TOKEN = process.env.NEXT_PUBLIC_TOKEN_CONTRACT_ID || "native"
 
+type FieldErrors = Partial<Record<"name" | "minimumDeposit" | "withdrawalFee", string>>
+type Touched = Partial<Record<"name" | "minimumDeposit" | "withdrawalFee", boolean>>
+
 export function FlexibleForm() {
   const router = useRouter()
   const { address } = useStellar()
   const [members, setMembers] = useState<string[]>([""])
+  const [memberErrors, setMemberErrors] = useState<string[]>([""])
   const [error, setError] = useState("")
   const [step, setStep] = useState<"idle" | "deploying" | "initializing" | "registering" | "saving">("idle")
   const [formData, setFormData] = useState({
     name: "", description: "", minimumDeposit: "", enableYield: false, withdrawalFee: "1",
   })
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({})
+  const [touched, setTouched] = useState<Touched>({})
+  const errorRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (error) errorRef.current?.scrollIntoView({ behavior: "smooth", block: "start" })
+  }, [error])
 
   const { deploy } = useDeployPool()
   const { initFlexible } = useInitializePool()
@@ -36,17 +55,49 @@ export function FlexibleForm() {
   const validMembers = Array.from(new Set(allMembers.filter(isValidStellarAddress)))
   const isCreating = step !== "idle"
 
-  const addMember = () => setMembers([...members, ""])
-  const removeMember = (i: number) => setMembers(members.filter((_, idx) => idx !== i))
-  const updateMember = (i: number, v: string) => { const n = [...members]; n[i] = v; setMembers(n) }
+  const validateField = useCallback((name: keyof FieldErrors, value: string) => {
+    let message = ""
+    if (name === "name") message = validateGroupName(value).message
+    else if (name === "minimumDeposit") message = validatePositiveAmount(value, "Minimum deposit").message
+    else if (name === "withdrawalFee") message = validateWithdrawalFee(value).message
+    setFieldErrors((prev) => ({ ...prev, [name]: message }))
+  }, [])
+
+  const handleBlur = (name: keyof FieldErrors, value: string) => {
+    setTouched((prev) => ({ ...prev, [name]: true }))
+    validateField(name, value)
+  }
+
+  const updateMember = (i: number, v: string) => {
+    const n = [...members]; n[i] = v; setMembers(n)
+    const errs = [...memberErrors]
+    errs[i] = v ? (validateStellarAddress(v).valid ? "" : validateStellarAddress(v).message) : ""
+    setMemberErrors(errs)
+  }
+
+  const addMember = () => { setMembers([...members, ""]); setMemberErrors([...memberErrors, ""]) }
+  const removeMember = (i: number) => {
+    setMembers(members.filter((_, idx) => idx !== i))
+    setMemberErrors(memberErrors.filter((_, idx) => idx !== i))
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError("")
+
+    setTouched({ name: true, minimumDeposit: true, withdrawalFee: true })
+    const nameResult = validateGroupName(formData.name)
+    const depositResult = validatePositiveAmount(formData.minimumDeposit, "Minimum deposit")
+    const feeResult = validateWithdrawalFee(formData.withdrawalFee)
+    setFieldErrors({
+      name: nameResult.message,
+      minimumDeposit: depositResult.message,
+      withdrawalFee: feeResult.message,
+    })
+
     if (!address) return setError("Please connect your wallet first")
     if (validMembers.length < 2) return setError("Need at least 2 valid Stellar addresses (you + 1 other)")
-    if (!formData.name) return setError("Please enter a group name")
-    if (!formData.minimumDeposit) return setError("Please enter a minimum deposit")
+    if (!nameResult.valid || !depositResult.valid || !feeResult.valid) return
 
     try {
       setStep("deploying")
@@ -107,77 +158,180 @@ export function FlexibleForm() {
     saving: "Saving metadata...",
   }
 
+  const progressFields: ProgressField[] = [
+    { label: "Group name", valid: validateGroupName(formData.name).valid },
+    { label: "Minimum deposit", valid: validatePositiveAmount(formData.minimumDeposit, "Amount").valid },
+    { label: "Withdrawal fee", valid: validateWithdrawalFee(formData.withdrawalFee).valid },
+    { label: "Members (2+)", valid: validMembers.length >= 2 },
+  ]
+
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
       {error && (
-        <div className="flex gap-2 p-3 rounded-lg bg-destructive/10 text-destructive">
-          <AlertCircle className="h-5 w-5 flex-shrink-0" />
+        <div ref={errorRef} className="flex gap-2 p-3 rounded-lg bg-destructive/10 text-destructive">
+          <AlertCircle className="h-5 w-5 shrink-0" />
           <p className="text-sm">{error}</p>
         </div>
       )}
       {isCreating && (
         <div className="flex gap-2 p-3 rounded-lg bg-primary/10 text-primary">
-          <Loader2 className="h-5 w-5 flex-shrink-0 animate-spin" />
+          <Loader2 className="h-5 w-5 shrink-0 animate-spin" />
           <p className="text-sm">{stepLabel[step]} — approve each wallet prompt.</p>
         </div>
       )}
 
-      <div className="space-y-2">
-        <Label htmlFor="name">Group Name</Label>
-        <Input id="name" placeholder="e.g., Emergency Fund" value={formData.name}
-          onChange={(e) => setFormData({ ...formData, name: e.target.value })} required />
+      <FormProgress fields={progressFields} />
+
+      <div className="space-y-1">
+        <FieldTooltip
+          htmlFor="name"
+          label="Group Name"
+          tooltip="A name for your flexible savings pool — e.g. 'Emergency Fund'. Visible to all members."
+          required
+        />
+        <Input
+          id="name"
+          placeholder="e.g., Emergency Fund"
+          value={formData.name}
+          onChange={(e) => {
+            setFormData({ ...formData, name: e.target.value })
+            if (touched.name) validateField("name", e.target.value)
+          }}
+          onBlur={(e) => handleBlur("name", e.target.value)}
+        />
+        {touched.name && <FieldError message={fieldErrors.name} />}
       </div>
-      <div className="space-y-2">
-        <Label htmlFor="description">Description (Optional)</Label>
-        <Textarea id="description" placeholder="Describe the purpose of this flexible pool"
-          value={formData.description} onChange={(e) => setFormData({ ...formData, description: e.target.value })} rows={3} />
+
+      <div className="space-y-1">
+        <FieldTooltip
+          htmlFor="description"
+          label="Description"
+          tooltip="Optional notes about this pool's purpose, deposit rules, or any agreements between members."
+        />
+        <Textarea
+          id="description"
+          placeholder="Describe the purpose of this flexible pool"
+          value={formData.description}
+          onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+          rows={3}
+        />
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div className="space-y-2">
-          <Label htmlFor="minimum">Minimum Deposit (XLM)</Label>
-          <Input id="minimum" type="number" step="0.01" placeholder="50" value={formData.minimumDeposit}
-            onChange={(e) => setFormData({ ...formData, minimumDeposit: e.target.value })} required />
+        <div className="space-y-1">
+          <FieldTooltip
+            htmlFor="minimum"
+            label="Minimum Deposit (XLM)"
+            tooltip="The smallest amount a member can deposit in a single transaction. Helps maintain meaningful contributions."
+            required
+          />
+          <Input
+            id="minimum"
+            type="number"
+            step="0.01"
+            min="0.01"
+            placeholder="50"
+            value={formData.minimumDeposit}
+            onChange={(e) => {
+              setFormData({ ...formData, minimumDeposit: e.target.value })
+              if (touched.minimumDeposit) validateField("minimumDeposit", e.target.value)
+            }}
+            onBlur={(e) => handleBlur("minimumDeposit", e.target.value)}
+          />
+          {touched.minimumDeposit && <FieldError message={fieldErrors.minimumDeposit} />}
         </div>
-        <div className="space-y-2">
-          <Label htmlFor="fee">Withdrawal Fee (%)</Label>
-          <Input id="fee" type="number" step="0.1" placeholder="1" value={formData.withdrawalFee}
-            onChange={(e) => setFormData({ ...formData, withdrawalFee: e.target.value })} required />
+
+        <div className="space-y-1">
+          <FieldTooltip
+            htmlFor="fee"
+            label="Withdrawal Fee (%)"
+            tooltip="A small fee charged on withdrawals to discourage early exits and build the pool's reserve. 0–10% allowed."
+            required
+          />
+          <Input
+            id="fee"
+            type="number"
+            step="0.1"
+            min="0"
+            max="10"
+            placeholder="1"
+            value={formData.withdrawalFee}
+            onChange={(e) => {
+              setFormData({ ...formData, withdrawalFee: e.target.value })
+              if (touched.withdrawalFee) validateField("withdrawalFee", e.target.value)
+            }}
+            onBlur={(e) => handleBlur("withdrawalFee", e.target.value)}
+          />
+          {touched.withdrawalFee && <FieldError message={fieldErrors.withdrawalFee} />}
         </div>
       </div>
 
       <div className="flex items-center justify-between p-4 rounded-lg border border-border">
         <div className="space-y-0.5">
-          <Label htmlFor="yield">Enable Yield Generation</Label>
+          <FieldTooltip
+            htmlFor="yield"
+            label="Enable Yield Generation"
+            tooltip="When enabled, idle funds are staked in Stellar DeFi protocols to earn passive income for the pool. Members share the yield proportionally."
+          />
           <p className="text-sm text-muted-foreground">Stake idle funds in Stellar DeFi protocols for passive income</p>
         </div>
-        <input id="yield" type="checkbox" checked={formData.enableYield}
+        <input
+          id="yield"
+          type="checkbox"
+          checked={formData.enableYield}
           onChange={(e) => setFormData({ ...formData, enableYield: e.target.checked })}
-          className="h-4 w-4 rounded" />
+          className="h-4 w-4 rounded"
+        />
       </div>
 
       <div className="space-y-4">
         <div className="flex items-center justify-between">
-          <Label>Member Stellar Addresses</Label>
+          <FieldTooltip
+            label="Member Stellar Addresses"
+            tooltip="Add the public Stellar address (starts with G) for each person joining this pool. You are automatically included."
+            required
+          />
           <Button type="button" variant="outline" size="sm" onClick={addMember}>
             <Plus className="h-4 w-4 mr-1" />Add Member
           </Button>
         </div>
+
         <div className="space-y-3">
-          <div className="flex gap-2 items-center">
-            <Input value={address || ""} readOnly disabled className="font-mono text-xs opacity-70" />
-            <span className="text-xs text-muted-foreground whitespace-nowrap">You</span>
+          <div className="space-y-1">
+            <div className="flex gap-2 items-center">
+              <Input value={address || "Connect your wallet"} readOnly disabled className="font-mono text-xs opacity-70" />
+              <span className="text-xs text-muted-foreground whitespace-nowrap">You</span>
+            </div>
+            {!address && (
+              <p className="text-xs text-amber-600">Connect your wallet to be included as a member</p>
+            )}
           </div>
+
           {members.map((member, i) => (
-            <div key={i} className="flex gap-2">
-              <Input placeholder="G..." value={member} onChange={(e) => updateMember(i, e.target.value)} />
-              {members.length > 1 && (
-                <Button type="button" variant="ghost" size="icon" onClick={() => removeMember(i)}>
-                  <X className="h-4 w-4" />
-                </Button>
+            <div key={i} className="space-y-1">
+              <div className="flex gap-2">
+                <Input
+                  placeholder="G... (56-character Stellar address)"
+                  value={member}
+                  onChange={(e) => updateMember(i, e.target.value)}
+                  className={memberErrors[i] ? "border-destructive" : member && isValidStellarAddress(member) ? "border-green-500" : ""}
+                />
+                {members.length > 1 && (
+                  <Button type="button" variant="ghost" size="icon" onClick={() => removeMember(i)}>
+                    <X className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+              {memberErrors[i] && <FieldError message={memberErrors[i]} />}
+              {!memberErrors[i] && member && isValidStellarAddress(member) && (
+                <p className="text-green-600 text-xs flex items-center gap-1">✓ Valid address</p>
               )}
             </div>
           ))}
+
+          {validMembers.length < 2 && members.some((m) => m) && (
+            <p className="text-xs text-muted-foreground">At least 2 valid members are required (you + 1 other)</p>
+          )}
         </div>
       </div>
 
@@ -192,7 +346,11 @@ export function FlexibleForm() {
           </ul>
         </div>
         <Button type="submit" className="w-full bg-primary hover:bg-primary/90" disabled={isCreating}>
-          {isCreating ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" />{stepLabel[step]}</> : "Create Flexible Pool"}
+          {isCreating ? (
+            <><Loader2 className="mr-2 h-4 w-4 animate-spin" />{stepLabel[step]}</>
+          ) : (
+            "Create Flexible Pool"
+          )}
         </Button>
       </div>
     </form>

--- a/frontend/components/create-group/rotational-form.tsx
+++ b/frontend/components/create-group/rotational-form.tsx
@@ -1,16 +1,23 @@
 "use client"
 
 import type React from "react"
-import { useState } from "react"
+import { useState, useCallback, useRef, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Plus, X, Loader2, AlertCircle, CheckCircle2 } from "lucide-react"
+import { Plus, X, Loader2, AlertCircle } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useStellar } from "@/components/web3-provider"
 import { useDeployPool, useInitializePool, useRegisterPool } from "@/hooks/useJointSaveContracts"
+import { FieldTooltip } from "@/components/ui/field-tooltip"
+import { FieldError } from "@/components/ui/form"
+import { FormProgress, type ProgressField } from "@/components/ui/form-progress"
+import {
+  validateGroupName,
+  validateStellarAddress,
+  validatePositiveAmount,
+} from "@/lib/form-validation"
 
 function isValidStellarAddress(addr: string) {
   return /^G[A-Z2-7]{55}$/.test(addr)
@@ -27,11 +34,15 @@ const FREQUENCY_SECONDS: Record<string, number> = {
   monthly: 2592000,
 }
 
+type FieldErrors = Partial<Record<"name" | "contributionAmount", string>>
+type Touched = Partial<Record<"name" | "contributionAmount", boolean>>
+
 export function RotationalForm() {
   const router = useRouter()
   const { address } = useStellar()
   // Creator is always the first member (read-only), others are editable
   const [members, setMembers] = useState<string[]>([""])
+  const [memberErrors, setMemberErrors] = useState<string[]>([""])
   const [error, setError] = useState("")
   const [step, setStep] = useState<"idle" | "deploying" | "initializing" | "registering" | "saving">("idle")
   const [formData, setFormData] = useState({
@@ -40,6 +51,13 @@ export function RotationalForm() {
     contributionAmount: "",
     frequency: "weekly",
   })
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({})
+  const [touched, setTouched] = useState<Touched>({})
+  const errorRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (error) errorRef.current?.scrollIntoView({ behavior: "smooth", block: "start" })
+  }, [error])
 
   const { deploy } = useDeployPool()
   const { initRotational } = useInitializePool()
@@ -50,19 +68,57 @@ export function RotationalForm() {
   const validMembers = Array.from(new Set(allMembers.filter(isValidStellarAddress)))
   const isCreating = step !== "idle"
 
-  const addMember = () => setMembers([...members, ""])
-  const removeMember = (i: number) => setMembers(members.filter((_, idx) => idx !== i))
+  const validateField = useCallback((name: keyof FieldErrors, value: string) => {
+    const result =
+      name === "name" ? validateGroupName(value) : validatePositiveAmount(value, "Contribution amount")
+    setFieldErrors((prev) => ({ ...prev, [name]: result.valid ? "" : result.message }))
+  }, [])
+
+  const handleBlur = (name: keyof FieldErrors, value: string) => {
+    setTouched((prev) => ({ ...prev, [name]: true }))
+    validateField(name, value)
+  }
+
   const updateMember = (i: number, v: string) => {
-    const next = [...members]; next[i] = v; setMembers(next)
+    const next = [...members]
+    next[i] = v
+    setMembers(next)
+    const errs = [...memberErrors]
+    if (v) {
+      const r = validateStellarAddress(v)
+      errs[i] = r.valid ? "" : r.message
+    } else {
+      errs[i] = ""
+    }
+    setMemberErrors(errs)
+  }
+
+  const addMember = () => {
+    setMembers([...members, ""])
+    setMemberErrors([...memberErrors, ""])
+  }
+
+  const removeMember = (i: number) => {
+    setMembers(members.filter((_, idx) => idx !== i))
+    setMemberErrors(memberErrors.filter((_, idx) => idx !== i))
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError("")
+
+    // Mark all as touched and validate
+    setTouched({ name: true, contributionAmount: true })
+    const nameResult = validateGroupName(formData.name)
+    const amountResult = validatePositiveAmount(formData.contributionAmount, "Contribution amount")
+    setFieldErrors({
+      name: nameResult.valid ? "" : nameResult.message,
+      contributionAmount: amountResult.valid ? "" : amountResult.message,
+    })
+
     if (!address) return setError("Please connect your wallet first")
     if (validMembers.length < 2) return setError("Need at least 2 valid Stellar addresses (you + 1 other)")
-    if (!formData.name) return setError("Please enter a group name")
-    if (!formData.contributionAmount) return setError("Please enter a contribution amount")
+    if (!nameResult.valid || !amountResult.valid) return
 
     try {
       // 1. Deploy contract instance from WASM hash
@@ -76,8 +132,8 @@ export function RotationalForm() {
         members: validMembers,
         depositAmount: formData.contributionAmount,
         roundDuration: FREQUENCY_SECONDS[formData.frequency],
-        treasuryFeeBps: 100, // 1%
-        relayerFeeBps: 50,   // 0.5%
+        treasuryFeeBps: 100,
+        relayerFeeBps: 50,
         treasury: TREASURY,
       })
 
@@ -124,43 +180,102 @@ export function RotationalForm() {
     saving: "Saving metadata...",
   }
 
+  const progressFields: ProgressField[] = [
+    { label: "Group name", valid: validateGroupName(formData.name).valid },
+    { label: "Contribution amount", valid: validatePositiveAmount(formData.contributionAmount, "Amount").valid },
+    { label: "Frequency", valid: !!formData.frequency },
+    { label: "Members (2+)", valid: validMembers.length >= 2 },
+  ]
+
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
       {error && (
-        <div className="flex gap-2 p-3 rounded-lg bg-destructive/10 text-destructive">
-          <AlertCircle className="h-5 w-5 flex-shrink-0" />
+        <div ref={errorRef} className="flex gap-2 p-3 rounded-lg bg-destructive/10 text-destructive">
+          <AlertCircle className="h-5 w-5 shrink-0" />
           <p className="text-sm">{error}</p>
         </div>
       )}
 
       {isCreating && (
         <div className="flex gap-2 p-3 rounded-lg bg-primary/10 text-primary">
-          <Loader2 className="h-5 w-5 flex-shrink-0 animate-spin" />
+          <Loader2 className="h-5 w-5 shrink-0 animate-spin" />
           <p className="text-sm">{stepLabel[step]} — approve each wallet prompt.</p>
         </div>
       )}
 
-      <div className="space-y-2">
-        <Label htmlFor="name">Group Name</Label>
-        <Input id="name" placeholder="e.g., Family Savings Circle" value={formData.name}
-          onChange={(e) => setFormData({ ...formData, name: e.target.value })} required />
+      <FormProgress fields={progressFields} />
+
+      <div className="space-y-1">
+        <FieldTooltip
+          htmlFor="name"
+          label="Group Name"
+          tooltip="A short, memorable name for your savings circle — e.g. 'Family Trip Fund'. Visible to all members."
+          required
+        />
+        <Input
+          id="name"
+          placeholder="e.g., Family Savings Circle"
+          value={formData.name}
+          onChange={(e) => {
+            setFormData({ ...formData, name: e.target.value })
+            if (touched.name) validateField("name", e.target.value)
+          }}
+          onBlur={(e) => handleBlur("name", e.target.value)}
+          aria-describedby="name-error"
+        />
+        {touched.name && <FieldError message={fieldErrors.name} />}
       </div>
 
-      <div className="space-y-2">
-        <Label htmlFor="description">Description (Optional)</Label>
-        <Textarea id="description" placeholder="Describe the purpose of this savings group"
-          value={formData.description} onChange={(e) => setFormData({ ...formData, description: e.target.value })} rows={3} />
+      <div className="space-y-1">
+        <FieldTooltip
+          htmlFor="description"
+          label="Description"
+          tooltip="Optional details about the group's purpose, rules, or goals. Helps members understand what they're joining."
+        />
+        <Textarea
+          id="description"
+          placeholder="Describe the purpose of this savings group"
+          value={formData.description}
+          onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+          rows={3}
+        />
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div className="space-y-2">
-          <Label htmlFor="amount">Contribution Amount (XLM)</Label>
-          <Input id="amount" type="number" step="0.01" placeholder="100" value={formData.contributionAmount}
-            onChange={(e) => setFormData({ ...formData, contributionAmount: e.target.value })} required />
+        <div className="space-y-1">
+          <FieldTooltip
+            htmlFor="amount"
+            label="Contribution Amount (XLM)"
+            tooltip="How much each member deposits per round. Every member pays the same amount, and one member receives the full pool each round."
+            required
+          />
+          <Input
+            id="amount"
+            type="number"
+            step="0.01"
+            min="0.01"
+            placeholder="100"
+            value={formData.contributionAmount}
+            onChange={(e) => {
+              setFormData({ ...formData, contributionAmount: e.target.value })
+              if (touched.contributionAmount) validateField("contributionAmount", e.target.value)
+            }}
+            onBlur={(e) => handleBlur("contributionAmount", e.target.value)}
+          />
+          {touched.contributionAmount && <FieldError message={fieldErrors.contributionAmount} />}
         </div>
-        <div className="space-y-2">
-          <Label htmlFor="frequency">Payout Frequency</Label>
-          <Select value={formData.frequency} onValueChange={(v) => setFormData({ ...formData, frequency: v })}>
+
+        <div className="space-y-1">
+          <FieldTooltip
+            htmlFor="frequency"
+            label="Payout Frequency"
+            tooltip="How often one member receives the pooled funds. Members take turns in rotation until everyone has received a payout."
+            required
+          />
+          <Select
+            value={formData.frequency}
+            onValueChange={(v) => setFormData({ ...formData, frequency: v })}
+          >
             <SelectTrigger id="frequency"><SelectValue /></SelectTrigger>
             <SelectContent>
               <SelectItem value="daily">Daily</SelectItem>
@@ -174,27 +289,53 @@ export function RotationalForm() {
 
       <div className="space-y-4">
         <div className="flex items-center justify-between">
-          <Label>Member Stellar Addresses</Label>
+          <FieldTooltip
+            label="Member Stellar Addresses"
+            tooltip="Add the public Stellar address (starts with G) for each person joining this pool. You are automatically included as the first member."
+            required
+          />
           <Button type="button" variant="outline" size="sm" onClick={addMember}>
             <Plus className="h-4 w-4 mr-1" />Add Member
           </Button>
         </div>
+
         <div className="space-y-3">
           {/* Creator — always included, read-only */}
-          <div className="flex gap-2 items-center">
-            <Input value={address || ""} readOnly disabled className="font-mono text-xs opacity-70" />
-            <span className="text-xs text-muted-foreground whitespace-nowrap">You</span>
+          <div className="space-y-1">
+            <div className="flex gap-2 items-center">
+              <Input value={address || "Connect your wallet"} readOnly disabled className="font-mono text-xs opacity-70" />
+              <span className="text-xs text-muted-foreground whitespace-nowrap">You</span>
+            </div>
+            {!address && (
+              <p className="text-xs text-amber-600">Connect your wallet to be included as a member</p>
+            )}
           </div>
+
           {members.map((member, i) => (
-            <div key={i} className="flex gap-2">
-              <Input placeholder="G..." value={member} onChange={(e) => updateMember(i, e.target.value)} />
-              {members.length > 1 && (
-                <Button type="button" variant="ghost" size="icon" onClick={() => removeMember(i)}>
-                  <X className="h-4 w-4" />
-                </Button>
+            <div key={i} className="space-y-1">
+              <div className="flex gap-2">
+                <Input
+                  placeholder="G... (56-character Stellar address)"
+                  value={member}
+                  onChange={(e) => updateMember(i, e.target.value)}
+                  className={memberErrors[i] ? "border-destructive" : member && isValidStellarAddress(member) ? "border-green-500" : ""}
+                />
+                {members.length > 1 && (
+                  <Button type="button" variant="ghost" size="icon" onClick={() => removeMember(i)}>
+                    <X className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+              {memberErrors[i] && <FieldError message={memberErrors[i]} />}
+              {!memberErrors[i] && member && isValidStellarAddress(member) && (
+                <p className="text-green-600 text-xs flex items-center gap-1">✓ Valid address</p>
               )}
             </div>
           ))}
+
+          {validMembers.length < 2 && members.some((m) => m) && (
+            <p className="text-xs text-muted-foreground">At least 2 valid members are required (you + 1 other)</p>
+          )}
         </div>
       </div>
 
@@ -209,7 +350,11 @@ export function RotationalForm() {
           </ul>
         </div>
         <Button type="submit" className="w-full bg-primary hover:bg-primary/90" disabled={isCreating}>
-          {isCreating ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" />{stepLabel[step]}</> : "Create Rotational Group"}
+          {isCreating ? (
+            <><Loader2 className="mr-2 h-4 w-4 animate-spin" />{stepLabel[step]}</>
+          ) : (
+            "Create Rotational Group"
+          )}
         </Button>
       </div>
     </form>

--- a/frontend/components/create-group/target-form.tsx
+++ b/frontend/components/create-group/target-form.tsx
@@ -1,15 +1,23 @@
 "use client"
 
 import type React from "react"
-import { useState } from "react"
+import { useState, useCallback, useRef, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { Plus, X, Loader2, AlertCircle } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useStellar } from "@/components/web3-provider"
 import { useDeployPool, useInitializePool, useRegisterPool, getRpc } from "@/hooks/useJointSaveContracts"
+import { FieldTooltip } from "@/components/ui/field-tooltip"
+import { FieldError } from "@/components/ui/form"
+import { FormProgress, type ProgressField } from "@/components/ui/form-progress"
+import {
+  validateGroupName,
+  validateStellarAddress,
+  validatePositiveAmount,
+  validateDeadline,
+} from "@/lib/form-validation"
 
 function isValidStellarAddress(addr: string) {
   return /^G[A-Z2-7]{55}$/.test(addr)
@@ -27,13 +35,24 @@ async function dateToLedger(date: Date): Promise<number> {
   return ledger.sequence + Math.floor(secsFromNow * 5)
 }
 
+type FieldErrors = Partial<Record<"name" | "targetAmount" | "deadline", string>>
+type Touched = Partial<Record<"name" | "targetAmount" | "deadline", boolean>>
+
 export function TargetForm() {
   const router = useRouter()
   const { address } = useStellar()
   const [members, setMembers] = useState<string[]>([""])
+  const [memberErrors, setMemberErrors] = useState<string[]>([""])
   const [error, setError] = useState("")
   const [step, setStep] = useState<"idle" | "deploying" | "initializing" | "registering" | "saving">("idle")
   const [formData, setFormData] = useState({ name: "", description: "", targetAmount: "", deadline: "" })
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({})
+  const [touched, setTouched] = useState<Touched>({})
+  const errorRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (error) errorRef.current?.scrollIntoView({ behavior: "smooth", block: "start" })
+  }, [error])
 
   const { deploy } = useDeployPool()
   const { initTarget } = useInitializePool()
@@ -43,19 +62,49 @@ export function TargetForm() {
   const validMembers = Array.from(new Set(allMembers.filter(isValidStellarAddress)))
   const isCreating = step !== "idle"
 
-  const addMember = () => setMembers([...members, ""])
-  const removeMember = (i: number) => setMembers(members.filter((_, idx) => idx !== i))
-  const updateMember = (i: number, v: string) => { const n = [...members]; n[i] = v; setMembers(n) }
+  const validateField = useCallback((name: keyof FieldErrors, value: string) => {
+    let message = ""
+    if (name === "name") message = validateGroupName(value).message
+    else if (name === "targetAmount") message = validatePositiveAmount(value, "Target amount").message
+    else if (name === "deadline") message = validateDeadline(value).message
+    setFieldErrors((prev) => ({ ...prev, [name]: message }))
+  }, [])
+
+  const handleBlur = (name: keyof FieldErrors, value: string) => {
+    setTouched((prev) => ({ ...prev, [name]: true }))
+    validateField(name, value)
+  }
+
+  const updateMember = (i: number, v: string) => {
+    const next = [...members]; next[i] = v; setMembers(next)
+    const errs = [...memberErrors]
+    errs[i] = v ? (validateStellarAddress(v).valid ? "" : validateStellarAddress(v).message) : ""
+    setMemberErrors(errs)
+  }
+
+  const addMember = () => { setMembers([...members, ""]); setMemberErrors([...memberErrors, ""]) }
+  const removeMember = (i: number) => {
+    setMembers(members.filter((_, idx) => idx !== i))
+    setMemberErrors(memberErrors.filter((_, idx) => idx !== i))
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError("")
+
+    setTouched({ name: true, targetAmount: true, deadline: true })
+    const nameResult = validateGroupName(formData.name)
+    const amountResult = validatePositiveAmount(formData.targetAmount, "Target amount")
+    const deadlineResult = validateDeadline(formData.deadline)
+    setFieldErrors({
+      name: nameResult.message,
+      targetAmount: amountResult.message,
+      deadline: deadlineResult.message,
+    })
+
     if (!address) return setError("Please connect your wallet first")
     if (validMembers.length < 2) return setError("Need at least 2 valid Stellar addresses (you + 1 other)")
-    if (!formData.name) return setError("Please enter a group name")
-    if (!formData.targetAmount) return setError("Please enter a target amount")
-    if (!formData.deadline) return setError("Please select a deadline")
-    if (new Date(formData.deadline) <= new Date()) return setError("Deadline must be in the future")
+    if (!nameResult.valid || !amountResult.valid || !deadlineResult.valid) return
 
     try {
       setStep("deploying")
@@ -117,67 +166,158 @@ export function TargetForm() {
       ? (parseFloat(formData.targetAmount || "0") / validMembers.length).toFixed(2)
       : "0"
 
+  const progressFields: ProgressField[] = [
+    { label: "Group name", valid: validateGroupName(formData.name).valid },
+    { label: "Target amount", valid: validatePositiveAmount(formData.targetAmount, "Amount").valid },
+    { label: "Deadline", valid: validateDeadline(formData.deadline).valid },
+    { label: "Members (2+)", valid: validMembers.length >= 2 },
+  ]
+
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
       {error && (
-        <div className="flex gap-2 p-3 rounded-lg bg-destructive/10 text-destructive">
-          <AlertCircle className="h-5 w-5 flex-shrink-0" />
+        <div ref={errorRef} className="flex gap-2 p-3 rounded-lg bg-destructive/10 text-destructive">
+          <AlertCircle className="h-5 w-5 shrink-0" />
           <p className="text-sm">{error}</p>
         </div>
       )}
       {isCreating && (
         <div className="flex gap-2 p-3 rounded-lg bg-primary/10 text-primary">
-          <Loader2 className="h-5 w-5 flex-shrink-0 animate-spin" />
+          <Loader2 className="h-5 w-5 shrink-0 animate-spin" />
           <p className="text-sm">{stepLabel[step]} — approve each wallet prompt.</p>
         </div>
       )}
 
-      <div className="space-y-2">
-        <Label htmlFor="name">Group Name</Label>
-        <Input id="name" placeholder="e.g., Wedding Fund" value={formData.name}
-          onChange={(e) => setFormData({ ...formData, name: e.target.value })} required />
+      <FormProgress fields={progressFields} />
+
+      <div className="space-y-1">
+        <FieldTooltip
+          htmlFor="name"
+          label="Group Name"
+          tooltip="A descriptive name for your savings goal — e.g. 'Wedding Fund'. Visible to all members."
+          required
+        />
+        <Input
+          id="name"
+          placeholder="e.g., Wedding Fund"
+          value={formData.name}
+          onChange={(e) => {
+            setFormData({ ...formData, name: e.target.value })
+            if (touched.name) validateField("name", e.target.value)
+          }}
+          onBlur={(e) => handleBlur("name", e.target.value)}
+        />
+        {touched.name && <FieldError message={fieldErrors.name} />}
       </div>
-      <div className="space-y-2">
-        <Label htmlFor="description">Description (Optional)</Label>
-        <Textarea id="description" placeholder="Describe the savings goal" value={formData.description}
-          onChange={(e) => setFormData({ ...formData, description: e.target.value })} rows={3} />
+
+      <div className="space-y-1">
+        <FieldTooltip
+          htmlFor="description"
+          label="Description"
+          tooltip="Optional context about the savings goal — what you're saving for, any rules, or milestones to reach."
+        />
+        <Textarea
+          id="description"
+          placeholder="Describe the savings goal"
+          value={formData.description}
+          onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+          rows={3}
+        />
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div className="space-y-2">
-          <Label htmlFor="target">Target Amount (XLM)</Label>
-          <Input id="target" type="number" step="0.01" placeholder="5000" value={formData.targetAmount}
-            onChange={(e) => setFormData({ ...formData, targetAmount: e.target.value })} required />
+        <div className="space-y-1">
+          <FieldTooltip
+            htmlFor="target"
+            label="Target Amount (XLM)"
+            tooltip="The total amount the group aims to save collectively. Members contribute until this amount is reached."
+            required
+          />
+          <Input
+            id="target"
+            type="number"
+            step="0.01"
+            min="0.01"
+            placeholder="5000"
+            value={formData.targetAmount}
+            onChange={(e) => {
+              setFormData({ ...formData, targetAmount: e.target.value })
+              if (touched.targetAmount) validateField("targetAmount", e.target.value)
+            }}
+            onBlur={(e) => handleBlur("targetAmount", e.target.value)}
+          />
+          {touched.targetAmount && <FieldError message={fieldErrors.targetAmount} />}
         </div>
-        <div className="space-y-2">
-          <Label htmlFor="deadline">Target Deadline</Label>
-          <Input id="deadline" type="date" value={formData.deadline}
-            onChange={(e) => setFormData({ ...formData, deadline: e.target.value })} required />
+
+        <div className="space-y-1">
+          <FieldTooltip
+            htmlFor="deadline"
+            label="Target Deadline"
+            tooltip="The date by which the group aims to reach the savings target. Must be at least 1 day in the future."
+            required
+          />
+          <Input
+            id="deadline"
+            type="date"
+            value={formData.deadline}
+            onChange={(e) => {
+              setFormData({ ...formData, deadline: e.target.value })
+              if (touched.deadline) validateField("deadline", e.target.value)
+            }}
+            onBlur={(e) => handleBlur("deadline", e.target.value)}
+          />
+          {touched.deadline && <FieldError message={fieldErrors.deadline} />}
         </div>
       </div>
 
       <div className="space-y-4">
         <div className="flex items-center justify-between">
-          <Label>Member Stellar Addresses</Label>
+          <FieldTooltip
+            label="Member Stellar Addresses"
+            tooltip="Add the public Stellar address (starts with G) for each person joining this pool. You are automatically included."
+            required
+          />
           <Button type="button" variant="outline" size="sm" onClick={addMember}>
             <Plus className="h-4 w-4 mr-1" />Add Member
           </Button>
         </div>
+
         <div className="space-y-3">
-          <div className="flex gap-2 items-center">
-            <Input value={address || ""} readOnly disabled className="font-mono text-xs opacity-70" />
-            <span className="text-xs text-muted-foreground whitespace-nowrap">You</span>
+          <div className="space-y-1">
+            <div className="flex gap-2 items-center">
+              <Input value={address || "Connect your wallet"} readOnly disabled className="font-mono text-xs opacity-70" />
+              <span className="text-xs text-muted-foreground whitespace-nowrap">You</span>
+            </div>
+            {!address && (
+              <p className="text-xs text-amber-600">Connect your wallet to be included as a member</p>
+            )}
           </div>
+
           {members.map((member, i) => (
-            <div key={i} className="flex gap-2">
-              <Input placeholder="G..." value={member} onChange={(e) => updateMember(i, e.target.value)} />
-              {members.length > 1 && (
-                <Button type="button" variant="ghost" size="icon" onClick={() => removeMember(i)}>
-                  <X className="h-4 w-4" />
-                </Button>
+            <div key={i} className="space-y-1">
+              <div className="flex gap-2">
+                <Input
+                  placeholder="G... (56-character Stellar address)"
+                  value={member}
+                  onChange={(e) => updateMember(i, e.target.value)}
+                  className={memberErrors[i] ? "border-destructive" : member && isValidStellarAddress(member) ? "border-green-500" : ""}
+                />
+                {members.length > 1 && (
+                  <Button type="button" variant="ghost" size="icon" onClick={() => removeMember(i)}>
+                    <X className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+              {memberErrors[i] && <FieldError message={memberErrors[i]} />}
+              {!memberErrors[i] && member && isValidStellarAddress(member) && (
+                <p className="text-green-600 text-xs flex items-center gap-1">✓ Valid address</p>
               )}
             </div>
           ))}
+
+          {validMembers.length < 2 && members.some((m) => m) && (
+            <p className="text-xs text-muted-foreground">At least 2 valid members are required (you + 1 other)</p>
+          )}
         </div>
       </div>
 
@@ -187,12 +327,16 @@ export function TargetForm() {
           <ul className="space-y-1 text-sm text-muted-foreground">
             <li>Members: {validMembers.length}</li>
             <li>Target Amount: {formData.targetAmount || "0"} XLM</li>
-            <li>Contribution per Member: {contributionPerMember} XLM</li>
+            <li>Each member contributes: {contributionPerMember} XLM</li>
             <li>Deadline: {formData.deadline || "Not set"}</li>
           </ul>
         </div>
         <Button type="submit" className="w-full bg-primary hover:bg-primary/90" disabled={isCreating}>
-          {isCreating ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" />{stepLabel[step]}</> : "Create Target Pool"}
+          {isCreating ? (
+            <><Loader2 className="mr-2 h-4 w-4 animate-spin" />{stepLabel[step]}</>
+          ) : (
+            "Create Target Pool"
+          )}
         </Button>
       </div>
     </form>

--- a/frontend/components/ui/field-tooltip.tsx
+++ b/frontend/components/ui/field-tooltip.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { HelpCircle } from "lucide-react"
+import { Label } from "@/components/ui/label"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+
+interface FieldTooltipProps {
+  htmlFor?: string
+  label: string
+  tooltip: string
+  required?: boolean
+  className?: string
+}
+
+export function FieldTooltip({ htmlFor, label, tooltip, required, className }: FieldTooltipProps) {
+  return (
+    <div className={`flex items-center gap-1.5 ${className ?? ""}`}>
+      <Label htmlFor={htmlFor}>
+        {label}
+        {required && <span className="text-destructive ml-0.5">*</span>}
+      </Label>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <HelpCircle className="h-3.5 w-3.5 text-muted-foreground cursor-help shrink-0" />
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-64 text-xs leading-relaxed">
+          {tooltip}
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  )
+}

--- a/frontend/components/ui/form-progress.tsx
+++ b/frontend/components/ui/form-progress.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import { CheckCircle2, Circle } from "lucide-react"
+import { Progress } from "@/components/ui/progress"
+
+export interface ProgressField {
+  label: string
+  valid: boolean
+}
+
+interface FormProgressProps {
+  fields: ProgressField[]
+  className?: string
+}
+
+export function FormProgress({ fields, className }: FormProgressProps) {
+  const completed = fields.filter((f) => f.valid).length
+  const total = fields.length
+  const pct = total === 0 ? 0 : Math.round((completed / total) * 100)
+
+  return (
+    <div className={`space-y-3 p-4 rounded-lg bg-muted/30 border border-border ${className ?? ""}`}>
+      <div className="flex items-center justify-between text-sm">
+        <span className="font-medium">Form completion</span>
+        <span className="text-muted-foreground tabular-nums">{completed}/{total} fields</span>
+      </div>
+      <Progress value={pct} className="h-1.5" />
+      <ul className="grid grid-cols-2 gap-1">
+        {fields.map((field) => (
+          <li key={field.label} className="flex items-center gap-1.5 text-xs">
+            {field.valid ? (
+              <CheckCircle2 className="h-3.5 w-3.5 text-green-500 shrink-0" />
+            ) : (
+              <Circle className="h-3.5 w-3.5 text-muted-foreground/50 shrink-0" />
+            )}
+            <span className={field.valid ? "text-foreground" : "text-muted-foreground"}>
+              {field.label}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/frontend/components/ui/form.tsx
+++ b/frontend/components/ui/form.tsx
@@ -155,6 +155,26 @@ function FormMessage({ className, ...props }: React.ComponentProps<'p'>) {
   )
 }
 
+function FieldError({ message, className }: { message?: string; className?: string }) {
+  if (!message) return null
+  return (
+    <p className={cn('text-destructive text-xs flex items-center gap-1 mt-1', className)}>
+      <span aria-hidden>✕</span>
+      {message}
+    </p>
+  )
+}
+
+function FieldSuccess({ message, className }: { message?: string; className?: string }) {
+  if (!message) return null
+  return (
+    <p className={cn('text-green-600 text-xs flex items-center gap-1 mt-1', className)}>
+      <span aria-hidden>✓</span>
+      {message}
+    </p>
+  )
+}
+
 export {
   useFormField,
   Form,
@@ -164,4 +184,6 @@ export {
   FormDescription,
   FormMessage,
   FormField,
+  FieldError,
+  FieldSuccess,
 }

--- a/frontend/lib/form-validation.ts
+++ b/frontend/lib/form-validation.ts
@@ -1,0 +1,46 @@
+export type ValidationResult = { valid: boolean; message: string }
+
+const ok: ValidationResult = { valid: true, message: "" }
+const err = (message: string): ValidationResult => ({ valid: false, message })
+
+export function validateGroupName(value: string): ValidationResult {
+  if (!value.trim()) return err("Group name is required")
+  if (value.trim().length < 3) return err("Must be at least 3 characters")
+  if (value.trim().length > 50) return err("Must be 50 characters or less")
+  return ok
+}
+
+export function validateStellarAddress(value: string): ValidationResult {
+  if (!value) return err("Stellar address is required")
+  if (!value.startsWith("G")) return err("Stellar addresses start with 'G'")
+  if (value.length !== 56) return err(`Address must be 56 characters (currently ${value.length})`)
+  if (!/^G[A-Z2-7]{55}$/.test(value)) return err("Invalid characters — only A–Z and 2–7 allowed after 'G'")
+  return ok
+}
+
+export function validatePositiveAmount(value: string, label = "Amount"): ValidationResult {
+  if (!value) return err(`${label} is required`)
+  const num = parseFloat(value)
+  if (isNaN(num) || !isFinite(num)) return err(`${label} must be a valid number`)
+  if (num <= 0) return err(`${label} must be greater than 0`)
+  return ok
+}
+
+export function validateDeadline(value: string): ValidationResult {
+  if (!value) return err("Deadline is required")
+  const date = new Date(value)
+  if (isNaN(date.getTime())) return err("Invalid date")
+  const minDate = new Date()
+  minDate.setDate(minDate.getDate() + 1)
+  if (date < minDate) return err("Deadline must be at least 1 day in the future")
+  return ok
+}
+
+export function validateWithdrawalFee(value: string): ValidationResult {
+  if (!value && value !== "0") return err("Withdrawal fee is required")
+  const num = parseFloat(value)
+  if (isNaN(num)) return err("Fee must be a number")
+  if (num < 0) return err("Fee cannot be negative")
+  if (num > 10) return err("Fee cannot exceed 10%")
+  return ok
+}


### PR DESCRIPTION
Closes #5 

Users were hitting submit with no idea what went wrong or what the fields even meant. This fixes that.

## What changed

- **Per-field validation**: errors now appear inline beneath each field on blur, not just as a wall of text after a failed submit
- **Tooltips on every label**: hover the `?` icon to get a plain-English explanation of what the field expects
- **Form progress bar**: live checklist at the top shows which required fields are complete before you even try to submit
- **Address feedback**: Stellar address fields turn green with a ✓ as soon as a valid address is typed, red with a specific message if it's wrong
- **Wallet warning**: if the wallet isn't connected, a clear amber message explains you need to connect before the form will work
