### PR TITLE
Add frontend env validation and setup docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ cargo build --target wasm32-unknown-unknown --release
 cd frontend
 pnpm install
 cp .env.example .env.local
-# Edit .env.local with your Supabase credentials and contract IDs
+# Edit .env.local using the comments in .env.example for value sources.
 ```
 
 ## Project Structure
@@ -154,6 +154,8 @@ pnpm build
 ### Environment Variables
 
 Copy `.env.example` to `.env.local` and fill in the values:
+
+`frontend/.env.example` includes inline comments for each variable, including where to find Supabase values, deployed Stellar contract IDs, and WASM hashes. The frontend imports `lib/env.ts` from the root layout, so missing required variables throw a clear startup error before a downstream component fails.
 
 | Variable | Description |
 |----------|-------------|

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ For complete API documentation — functions, events, storage keys, error condit
    ```
 
 3. **Configure environment variables**
+   Use the inline comments in `frontend/.env.example` as the source of truth for each value. The frontend validates required variables during startup, so missing values fail fast with a clear `Missing required env var: ...` error.
+
    ```env
    NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
    NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_key

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,22 +1,33 @@
-# Supabase
+# Supabase project URL. Find it in Supabase: Project Settings -> API -> Project URL.
 NEXT_PUBLIC_SUPABASE_URL=
+
+# Supabase anon public key. Find it in Supabase: Project Settings -> API -> Project API keys -> anon public.
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 
-# Stellar
+# Stellar Soroban RPC endpoint used by the frontend for contract reads and submissions.
 NEXT_PUBLIC_STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+
+# Stellar Horizon endpoint used for account and network lookups.
 NEXT_PUBLIC_STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 
-# JointSave Contracts (populate after running scripts/deploy.sh)
+# JointSave factory contract ID deployed on Stellar testnet. Populate after running smartcontract/scripts/deploy.sh.
 NEXT_PUBLIC_FACTORY_CONTRACT_ID=CBZNGP52FLFZ4BOGC265FUAMP5KFMAYPQK3KTI5UHMYVMM3QCST3IMRI
+
+# Token contract ID used by pool creation flows. Use "native" for testnet XLM.
 NEXT_PUBLIC_TOKEN_CONTRACT_ID=native
-# Optional — reputation system is additive; leave blank to disable
+
+# Optional reputation contract ID. Leave blank to disable the additive reputation system.
 NEXT_PUBLIC_REPUTATION_CONTRACT_ID=
 
-# Pool WASM hashes (from stellar-testnet.json deployments)
+# Rotational pool WASM hash from smartcontract/deployments/stellar-testnet.json.
 NEXT_PUBLIC_ROTATIONAL_WASM_HASH=d350a325d8734263a3d7150c875555d8956e13a527fb3497d5141b8b3f3d2c74
+
+# Target pool WASM hash from smartcontract/deployments/stellar-testnet.json.
 NEXT_PUBLIC_TARGET_WASM_HASH=133a62226501fc5443e70007d79deeeb0b33fdf8c85c7fcd3cf16293bb5c7292
+
+# Flexible pool WASM hash from smartcontract/deployments/stellar-testnet.json.
 NEXT_PUBLIC_FLEXIBLE_WASM_HASH=df6ff088fd79f13d8d03e72160434517fdb4a83b8c7bfdd887be4369805e0d6b
 
-# Dev Tooling — set to "true" to reveal the floating Data Layer Debug Panel
-# Can also be enabled at runtime: localStorage.setItem('DEBUG_DATA_LAYER', 'true')
+# Dev tooling flag. Set to "true" to reveal the floating Data Layer Debug Panel.
+# Can also be enabled at runtime with: localStorage.setItem('DEBUG_DATA_LAYER', 'true')
 NEXT_PUBLIC_DEBUG_DATA_LAYER=false

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -7,6 +7,7 @@ import { Analytics } from "@vercel/analytics/next"
 import "./globals.css"
 import { Web3Provider } from "@/components/web3-provider"
 import { PoolDataProvider } from "@/lib/data-layer/PoolDataProvider"
+import "@/lib/env"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Suspense } from "react"
 

--- a/frontend/lib/env.ts
+++ b/frontend/lib/env.ts
@@ -1,0 +1,41 @@
+const requiredEnvVars = [
+  "NEXT_PUBLIC_SUPABASE_URL",
+  "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+  "NEXT_PUBLIC_STELLAR_RPC_URL",
+  "NEXT_PUBLIC_STELLAR_HORIZON_URL",
+  "NEXT_PUBLIC_FACTORY_CONTRACT_ID",
+  "NEXT_PUBLIC_TOKEN_CONTRACT_ID",
+  "NEXT_PUBLIC_ROTATIONAL_WASM_HASH",
+  "NEXT_PUBLIC_TARGET_WASM_HASH",
+  "NEXT_PUBLIC_FLEXIBLE_WASM_HASH",
+] as const
+
+type RequiredEnvVar = (typeof requiredEnvVars)[number]
+
+function readRequiredEnv(key: RequiredEnvVar): string {
+  const value = process.env[key]?.trim()
+  if (!value) {
+    throw new Error(
+      `Missing required env var: ${key}. Copy frontend/.env.example to frontend/.env.local and fill in this value.`,
+    )
+  }
+  return value
+}
+
+export const env = {
+  NEXT_PUBLIC_SUPABASE_URL: readRequiredEnv("NEXT_PUBLIC_SUPABASE_URL"),
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: readRequiredEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY"),
+  NEXT_PUBLIC_STELLAR_RPC_URL: readRequiredEnv("NEXT_PUBLIC_STELLAR_RPC_URL"),
+  NEXT_PUBLIC_STELLAR_HORIZON_URL: readRequiredEnv("NEXT_PUBLIC_STELLAR_HORIZON_URL"),
+  NEXT_PUBLIC_FACTORY_CONTRACT_ID: readRequiredEnv("NEXT_PUBLIC_FACTORY_CONTRACT_ID"),
+  NEXT_PUBLIC_TOKEN_CONTRACT_ID: readRequiredEnv("NEXT_PUBLIC_TOKEN_CONTRACT_ID"),
+  NEXT_PUBLIC_REPUTATION_CONTRACT_ID:
+    process.env.NEXT_PUBLIC_REPUTATION_CONTRACT_ID?.trim() ?? "",
+  NEXT_PUBLIC_ROTATIONAL_WASM_HASH: readRequiredEnv("NEXT_PUBLIC_ROTATIONAL_WASM_HASH"),
+  NEXT_PUBLIC_TARGET_WASM_HASH: readRequiredEnv("NEXT_PUBLIC_TARGET_WASM_HASH"),
+  NEXT_PUBLIC_FLEXIBLE_WASM_HASH: readRequiredEnv("NEXT_PUBLIC_FLEXIBLE_WASM_HASH"),
+  NEXT_PUBLIC_DEBUG_DATA_LAYER:
+    process.env.NEXT_PUBLIC_DEBUG_DATA_LAYER?.trim() ?? "false",
+} as const
+
+export { requiredEnvVars }


### PR DESCRIPTION
## Summary
- Add inline source/purpose comments for every frontend environment variable in rontend/.env.example.
- Add rontend/lib/env.ts with explicit required-variable validation and clear Missing required env var: ... startup errors.
- Import the validation from rontend/app/layout.tsx and update README/CONTRIBUTING setup notes to point contributors to .env.example.

Closes #69

## Evidence / validation
- 
px tsc --noEmit --skipLibCheck --module esnext --target es2020 --moduleResolution bundler lib/env.ts passed.
- Missing-env smoke check passed: importing rontend/lib/env.ts without env vars throws Missing required env var: NEXT_PUBLIC_SUPABASE_URL....
- Populated-env smoke check passed: importing rontend/lib/env.ts with required values returns 9 required vars and NEXT_PUBLIC_TOKEN_CONTRACT_ID=native.
- .env.example marker check found 11 NEXT_PUBLIC_* variables, 12 explanatory comments, rontend/lib/env.ts, and the root-layout import.
- Sensitive scan of changed files returned no account/payment/private-key markers.

## Known upstream blocker
- 
px tsc --noEmit and 
pm run build are currently blocked by an existing parse error in rontend/components/group/group-members.tsx around line 159 (Expected '</', got '{'). This PR does not touch that file.

## Notes
- NEXT_PUBLIC_REPUTATION_CONTRACT_ID and NEXT_PUBLIC_DEBUG_DATA_LAYER remain optional by design.
- No package-lock changes or payment/account details are included.