### PR TITLE
feat: add recent pools widget

### DIFF
--- a/frontend/app/dashboard/group/[id]/GroupClient.tsx
+++ b/frontend/app/dashboard/group/[id]/GroupClient.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { use, useCallback, useEffect, useState } from "react"
+import { use, useCallback, useEffect, useRef, useState } from "react"
 import { DashboardHeader } from "@/components/dashboard/dashboard-header"
 import { GroupDetails } from "@/components/group/group-details"
 import { GroupMembers } from "@/components/group/group-members"
@@ -10,6 +10,8 @@ import { Button } from "@/components/ui/button"
 import { ArrowLeft } from "lucide-react"
 import Link from "next/link"
 import { fetchIsPaused, fetchPoolAdmin } from "@/hooks/useJointSaveContracts"
+import { useStellar } from "@/components/web3-provider"
+import { useRecentPools } from "@/hooks/useRecentPools"
 
 interface Pool {
   id: string
@@ -23,10 +25,13 @@ const isPendingAddress = (addr: string) => !addr || addr === "pending_deployment
 
 export default function GroupClient({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params)
+  const { address } = useStellar()
+  const { trackVisit } = useRecentPools(address)
   const [pool, setPool] = useState<Pool | null>(null)
   const [loading, setLoading] = useState(true)
   const [isPaused, setIsPaused] = useState(false)
   const [poolAdmin, setPoolAdmin] = useState<string | null>(null)
+  const trackedRef = useRef(false)
 
   useEffect(() => {
     fetch(`/api/pools?id=${id}`)
@@ -37,6 +42,22 @@ export default function GroupClient({ params }: { params: Promise<{ id: string }
       })
       .catch(() => setLoading(false))
   }, [id])
+
+  // Track visit when pool data loads
+  useEffect(() => {
+    if (pool && !loading && !trackedRef.current) {
+      trackedRef.current = true
+      trackVisit({
+        id: pool.id,
+        name: pool.name,
+        type: pool.type,
+        contract_address: pool.contract_address,
+      })
+    }
+    if (!pool || loading) {
+      trackedRef.current = false
+    }
+  }, [pool, loading, trackVisit])
 
   const refreshPoolState = useCallback(async () => {
     if (!pool || isPendingAddress(pool.contract_address)) return

--- a/frontend/app/dashboard/group/[id]/page.tsx
+++ b/frontend/app/dashboard/group/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useCallback, useEffect, useState } from "react";
+import { use, useCallback, useEffect, useRef, useState } from "react";
 import { DashboardHeader } from "@/components/dashboard/dashboard-header";
 import { GroupDetails } from "@/components/group/group-details";
 import { GroupMembers } from "@/components/group/group-members";
@@ -11,6 +11,8 @@ import { Button } from "@/components/ui/button";
 import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import { fetchIsPaused, fetchPoolAdmin } from "@/hooks/useJointSaveContracts";
+import { useStellar } from "@/components/web3-provider";
+import { useRecentPools } from "@/hooks/useRecentPools";
 
 interface Pool {
   id: string;
@@ -29,10 +31,13 @@ export default function GroupPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = use(params);
+  const { address } = useStellar();
+  const { trackVisit } = useRecentPools(address);
   const [pool, setPool] = useState<Pool | null>(null);
   const [loading, setLoading] = useState(true);
   const [isPaused, setIsPaused] = useState(false);
   const [poolAdmin, setPoolAdmin] = useState<string | null>(null);
+  const trackedRef = useRef(false);
 
   useEffect(() => {
     fetch(`/api/pools?id=${id}`)
@@ -43,6 +48,23 @@ export default function GroupPage({
       })
       .catch(() => setLoading(false));
   }, [id]);
+
+  // Track visit when pool data loads
+  useEffect(() => {
+    if (pool && !loading && !trackedRef.current) {
+      trackedRef.current = true;
+      trackVisit({
+        id: pool.id,
+        name: pool.name,
+        type: pool.type,
+        contract_address: pool.contract_address,
+      });
+    }
+    // Reset tracker when navigating to a different pool
+    if (!pool || loading) {
+      trackedRef.current = false;
+    }
+  }, [pool, loading, trackVisit]);
 
   const refreshPoolState = useCallback(async () => {
     if (!pool || isPendingAddress(pool.contract_address)) return;

--- a/frontend/components/dashboard/dashboard-header.tsx
+++ b/frontend/components/dashboard/dashboard-header.tsx
@@ -8,20 +8,25 @@ import { useStellar } from "@/components/web3-provider"
 import { ThemeToggle } from "@/components/ui/theme-toggle"
 import { useRouter } from "next/navigation"
 import { useToast } from "@/hooks/use-toast"
-import { Copy, Check, ExternalLink, LogOut, ChevronDown } from "lucide-react"
+import { Copy, Check, ExternalLink, LogOut, ChevronDown, Clock } from "lucide-react"
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import { Badge } from "@/components/ui/badge"
+import { useRecentPools } from "@/hooks/useRecentPools"
+import { formatRelativeTime } from "@/lib/utils"
 
 export function DashboardHeader() {
   const { address, walletId, disconnect } = useStellar()
   const router = useRouter()
   const { toast } = useToast()
   const [copied, setCopied] = useState(false)
+  const { recentPools } = useRecentPools(address)
 
   const truncatedAddress = address
     ? `${address.slice(0, 4)}...${address.slice(-4)}`
@@ -65,6 +70,39 @@ export function DashboardHeader() {
 
           <div className="flex items-center gap-4">
             <ThemeToggle />
+
+            {address && recentPools.length > 0 && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline" size="sm" className="gap-1.5">
+                    <Clock className="h-4 w-4" />
+                    <span className="hidden sm:inline">Recent</span>
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-64">
+                  <DropdownMenuLabel>Recent Pools</DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  {recentPools.map((pool) => (
+                    <DropdownMenuItem key={pool.contract_address || pool.id} asChild>
+                      <Link
+                        href={`/dashboard/group/${pool.id}`}
+                        className="flex w-full cursor-pointer items-center justify-between gap-2"
+                      >
+                        <span className="flex-1 truncate text-sm">{pool.name}</span>
+                        <span className="flex items-center gap-1.5">
+                          <Badge variant="secondary" className="text-[10px] px-1.5 py-0 capitalize">
+                            {pool.type}
+                          </Badge>
+                          <span className="text-[11px] text-muted-foreground whitespace-nowrap">
+                            {formatRelativeTime(new Date(pool.visitedAt))}
+                          </span>
+                        </span>
+                      </Link>
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
 
             {address ? (
               <DropdownMenu>

--- a/frontend/hooks/useRecentPools.ts
+++ b/frontend/hooks/useRecentPools.ts
@@ -1,0 +1,75 @@
+"use client"
+
+import { useState, useCallback, useEffect, useRef } from "react"
+
+export interface RecentPool {
+  id: string
+  name: string
+  type: "rotational" | "target" | "flexible"
+  contract_address: string
+  visitedAt: number
+}
+
+const STORAGE_PREFIX = "jointsave_recent_pools_"
+const MAX_ITEMS = 5
+
+function readStorage(address: string): RecentPool[] {
+  if (typeof window === "undefined") return []
+  try {
+    const raw = localStorage.getItem(STORAGE_PREFIX + address)
+    if (!raw) return []
+    return JSON.parse(raw) as RecentPool[]
+  } catch {
+    return []
+  }
+}
+
+function writeStorage(address: string, pools: RecentPool[]) {
+  if (typeof window === "undefined") return
+  try {
+    localStorage.setItem(STORAGE_PREFIX + address, JSON.stringify(pools))
+  } catch {
+    // localStorage full or unavailable — silently ignore
+  }
+}
+
+export function useRecentPools(address: string | null) {
+  const [recentPools, setRecentPools] = useState<RecentPool[]>(() =>
+    address ? readStorage(address) : []
+  )
+  const addressRef = useRef(address)
+  addressRef.current = address
+
+  // Re-read when address changes (wallet switch)
+  useEffect(() => {
+    if (address) {
+      setRecentPools(readStorage(address))
+    } else {
+      setRecentPools([])
+    }
+  }, [address])
+
+  const trackVisit = useCallback(
+    (pool: Omit<RecentPool, "visitedAt">) => {
+      const currentAddr = addressRef.current
+      if (!currentAddr) return
+
+      setRecentPools((prev) => {
+        const dedupKey = pool.contract_address || pool.id
+        const filtered = prev.filter(
+          (p) => (p.contract_address || p.id) !== dedupKey
+        )
+        const updated: RecentPool[] = [
+          { ...pool, visitedAt: Date.now() },
+          ...filtered,
+        ].slice(0, MAX_ITEMS)
+
+        writeStorage(currentAddr, updated)
+        return updated
+      })
+    },
+    []
+  )
+
+  return { recentPools, trackVisit }
+}


### PR DESCRIPTION
## Description

This PR adds a "Recent Pools" widget to the dashboard header. It allows users to quickly access their most recently visited pools from anywhere in the dashboard.

The feature tracks pool visits per wallet address using localStorage and displays up to 5 most recent pools in a dropdown menu located in the dashboard header.

Closes #39

## Type of Change

- [x] feat: new feature
- [ ] fix: bug fix
- [ ] chore: maintenance, tooling, dependencies
- [ ] docs: documentation only
- [ ] refactor: code restructuring (no functional changes)
- [ ] test: adding or updating tests

## How Has This Been Tested?

- [x] pnpm build succeeds (frontend)
- [x] pnpm lint passes (frontend)
- [x] Manual testing (verified locally via browser)

Manual testing steps performed:
- Connected wallet and accessed dashboard
- Visited multiple group pages to generate recent pool entries
- Verified dropdown appears in dashboard header after visiting pools
- Confirmed maximum of 5 pools are stored and displayed
- Verified revisiting a pool moves it to the top (no duplicates)
- Verified wallet-scoped storage (different wallets show different recent pools)
- Verified navigation works correctly from dropdown items

## Checklist

- [x] My code follows the coding conventions of this project
- [x] I have added/updated tests if needed
- [x] I have updated documentation if needed
- [x] My changes generate no new warnings or errors

