### PR TITLE
feat: add pool event notifications and user email preferences closes issue #68

### DIFF
--- a/frontend/components/dashboard/dashboard-header.tsx
+++ b/frontend/components/dashboard/dashboard-header.tsx
@@ -8,7 +8,7 @@ import { useStellar } from "@/components/web3-provider"
 import { ThemeToggle } from "@/components/ui/theme-toggle"
 import { useRouter } from "next/navigation"
 import { useToast } from "@/hooks/use-toast"
-import { Copy, Check, ExternalLink, LogOut, ChevronDown, Clock } from "lucide-react"
+import { Copy, Check, ExternalLink, LogOut, ChevronDown, Clock, Bell } from "lucide-react"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { Badge } from "@/components/ui/badge"
 import { useRecentPools } from "@/hooks/useRecentPools"
+import { useNotifications } from "@/hooks/useNotifications"
 import { formatRelativeTime } from "@/lib/utils"
 
 export function DashboardHeader() {
@@ -27,6 +28,7 @@ export function DashboardHeader() {
   const { toast } = useToast()
   const [copied, setCopied] = useState(false)
   const { recentPools } = useRecentPools(address)
+  const { notifications, unreadCount, markAllRead } = useNotifications(address)
 
   const truncatedAddress = address
     ? `${address.slice(0, 4)}...${address.slice(-4)}`
@@ -70,6 +72,59 @@ export function DashboardHeader() {
               Press <kbd className="rounded-sm border border-border bg-muted px-1 font-sans text-[10px] font-medium">?</kbd> for shortcuts
             </span>
             <ThemeToggle />
+
+            {/* Notification bell — only shown when wallet is connected */}
+            {address && (
+              <DropdownMenu onOpenChange={(open) => { if (open && unreadCount > 0) markAllRead() }}>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" size="icon" className="relative" aria-label="Notifications">
+                    <Bell className="h-5 w-5" />
+                    {unreadCount > 0 && (
+                      <span className="absolute -right-0.5 -top-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-primary-foreground">
+                        {unreadCount > 9 ? "9+" : unreadCount}
+                      </span>
+                    )}
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-80">
+                  <DropdownMenuLabel>Notifications</DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  {notifications.length === 0 ? (
+                    <p className="px-3 py-6 text-center text-sm text-muted-foreground">
+                      No notifications yet
+                    </p>
+                  ) : (
+                    notifications.map((n) => (
+                      <DropdownMenuItem
+                        key={n.id}
+                        className="flex flex-col items-start gap-0.5 py-2.5"
+                        asChild={!!n.pool_id}
+                      >
+                        {n.pool_id ? (
+                          <Link href={`/dashboard/group/${n.pool_id}`} className="w-full cursor-pointer">
+                            <span className={`block text-sm leading-snug ${!n.read ? "font-medium" : "text-muted-foreground"}`}>
+                              {n.message}
+                            </span>
+                            <span className="text-[11px] text-muted-foreground">
+                              {formatRelativeTime(new Date(n.created_at))}
+                            </span>
+                          </Link>
+                        ) : (
+                          <>
+                            <span className={`text-sm leading-snug ${!n.read ? "font-medium" : "text-muted-foreground"}`}>
+                              {n.message}
+                            </span>
+                            <span className="text-[11px] text-muted-foreground">
+                              {formatRelativeTime(new Date(n.created_at))}
+                            </span>
+                          </>
+                        )}
+                      </DropdownMenuItem>
+                    ))
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
 
             {address && recentPools.length > 0 && (
               <DropdownMenu>

--- a/frontend/components/dashboard/profile.tsx
+++ b/frontend/components/dashboard/profile.tsx
@@ -3,10 +3,14 @@
 import { Card } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Switch } from "@/components/ui/switch"
 import { useStellar } from "@/components/web3-provider"
-import { Wallet, Award, TrendingUp, Users } from "lucide-react"
+import { Wallet, Award, TrendingUp, Users, Bell, Mail, Loader2 } from "lucide-react"
 import { useState, useEffect } from "react"
 import { supabase } from "@/lib/supabase"
+import { useUserProfile } from "@/hooks/useUserProfile"
 import {
   fetchTargetState,
   fetchFlexibleState,
@@ -87,10 +91,40 @@ async function fetchProfileStats(address: string): Promise<ProfileStats> {
   }
 }
 
+const PREF_LABELS: Record<string, string> = {
+  email_on_payout:  "Payout received",
+  email_on_deposit: "Member deposited",
+  email_on_round:   "Round advanced",
+  email_on_target:  "Target reached",
+}
+
 export function Profile() {
   const { address } = useStellar()
   const [stats, setStats] = useState<ProfileStats | null>(null)
   const [loading, setLoading] = useState(true)
+
+  const { profile, saving, saveProfile } = useUserProfile(address)
+  const [emailDraft, setEmailDraft] = useState("")
+  const [emailSaved, setEmailSaved] = useState(false)
+
+  // Sync draft when profile loads
+  useEffect(() => {
+    if (profile?.email != null) setEmailDraft(profile.email)
+  }, [profile?.email])
+
+  const handleSaveEmail = async () => {
+    const trimmed = emailDraft.trim()
+    await saveProfile({ email: trimmed || null })
+    setEmailSaved(true)
+    setTimeout(() => setEmailSaved(false), 2500)
+  }
+
+  const handleTogglePref = (key: string, value: boolean) => {
+    if (!profile) return
+    saveProfile({
+      notification_preferences: { ...profile.notification_preferences, [key]: value },
+    })
+  }
 
   useEffect(() => {
     if (!address) { setLoading(false); return }
@@ -237,6 +271,75 @@ export function Profile() {
               <p className="text-2xl font-bold mt-1">{stats?.onChain.missedRounds ?? 0}</p>
             </div>
           </div>
+        )}
+      </Card>
+
+      {/* ── Email address ──────────────────────────────────────────────── */}
+      <Card className="p-6">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+            <Mail className="h-5 w-5 text-primary" />
+          </div>
+          <div>
+            <h3 className="font-semibold text-lg">Email Address</h3>
+            <p className="text-sm text-muted-foreground">Receive pool event notifications by email</p>
+          </div>
+        </div>
+
+        <div className="flex gap-3">
+          <Input
+            type="email"
+            placeholder="you@example.com"
+            value={emailDraft}
+            onChange={(e) => setEmailDraft(e.target.value)}
+            className="flex-1"
+          />
+          <Button onClick={handleSaveEmail} disabled={saving}>
+            {saving ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : emailSaved ? (
+              "Saved!"
+            ) : (
+              "Save"
+            )}
+          </Button>
+        </div>
+        {!profile?.email && (
+          <p className="mt-2 text-xs text-muted-foreground">
+            Add an email to receive notifications. Your address is never shared.
+          </p>
+        )}
+      </Card>
+
+      {/* ── Notification preferences ───────────────────────────────────── */}
+      <Card className="p-6">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+            <Bell className="h-5 w-5 text-primary" />
+          </div>
+          <div>
+            <h3 className="font-semibold text-lg">Notifications</h3>
+            <p className="text-sm text-muted-foreground">Choose which events send you an email</p>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          {Object.entries(PREF_LABELS).map(([key, label]) => (
+            <div key={key} className="flex items-center justify-between">
+              <span className="text-sm">{label}</span>
+              <Switch
+                checked={profile?.notification_preferences?.[key as keyof typeof profile.notification_preferences] ?? true}
+                onCheckedChange={(val) => handleTogglePref(key, val)}
+                disabled={saving || !profile}
+              />
+            </div>
+          ))}
+        </div>
+
+        {!profile?.email && (
+          <p className="mt-4 text-xs text-muted-foreground border-t border-border pt-4">
+            Add an email above to receive these notifications.
+          </p>
         )}
       </Card>
 

--- a/frontend/hooks/useNotifications.ts
+++ b/frontend/hooks/useNotifications.ts
@@ -1,0 +1,71 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import { supabase } from "@/lib/supabase"
+
+export interface AppNotification {
+  id: string
+  pool_id: string | null
+  activity_type: string
+  message: string
+  read: boolean
+  created_at: string
+}
+
+export function useNotifications(walletAddress: string | null) {
+  const [notifications, setNotifications] = useState<AppNotification[]>([])
+  const [loading, setLoading] = useState(false)
+
+  const fetch = useCallback(async () => {
+    if (!walletAddress) { setNotifications([]); return }
+    setLoading(true)
+    const { data } = await supabase
+      .from("notifications")
+      .select("id, pool_id, activity_type, message, read, created_at")
+      .eq("wallet_address", walletAddress.toLowerCase())
+      .order("created_at", { ascending: false })
+      .limit(10)
+    setNotifications((data as AppNotification[]) ?? [])
+    setLoading(false)
+  }, [walletAddress])
+
+  useEffect(() => {
+    fetch()
+    if (!walletAddress) return
+
+    // Real-time: prepend new notifications as they arrive
+    const channel = supabase
+      .channel(`notifications:${walletAddress}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "notifications",
+          filter: `wallet_address=eq.${walletAddress.toLowerCase()}`,
+        },
+        (payload) => {
+          setNotifications((prev) =>
+            [payload.new as AppNotification, ...prev].slice(0, 10)
+          )
+        }
+      )
+      .subscribe()
+
+    return () => { supabase.removeChannel(channel) }
+  }, [walletAddress, fetch])
+
+  const markAllRead = useCallback(async () => {
+    if (!walletAddress) return
+    await supabase
+      .from("notifications")
+      .update({ read: true })
+      .eq("wallet_address", walletAddress.toLowerCase())
+      .eq("read", false)
+    setNotifications((prev) => prev.map((n) => ({ ...n, read: true })))
+  }, [walletAddress])
+
+  const unreadCount = notifications.filter((n) => !n.read).length
+
+  return { notifications, loading, unreadCount, markAllRead, refetch: fetch }
+}

--- a/frontend/hooks/useUserProfile.ts
+++ b/frontend/hooks/useUserProfile.ts
@@ -1,0 +1,72 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import { supabase } from "@/lib/supabase"
+
+export interface NotificationPreferences {
+  email_on_payout: boolean
+  email_on_deposit: boolean
+  email_on_round: boolean
+  email_on_target: boolean
+}
+
+export interface UserProfile {
+  wallet_address: string
+  email: string | null
+  notification_preferences: NotificationPreferences
+}
+
+const DEFAULT_PREFS: NotificationPreferences = {
+  email_on_payout: true,
+  email_on_deposit: true,
+  email_on_round: true,
+  email_on_target: true,
+}
+
+export function useUserProfile(walletAddress: string | null) {
+  const [profile, setProfile] = useState<UserProfile | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+
+  const fetchProfile = useCallback(async () => {
+    if (!walletAddress) { setProfile(null); return }
+    setLoading(true)
+    const { data } = await supabase
+      .from("user_profiles")
+      .select("wallet_address, email, notification_preferences")
+      .eq("wallet_address", walletAddress.toLowerCase())
+      .maybeSingle()
+    setProfile(
+      data ?? {
+        wallet_address: walletAddress.toLowerCase(),
+        email: null,
+        notification_preferences: DEFAULT_PREFS,
+      }
+    )
+    setLoading(false)
+  }, [walletAddress])
+
+  useEffect(() => { fetchProfile() }, [fetchProfile])
+
+  const saveProfile = useCallback(
+    async (updates: Partial<Pick<UserProfile, "email" | "notification_preferences">>) => {
+      if (!walletAddress) return
+      setSaving(true)
+      await supabase.from("user_profiles").upsert(
+        {
+          wallet_address: walletAddress.toLowerCase(),
+          ...updates,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: "wallet_address" }
+      )
+      setProfile((prev) =>
+        prev ? { ...prev, ...updates } : null
+      )
+      setSaving(false)
+    },
+    [walletAddress]
+  )
+
+  return { profile, loading, saving, saveProfile, refetch: fetchProfile }
+}

--- a/frontend/lib/supabase.ts
+++ b/frontend/lib/supabase.ts
@@ -191,6 +191,65 @@ export type Database = {
           last_calculated_at?: string
         }
       }
+      user_profiles: {
+        Row: {
+          wallet_address: string
+          email: string | null
+          notification_preferences: {
+            email_on_payout: boolean
+            email_on_deposit: boolean
+            email_on_round: boolean
+            email_on_target: boolean
+          }
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          wallet_address: string
+          email?: string | null
+          notification_preferences?: {
+            email_on_payout?: boolean
+            email_on_deposit?: boolean
+            email_on_round?: boolean
+            email_on_target?: boolean
+          }
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          email?: string | null
+          notification_preferences?: {
+            email_on_payout?: boolean
+            email_on_deposit?: boolean
+            email_on_round?: boolean
+            email_on_target?: boolean
+          }
+          updated_at?: string
+        }
+      }
+      notifications: {
+        Row: {
+          id: string
+          wallet_address: string
+          pool_id: string | null
+          activity_type: string
+          message: string
+          read: boolean
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          wallet_address: string
+          pool_id?: string | null
+          activity_type: string
+          message: string
+          read?: boolean
+          created_at?: string
+        }
+        Update: {
+          read?: boolean
+        }
+      }
     }
   }
 }

--- a/supabase/functions/notify-pool-event/index.ts
+++ b/supabase/functions/notify-pool-event/index.ts
@@ -1,0 +1,217 @@
+// Supabase Edge Function: notify-pool-event
+//
+// Triggered by a Supabase database webhook on pool_activity INSERT.
+// Reads event type, fetches affected members, checks notification preferences,
+// sends email via Resend, and writes in-app notification rows.
+//
+// Required env vars:
+//   SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY  — auto-injected by Supabase
+//   RESEND_API_KEY                            — set in Supabase dashboard > Edge Functions > Secrets
+//   RESEND_FROM_EMAIL                         — e.g. "JointSave <noreply@jointsave.app>"
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2"
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts"
+
+const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY") ?? ""
+const RESEND_FROM = Deno.env.get("RESEND_FROM_EMAIL") ?? "JointSave <noreply@jointsave.app>"
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? ""
+const SUPABASE_SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+
+const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY)
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface ActivityRecord {
+  id: string
+  pool_id: string
+  activity_type: string
+  user_address: string | null
+  amount: number | null
+  description: string | null
+  created_at: string
+}
+
+interface WebhookPayload {
+  type: "INSERT" | "UPDATE" | "DELETE"
+  table: string
+  record: ActivityRecord
+}
+
+interface NotificationPreferences {
+  email_on_payout: boolean
+  email_on_deposit: boolean
+  email_on_round: boolean
+  email_on_target: boolean
+}
+
+interface UserProfile {
+  wallet_address: string
+  email: string | null
+  notification_preferences: NotificationPreferences
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function shortAddress(addr: string): string {
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`
+}
+
+function xlmFromStroops(stroops: number | null): string {
+  if (stroops == null) return "?"
+  return (stroops / 10_000_000).toFixed(2)
+}
+
+async function sendEmail(to: string, subject: string, html: string): Promise<void> {
+  if (!RESEND_API_KEY || !to) return
+  const res = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${RESEND_API_KEY}`,
+    },
+    body: JSON.stringify({ from: RESEND_FROM, to, subject, html }),
+  })
+  if (!res.ok) {
+    console.error("Resend error:", await res.text())
+  }
+}
+
+function emailHtml(bodyContent: string): string {
+  return `
+    <div style="font-family:sans-serif;max-width:520px;margin:0 auto;padding:24px">
+      <h2 style="color:#6d28d9;margin-bottom:8px">JointSave</h2>
+      ${bodyContent}
+      <hr style="border:none;border-top:1px solid #e5e7eb;margin:24px 0"/>
+      <p style="font-size:12px;color:#9ca3af">
+        You're receiving this because you're a member of a JointSave pool.
+        Manage preferences in your profile settings.
+      </p>
+    </div>`
+}
+
+// ── Main handler ─────────────────────────────────────────────────────────────
+
+serve(async (req) => {
+  try {
+    const payload: WebhookPayload = await req.json()
+    if (payload.type !== "INSERT") return new Response("ok", { status: 200 })
+
+    const act = payload.record
+    const { activity_type, pool_id, user_address, amount } = act
+
+    const HANDLED = ["payout", "deposit", "round_advance", "target_reached"]
+    if (!HANDLED.includes(activity_type)) {
+      return new Response("ok", { status: 200 })
+    }
+
+    // Fetch pool info
+    const { data: pool } = await sb
+      .from("pools")
+      .select("id, name")
+      .eq("id", pool_id)
+      .single()
+    if (!pool) return new Response("pool not found", { status: 200 })
+
+    // Fetch all pool members
+    const { data: members } = await sb
+      .from("pool_members")
+      .select("member_address")
+      .eq("pool_id", pool_id)
+    const allMembers: string[] = (members ?? []).map((m: { member_address: string }) => m.member_address)
+
+    // Fetch user profiles for email + preferences lookup
+    const { data: profiles } = await sb
+      .from("user_profiles")
+      .select("wallet_address, email, notification_preferences")
+      .in("wallet_address", allMembers)
+    const profileMap = new Map<string, UserProfile>(
+      (profiles ?? []).map((p: UserProfile) => [p.wallet_address, p])
+    )
+
+    const poolName = pool.name
+    const xlm = xlmFromStroops(amount)
+    const senderShort = user_address ? shortAddress(user_address) : "A member"
+
+    // Determine recipients, preference key, message content
+    let recipients: string[] = []
+    let prefKey: keyof NotificationPreferences = "email_on_deposit"
+    let subject = ""
+    let inAppMsg = ""
+    let bodyHtml = ""
+
+    if (activity_type === "payout") {
+      recipients = user_address ? [user_address] : []
+      prefKey = "email_on_payout"
+      subject = `You received ${xlm} XLM from ${poolName}`
+      inAppMsg = subject
+      bodyHtml = emailHtml(
+        `<p>Great news! You received <strong>${xlm} XLM</strong> from your savings pool <strong>${poolName}</strong>.</p>
+         <p>Log in to view your updated balance.</p>`
+      )
+    } else if (activity_type === "deposit") {
+      recipients = allMembers.filter((a) => a !== user_address)
+      prefKey = "email_on_deposit"
+      subject = `${senderShort} deposited to ${poolName}`
+      inAppMsg = subject
+      bodyHtml = emailHtml(
+        `<p><strong>${senderShort}</strong> made a deposit of <strong>${xlm} XLM</strong> to <strong>${poolName}</strong>.</p>`
+      )
+    } else if (activity_type === "round_advance") {
+      recipients = allMembers
+      prefKey = "email_on_round"
+      const nextMember = act.description ?? "the next member"
+      subject = `Round complete in ${poolName} — ${nextMember} is next`
+      inAppMsg = subject
+      bodyHtml = emailHtml(
+        `<p>A round is complete in <strong>${poolName}</strong>.</p>
+         <p>The next beneficiary is <strong>${nextMember}</strong>.</p>`
+      )
+    } else if (activity_type === "target_reached") {
+      recipients = allMembers
+      prefKey = "email_on_target"
+      subject = `${poolName} reached its target! You can now withdraw.`
+      inAppMsg = subject
+      bodyHtml = emailHtml(
+        `<p>Your savings pool <strong>${poolName}</strong> has reached its savings target!</p>
+         <p>You are now eligible to withdraw your funds. Log in to proceed.</p>`
+      )
+    }
+
+    // Write in-app notifications for all recipients
+    if (recipients.length > 0) {
+      await sb.from("notifications").insert(
+        recipients.map((addr) => ({
+          wallet_address: addr,
+          pool_id,
+          activity_type,
+          message: inAppMsg,
+        }))
+      )
+    }
+
+    // Send emails, respecting per-user opt-out preferences
+    await Promise.all(
+      recipients.map(async (addr) => {
+        const profile = profileMap.get(addr)
+        if (!profile?.email) return
+        const prefs: NotificationPreferences = {
+          email_on_payout: true,
+          email_on_deposit: true,
+          email_on_round: true,
+          email_on_target: true,
+          ...(profile.notification_preferences ?? {}),
+        }
+        if (!prefs[prefKey]) return
+        await sendEmail(profile.email, subject, bodyHtml)
+      })
+    )
+
+    return new Response(
+      JSON.stringify({ ok: true, notified: recipients.length }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    )
+  } catch (err) {
+    console.error("notify-pool-event error:", err)
+    return new Response("internal error", { status: 500 })
+  }
+})

--- a/supabase/migrations/20260622000000_notifications_schema.sql
+++ b/supabase/migrations/20260622000000_notifications_schema.sql
@@ -1,0 +1,31 @@
+-- Migration: User Profiles and In-App Notifications
+-- Adds user_profiles (email + notification prefs) and notifications (bell feed).
+
+-- 1. user_profiles — keyed by wallet address, holds email and opt-in preferences
+CREATE TABLE IF NOT EXISTS user_profiles (
+  wallet_address           TEXT PRIMARY KEY,
+  email                    TEXT,
+  notification_preferences JSONB NOT NULL DEFAULT
+    '{"email_on_payout":true,"email_on_deposit":true,"email_on_round":true,"email_on_target":true}'::jsonb,
+  created_at               TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at               TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_profiles_email
+  ON user_profiles(email) WHERE email IS NOT NULL;
+
+-- 2. notifications — persisted in-app notification feed (bell dropdown)
+CREATE TABLE IF NOT EXISTS notifications (
+  id             UUID    PRIMARY KEY DEFAULT gen_random_uuid(),
+  wallet_address TEXT    NOT NULL,
+  pool_id        UUID    REFERENCES pools(id) ON DELETE CASCADE,
+  activity_type  TEXT    NOT NULL,
+  message        TEXT    NOT NULL,
+  read           BOOLEAN NOT NULL DEFAULT false,
+  created_at     TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_notifications_wallet
+  ON notifications(wallet_address, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_notifications_unread
+  ON notifications(wallet_address) WHERE read = false;


### PR DESCRIPTION
## Description

closes issue #68 
## Description
Implements pool event notifications and user email preferences for JointSave.
A Supabase Edge Function listens for four pool activity types and dispatches
in-app and email notifications based on each user's stored preferences.

## Key Changes

### Database
- Added `user_profiles` table storing each user's email address and
  notification opt-in preferences per event type
- Added `notifications` table serving as the in-app notification feed

### Supabase Edge Function
- Handles four activity types: `payout`, `deposit`, `round_advance`,
  and `target_reached`
- Checks `user_profiles` preferences before dispatching to avoid
  sending unwanted emails
- Dispatches email via the Resend API
- Converts Stellar amounts from stroops to display units

## Type of Change
- ✓ feat: new feature

## Testing
- Edge Function deployed and invoked locally against each of the four
  activity types
- Email delivery confirmed via Resend dashboard
- Notification rows verified in Supabase `notifications` table
- Preference opt-out verified to suppress email dispatch

## Checklist
- [ ] Code follows project conventions
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] No new warnings or errors

**Closes:** #68
<img width="2038" height="2160" alt="Screenshot (50)" src="https://github.com/user-attachments/assets/a69a366d-4396-4fa5-b652-5b809fee38cb" />


