### PR TITLE
feat: add client-side transaction signing queue

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -10,6 +10,7 @@ import { PoolDataProvider } from "@/lib/data-layer/PoolDataProvider"
 import "@/lib/env"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Suspense } from "react"
+import { TxQueueBadge } from "@/components/tx-queue-badge"
 
 export const metadata: Metadata = {
   title: "JointSave — Decentralized Community Savings on Stellar",
@@ -52,6 +53,7 @@ export default function RootLayout({
         </ThemeProvider>
         <Analytics />
         <Toaster />
+        <TxQueueBadge />
       </body>
     </html>
   )

--- a/frontend/components/group/yield-dashboard.tsx
+++ b/frontend/components/group/yield-dashboard.tsx
@@ -8,6 +8,7 @@ import { Label } from "@/components/ui/label"
 import { Badge } from "@/components/ui/badge"
 import { Loader2, TrendingUp, Zap, AlertTriangle, RefreshCw } from "lucide-react"
 import { useStellar, STELLAR_RPC_URL, STELLAR_NETWORK_PASSPHRASE } from "@/components/web3-provider"
+import { enqueueSign } from "@/lib/tx-queue"
 import {
   Contract, TransactionBuilder, BASE_FEE, nativeToScVal, xdr,
   Address, rpc,
@@ -122,7 +123,7 @@ export function YieldDashboard({ poolAddress }: YieldDashboardProps) {
     const sim = await server.simulateTransaction(tx)
     if (rpc.Api.isSimulationError(sim)) throw new Error(`Simulation: ${sim.error}`)
     const prepared = rpc.assembleTransaction(tx, sim).build()
-    const { signedTxXdr } = await kit!.signTransaction(prepared.toXDR(), {
+    const { signedTxXdr } = await enqueueSign(prepared.toXDR(), {
       networkPassphrase: STELLAR_NETWORK_PASSPHRASE,
     })
     const result = await server.sendTransaction(new Transaction(signedTxXdr, STELLAR_NETWORK_PASSPHRASE))

--- a/frontend/components/tx-queue-badge.tsx
+++ b/frontend/components/tx-queue-badge.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+/**
+ * Small floating badge that shows "N transactions waiting for your approval"
+ * whenever more than one signing request is queued (see lib/tx-queue.ts).
+ * Renders nothing when the queue has 0 or 1 entries, since a single pending
+ * request is the normal case and doesn't need a special indicator.
+ */
+
+import { useEffect, useState } from "react"
+import { subscribeToQueueLength } from "@/lib/tx-queue"
+
+export function TxQueueBadge() {
+  const [queueLength, setQueueLength] = useState(0)
+
+  useEffect(() => {
+    return subscribeToQueueLength(setQueueLength)
+  }, [])
+
+  if (queueLength <= 1) return null
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed bottom-4 right-4 z-50 flex items-center gap-2 rounded-full border border-yellow-500/30 bg-yellow-500/10 px-4 py-2 text-sm font-medium text-yellow-600 shadow-lg backdrop-blur-sm dark:text-yellow-400"
+    >
+      <span className="h-2 w-2 animate-pulse rounded-full bg-yellow-500" />
+      {queueLength} transactions waiting for your approval
+    </div>
+  )
+}

--- a/frontend/components/web3-provider.tsx
+++ b/frontend/components/web3-provider.tsx
@@ -18,6 +18,7 @@ import {
   LobstrModule,
 } from "@creit.tech/stellar-wallets-kit"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { setSigningKit } from "@/lib/tx-queue"
 
 // Create a single QueryClient instance
 const queryClient = new QueryClient({
@@ -88,6 +89,7 @@ export function Web3Provider({ children }: { children: ReactNode }) {
       ],
     })
     setKit(walletKit)
+    setSigningKit(walletKit)
 
     const savedAddress = localStorage.getItem("jointsave_address")
     const savedWalletId = localStorage.getItem("jointsave_wallet_id")

--- a/frontend/hooks/useJointSaveContracts.ts
+++ b/frontend/hooks/useJointSaveContracts.ts
@@ -18,6 +18,7 @@ import {
   STELLAR_RPC_URL,
   STELLAR_NETWORK_PASSPHRASE,
 } from "@/components/web3-provider"
+import { enqueueSign } from "@/lib/tx-queue"
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -83,7 +84,7 @@ async function submitTx(kit: any, tx: any): Promise<string> {
 
   const preparedTx = rpc.assembleTransaction(tx, simResult).build()
 
-  const { signedTxXdr } = await kit.signTransaction(preparedTx.toXDR(), {
+  const { signedTxXdr } = await enqueueSign(preparedTx.toXDR(), {
     networkPassphrase: STELLAR_NETWORK_PASSPHRASE,
   })
 
@@ -151,7 +152,7 @@ export function useDeployPool() {
       }
 
       const preparedTx = rpc.assembleTransaction(tx, simResult).build()
-      const { signedTxXdr } = await kit.signTransaction(preparedTx.toXDR(), {
+      const { signedTxXdr } = await enqueueSign(preparedTx.toXDR(), {
         networkPassphrase: STELLAR_NETWORK_PASSPHRASE,
       })
 

--- a/frontend/lib/tx-queue.ts
+++ b/frontend/lib/tx-queue.ts
@@ -1,0 +1,218 @@
+/**
+ * Client-side transaction signing queue.
+ *
+ * Freighter (and other wallet extensions) can only show one signing popup
+ * at a time. If two `kit.signTransaction(...)` calls fire close together —
+ * e.g. a user double-clicks "Deposit" then immediately clicks "Trigger
+ * Payout" on another pool card — the second call can silently fail, get
+ * stuck pending, or produce a confusing double-prompt experience.
+ *
+ * This module serializes every `signTransaction` call in the app through a
+ * single FIFO queue, so only one wallet popup is ever in flight. Callers
+ * await `enqueueSign(...)` exactly as they would await `kit.signTransaction(...)`
+ * directly — the queueing is transparent to the caller.
+ */
+
+import type { StellarWalletsKit } from "@creit.tech/stellar-wallets-kit"
+import { toastManager } from "@/lib/toast"
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+export interface EnqueueSignOptions {
+  networkPassphrase: string
+  /** Optional Freighter "address" override, forwarded as-is to signTransaction. */
+  address?: string
+}
+
+export interface SignResult {
+  signedTxXdr: string
+}
+
+interface QueueEntry {
+  xdr: string
+  opts: EnqueueSignOptions
+  resolve: (result: SignResult) => void
+  reject: (error: unknown) => void
+  timeoutId: ReturnType<typeof setTimeout>
+  /** True once settled (resolved, rejected, or timed out) — guards against
+   * double-settling if a timeout race fires after the popup already
+   * resolved (or vice versa). */
+  settled: boolean
+}
+
+// ── Configuration ───────────────────────────────────────────────────────
+
+/** If a queued signing request sits unconfirmed this long, we assume the
+ * user closed the wallet popup without responding, and free the queue for
+ * the next request rather than blocking it forever. */
+const SIGN_TIMEOUT_MS = 2 * 60 * 1000 // 2 minutes
+
+// ── Queue state ──────────────────────────────────────────────────────────
+
+let kitRef: StellarWalletsKit | null = null
+const queue: QueueEntry[] = []
+let isProcessing = false
+
+/** Subscribers notified whenever the queue length changes, so UI components
+ * (e.g. a toast/badge) can reflect "N transactions waiting for your approval"
+ * without polling. */
+type QueueListener = (length: number) => void
+const listeners = new Set<QueueListener>()
+
+function notifyListeners() {
+  for (const listener of listeners) {
+    listener(queue.length)
+  }
+}
+
+/** Subscribe to queue-length changes. Returns an unsubscribe function. */
+export function subscribeToQueueLength(listener: QueueListener): () => void {
+  listeners.add(listener)
+  // Immediately report current length so a freshly-mounted UI doesn't have
+  // to wait for the next change to render the correct count.
+  listener(queue.length)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+export function getQueueLength(): number {
+  return queue.length
+}
+
+/**
+ * Registers the active StellarWalletsKit instance. Must be called once the
+ * kit is available (e.g. from Web3Provider) before enqueueSign can be used.
+ * Safe to call repeatedly — e.g. if the kit instance is recreated.
+ */
+export function setSigningKit(kit: StellarWalletsKit | null) {
+  kitRef = kit
+}
+
+// ── Core queue processing ───────────────────────────────────────────────
+
+function settleEntry(
+  entry: QueueEntry,
+  outcome: { ok: true; result: SignResult } | { ok: false; error: unknown }
+) {
+  if (entry.settled) return
+  entry.settled = true
+  clearTimeout(entry.timeoutId)
+  if (outcome.ok) {
+    entry.resolve(outcome.result)
+  } else {
+    entry.reject(outcome.error)
+  }
+}
+
+async function processQueue() {
+  if (isProcessing) return
+  isProcessing = true
+
+  try {
+    while (queue.length > 0) {
+      const entry = queue[0]
+
+      if (queue.length > 1) {
+        toastManager.info(
+          `${queue.length} transactions waiting for your approval`
+        )
+      }
+
+      if (!kitRef) {
+        settleEntry(entry, {
+          ok: false,
+          error: new Error("Wallet kit not initialized"),
+        })
+        queue.shift()
+        continue
+      }
+
+      try {
+        const result = await kitRef.signTransaction(entry.xdr, {
+          networkPassphrase: entry.opts.networkPassphrase,
+          ...(entry.opts.address ? { address: entry.opts.address } : {}),
+        })
+        settleEntry(entry, {
+          ok: true,
+          result: { signedTxXdr: result.signedTxXdr },
+        })
+      } catch (error) {
+        settleEntry(entry, { ok: false, error })
+      }
+
+      // The entry may have already been removed by its own timeout firing
+      // concurrently with the await above; only shift if it's still at the
+      // front (guards against double-shift in that race).
+      if (queue[0] === entry) {
+        queue.shift()
+      }
+      notifyListeners()
+    }
+  } finally {
+    isProcessing = false
+  }
+}
+
+/**
+ * Enqueues a transaction XDR for signing. Resolves with the signed XDR once
+ * the wallet popup completes, in FIFO order relative to other pending
+ * signing requests across the entire app.
+ *
+ * If the request is not confirmed (approved or rejected) within
+ * SIGN_TIMEOUT_MS, it is rejected and removed from the queue — the wallet
+ * popup itself is not force-closed (that's not possible from the page), but
+ * the queue stops waiting on it so subsequent requests aren't blocked
+ * indefinitely by an abandoned popup.
+ */
+export function enqueueSign(
+  xdr: string,
+  opts: EnqueueSignOptions
+): Promise<SignResult> {
+  return new Promise<SignResult>((resolve, reject) => {
+    const entry: QueueEntry = {
+      xdr,
+      opts,
+      resolve,
+      reject,
+      settled: false,
+      // Placeholder; replaced immediately below once `entry` exists, since
+      // the timeout callback needs to reference `entry` itself.
+      timeoutId: setTimeout(() => {}, 0),
+    }
+    clearTimeout(entry.timeoutId)
+
+    entry.timeoutId = setTimeout(() => {
+      if (entry.settled) return
+      settleEntry(entry, {
+        ok: false,
+        error: new Error(
+          "Signing request timed out after 2 minutes. The wallet popup may have been closed without a response."
+        ),
+      })
+      toastManager.warning(
+        "A signing request timed out and was cancelled. Please try again."
+      )
+      const idx = queue.indexOf(entry)
+      if (idx !== -1) {
+        queue.splice(idx, 1)
+        notifyListeners()
+      }
+    }, SIGN_TIMEOUT_MS)
+
+    queue.push(entry)
+    notifyListeners()
+    void processQueue()
+  })
+}
+
+/** Test-only escape hatch to reset module state between test cases. */
+export function __resetQueueForTests() {
+  for (const entry of queue) {
+    settleEntry(entry, { ok: false, error: new Error("Queue reset") })
+  }
+  queue.length = 0
+  isProcessing = false
+  listeners.clear()
+  kitRef = null
+}


### PR DESCRIPTION
## What does this PR do?
Adds a singleton FIFO queue (`lib/tx-queue.ts`) that serializes every `kit.signTransaction` call across the app, plus a floating UI indicator (`components/tx-queue-badge.tsx`) showing how many signing requests are waiting.

## Why?
Closes #65 — with the growing number of wallet-signed actions (deposit, withdraw, trigger payout, pause/unpause, add/remove member, etc.), triggering two in quick succession could cause Freighter's `signTransaction` popups to collide, leading to silent failures or a confusing double-prompt experience. There was no serialization of signing requests anywhere in the app.

## Changes
- `lib/tx-queue.ts`: exposes `enqueueSign(xdr, opts): Promise<{ signedTxXdr }>`. Internally maintains a FIFO queue; only one `signTransaction` call is in-flight at a time. A 2-minute timeout per request rejects and frees the queue if the user closes the popup without responding.
- `components/tx-queue-badge.tsx`: floating badge showing "N transactions waiting for your approval" when 2+ requests are queued; renders nothing otherwise.
- `components/web3-provider.tsx`: registers the wallet kit with the queue via `setSigningKit(walletKit)`.
- `hooks/useJointSaveContracts.ts`: migrated both existing direct `kit.signTransaction` call sites to `enqueueSign` — the shared `submitTx()` helper (covers ~15 hooks: deposit, withdraw, trigger payout, pause/unpause, add/remove member, register, init, set-reputation-tracker, and more) and `useDeployPool`'s `deploy()`, which previously bypassed `submitTx` and called `kit.signTransaction` directly.
- `app/layout.tsx`: mounts `<TxQueueBadge />` app-wide.

## Manual test scenario
Trigger two signed actions back-to-back (e.g. click Deposit on one pool, then immediately click Trigger Payout on another). Only one Freighter popup appears at a time; the second appears immediately after the first is dismissed (approved or rejected). The floating badge shows "2 transactions waiting for your approval" while both are queued. Single-request actions behave exactly as before — no change in the common case.

## How was it tested?
- `npx tsc --noEmit` — zero errors
- `npm run build` — completes successfully, no new warnings
- Manual test scenario above

## Checklist
- [x] Linked issue: Closes #65
- [x] No new linting/type warnings