### PR TITLE
feat: add empty state and first-pool onboarding guidance (#41)

### DIFF
--- a/frontend/components/dashboard/empty-state.tsx
+++ b/frontend/components/dashboard/empty-state.tsx
@@ -1,0 +1,103 @@
+"use client"
+
+import { Card } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Users, Target, Zap, PiggyBank } from "lucide-react"
+import Link from "next/link"
+import { motion } from "framer-motion"
+
+const poolTypes = [
+  {
+    type: "rotational",
+    icon: Users,
+    title: "Rotational",
+    description: "Members take turns receiving the full pool payout on a fixed schedule.",
+  },
+  {
+    type: "target",
+    icon: Target,
+    title: "Target Pool",
+    description: "Save together toward a shared goal — funds unlock when the target is reached.",
+  },
+  {
+    type: "flexible",
+    icon: Zap,
+    title: "Flexible Pool",
+    description: "Deposit anytime with optional yield distribution and no rigid schedule.",
+  },
+]
+
+const container = {
+  hidden: { opacity: 0 },
+  show: { opacity: 1, transition: { staggerChildren: 0.1 } },
+}
+
+const item = {
+  hidden: { opacity: 0, y: 16 },
+  show: { opacity: 1, y: 0 },
+}
+
+interface EmptyStateProps {
+  onCreateClick?: () => void
+}
+
+export function EmptyState({ onCreateClick }: EmptyStateProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.97 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.4 }}
+      className="space-y-8"
+    >
+      {/* Hero section */}
+      <div className="text-center py-8">
+        <div className="flex h-20 w-20 items-center justify-center rounded-full bg-primary/10 mx-auto mb-4">
+          <PiggyBank className="h-10 w-10 text-primary" aria-hidden="true" />
+        </div>
+        <h3 className="text-2xl font-bold mb-2">Start your first savings pool</h3>
+        <p className="text-muted-foreground max-w-md mx-auto">
+          Choose a savings model that fits your group. Each pool is governed by a Soroban
+          smart contract for full transparency.
+        </p>
+      </div>
+
+      {/* Pool type cards */}
+      <motion.div
+        variants={container}
+        initial="hidden"
+        animate="show"
+        className="grid grid-cols-1 sm:grid-cols-3 gap-4"
+      >
+        {poolTypes.map(({ type, icon: Icon, title, description }) => (
+          <motion.div key={type} variants={item} whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
+            <Card className="p-5 h-full flex flex-col hover:shadow-lg hover:shadow-primary/5 transition-all duration-300">
+              <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10 mb-3">
+                <Icon className="h-6 w-6 text-primary" aria-hidden="true" />
+              </div>
+              <h4 className="text-base font-semibold mb-1">{title}</h4>
+              <p className="text-sm text-muted-foreground mb-4 flex-1">{description}</p>
+              <Button
+                className="w-full bg-primary hover:bg-primary/90"
+                asChild
+                onClick={onCreateClick}
+              >
+                <Link href={`/dashboard/create/${type}`}>Create {title}</Link>
+              </Button>
+            </Card>
+          </motion.div>
+        ))}
+      </motion.div>
+
+      {/* Learn more link */}
+      <p className="text-center text-sm text-muted-foreground">
+        Not sure which to pick?{" "}
+        <a
+          href="/#how-it-works"
+          className="text-primary underline-offset-4 hover:underline font-medium"
+        >
+          Learn how JointSave works
+        </a>
+      </p>
+    </motion.div>
+  )
+}

--- a/frontend/components/dashboard/first-pool-tooltip.tsx
+++ b/frontend/components/dashboard/first-pool-tooltip.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { motion, AnimatePresence } from "framer-motion"
+import { X } from "lucide-react"
+
+const STORAGE_KEY = "jointsave:has-created-first-pool"
+
+interface FirstPoolTooltipProps {
+  /** Number of pools the user currently has. Tooltip only shows when exactly 1. */
+  poolCount: number
+}
+
+export function FirstPoolTooltip({ poolCount }: FirstPoolTooltipProps) {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    // Show only when the user has exactly one pool and hasn't dismissed yet
+    if (poolCount !== 1) return
+    try {
+      const dismissed = localStorage.getItem(STORAGE_KEY)
+      if (!dismissed) setVisible(true)
+    } catch {
+      // localStorage unavailable (SSR or private mode) — silently skip
+    }
+  }, [poolCount])
+
+  const dismiss = () => {
+    setVisible(false)
+    try {
+      localStorage.setItem(STORAGE_KEY, "true")
+    } catch {
+      // ignore
+    }
+  }
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          role="tooltip"
+          aria-live="polite"
+          initial={{ opacity: 0, y: -8 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -8 }}
+          transition={{ duration: 0.25 }}
+          className="flex items-start gap-3 rounded-lg border border-primary/30 bg-primary/10 px-4 py-3 text-sm text-foreground shadow-sm"
+        >
+          <span className="flex-1">
+            🎉 <strong>Great!</strong> Invite members or make your first deposit to get started.
+          </span>
+          <button
+            onClick={dismiss}
+            aria-label="Dismiss tip"
+            className="shrink-0 rounded p-0.5 hover:bg-primary/20 transition-colors"
+          >
+            <X className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          </button>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/frontend/components/dashboard/my-groups.tsx
+++ b/frontend/components/dashboard/my-groups.tsx
@@ -15,6 +15,8 @@ import {
   TargetPoolState,
   FlexiblePoolState,
 } from "@/hooks/useJointSaveContracts"
+import { EmptyState } from "@/components/dashboard/empty-state"
+import { FirstPoolTooltip } from "@/components/dashboard/first-pool-tooltip"
 
 interface Pool {
   id: string
@@ -230,27 +232,17 @@ export function MyGroups({ onCreateClick }: MyGroupsProps) {
       </motion.div>
 
       {pools.length === 0 ? (
-        <motion.div initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} transition={{ duration: 0.5 }}>
-          <Card className="p-12 text-center">
-            <div className="max-w-md mx-auto">
-              <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary/10 mx-auto mb-4">
-                <Users className="h-8 w-8 text-primary" />
-              </div>
-              <h3 className="text-xl font-semibold mb-2">No groups yet</h3>
-              <p className="text-muted-foreground mb-6">Create your first savings group or join an existing one</p>
-              <Button className="bg-primary hover:bg-primary/90" onClick={onCreateClick}>
-                Create Your First Group
-              </Button>
-            </div>
-          </Card>
-        </motion.div>
+        <EmptyState onCreateClick={onCreateClick} />
       ) : (
-        <motion.div variants={container} initial="hidden" animate="show"
-          className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {pools.map((pool) => (
-            <PoolCard key={pool.id} pool={pool} />
-          ))}
-        </motion.div>
+        <>
+          <FirstPoolTooltip poolCount={pools.length} />
+          <motion.div variants={container} initial="hidden" animate="show"
+            className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {pools.map((pool) => (
+              <PoolCard key={pool.id} pool={pool} />
+            ))}
+          </motion.div>
+        </>
       )}
     </div>
   )


### PR DESCRIPTION
- Add EmptyState component with PiggyBank icon, headline, three pool-type cards (Rotational/Target/Flexible) each linking to /dashboard/create/[type], and a 'Learn how JointSave works' anchor to /#how-it-works
- Add FirstPoolTooltip component that shows a dismissible one-time tip ('Invite members or make your first deposit') when poolCount === 1, using localStorage key jointsave:has-created-first-pool to track dismissal
- Update MyGroups to render EmptyState (only after loading resolves, so no flash for users with pools) and FirstPoolTooltip above the pool grid

Closes #41 