### PR TITLE
docs(env): add example values and clearer comments to .env.example

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,8 +1,8 @@
-# Supabase project URL. Find it in Supabase: Project Settings -> API -> Project URL.
-NEXT_PUBLIC_SUPABASE_URL=
+# Supabase project URL — found at: https://app.supabase.com → Settings → API → Project URL
+NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
 
-# Supabase anon public key. Find it in Supabase: Project Settings -> API -> Project API keys -> anon public.
-NEXT_PUBLIC_SUPABASE_ANON_KEY=
+# Supabase anon/public key — found at: https://app.supabase.com → Settings → API → Project API keys → anon public
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 
 # Stellar Soroban RPC endpoint used by the frontend for contract reads and submissions.
 NEXT_PUBLIC_STELLAR_RPC_URL=https://soroban-testnet.stellar.org


### PR DESCRIPTION
## Summary

Improves `frontend/.env.example` by adding example placeholder values and clearer inline comments for `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`, matching the format suggested in the issue description (e.g. `https://your-project-ref.supabase.co`).

This makes it immediately obvious to new contributors what format each value should be in, not just where to find it.

## Changes
- `frontend/.env.example`: updated Supabase variable comments to use arrow-style source paths and added placeholder example values

## Closes

Closes #69