### PR TITLE
fix(data-layer): conditionally enable debug logging in PoolDataProvider

### DIFF
--- a/frontend/lib/data-layer/PoolDataProvider.tsx
+++ b/frontend/lib/data-layer/PoolDataProvider.tsx
@@ -236,7 +236,13 @@ export function PoolDataProvider({ children }: { children: ReactNode }) {
     const interval = setInterval(() => {
       const activeIds = Array.from(activeContractsRef.current)
       if (activeIds.length === 0) return
-      console.log(`[PoolDataProvider] Polling ${activeIds.length} active pool(s)…`)
+      if (
+        process.env.NEXT_PUBLIC_DEBUG_DATA_LAYER === "true" ||
+        (typeof localStorage !== "undefined" &&
+          localStorage.getItem("DEBUG_DATA_LAYER") === "true")
+      ) {
+        console.log(`[PoolDataProvider] Polling ${activeIds.length} active pool(s)…`)
+      }
       activeIds.forEach((id) => fetchPool(id, true))
     }, STALE_TIME_MS)
 


### PR DESCRIPTION
## Description

Gates the unconditional `console.log` in the `PoolDataProvider` centralized polling loop behind the existing debug flag. Previously this log fired every 15 seconds for every user with an active pool open, including in production. It now only logs when `NEXT_PUBLIC_DEBUG_DATA_LAYER === "true"` or `localStorage.DEBUG_DATA_LAYER === "true"`, consistent with how the file's debug panel is already gated.

Closes #52 

## Type of Change

- [ ] feat: new feature

- [x] fix: bug fix

- [ ] chore: maintenance, tooling, dependencies

- [ ] docs: documentation only

- [ ] refactor: code restructuring (no functional changes)

- [ ] test: adding or updating tests

## How Has This Been Tested?

Verified the only `console.log` in `PoolDataProvider.tsx` is now wrapped in the debug check, and confirmed no other unconditional debug logging exists (the remaining `console.error` is legitimate error reporting). The change is scoped to the polling `useEffect` and touches no other logic.

- [ ] `cargo test` passes (smart contracts)

- [ ] `pnpm build` succeeds (frontend)

- [ ] `pnpm lint` passes (frontend)

- [x] Manual testing (describe below)

## Checklist

- [x] My code follows the coding conventions of this project

- [ ] I have added/updated tests if needed

- [ ] I have updated documentation if needed

- [x] My changes generate no new warnings or errors

