### PR TITLE
fix: skip Supabase realtime/network calls in E2E mode

### DIFF
--- a/frontend/hooks/useNotifications.ts
+++ b/frontend/hooks/useNotifications.ts
@@ -2,6 +2,9 @@
 
 import { useState, useEffect, useCallback } from "react"
 import { supabase } from "@/lib/supabase"
+import type { RealtimePostgresInsertPayload } from "@supabase/supabase-js"
+
+const IS_E2E = process.env.NEXT_PUBLIC_E2E === "true"
 
 export interface AppNotification {
   id: string
@@ -17,7 +20,7 @@ export function useNotifications(walletAddress: string | null) {
   const [loading, setLoading] = useState(false)
 
   const fetch = useCallback(async () => {
-    if (!walletAddress) { setNotifications([]); return }
+    if (!walletAddress || IS_E2E) { setNotifications([]); return }
     setLoading(true)
     const { data } = await supabase
       .from("notifications")
@@ -31,7 +34,7 @@ export function useNotifications(walletAddress: string | null) {
 
   useEffect(() => {
     fetch()
-    if (!walletAddress) return
+    if (!walletAddress || IS_E2E) return
 
     // Real-time: prepend new notifications as they arrive
     const channel = supabase
@@ -44,7 +47,7 @@ export function useNotifications(walletAddress: string | null) {
           table: "notifications",
           filter: `wallet_address=eq.${walletAddress.toLowerCase()}`,
         },
-        (payload) => {
+        (payload: RealtimePostgresInsertPayload<AppNotification>) => {
           setNotifications((prev) =>
             [payload.new as AppNotification, ...prev].slice(0, 10)
           )
@@ -56,7 +59,7 @@ export function useNotifications(walletAddress: string | null) {
   }, [walletAddress, fetch])
 
   const markAllRead = useCallback(async () => {
-    if (!walletAddress) return
+    if (!walletAddress || IS_E2E) return
     await supabase
       .from("notifications")
       .update({ read: true })

--- a/frontend/hooks/useUserProfile.ts
+++ b/frontend/hooks/useUserProfile.ts
@@ -3,6 +3,8 @@
 import { useState, useEffect, useCallback } from "react"
 import { supabase } from "@/lib/supabase"
 
+const IS_E2E = process.env.NEXT_PUBLIC_E2E === "true"
+
 export interface NotificationPreferences {
   email_on_payout: boolean
   email_on_deposit: boolean
@@ -29,7 +31,18 @@ export function useUserProfile(walletAddress: string | null) {
   const [saving, setSaving] = useState(false)
 
   const fetchProfile = useCallback(async () => {
-    if (!walletAddress) { setProfile(null); return }
+    if (!walletAddress || IS_E2E) {
+      setProfile(
+        walletAddress
+          ? {
+              wallet_address: walletAddress.toLowerCase(),
+              email: null,
+              notification_preferences: DEFAULT_PREFS,
+            }
+          : null
+      )
+      return
+    }
     setLoading(true)
     const { data } = await supabase
       .from("user_profiles")
@@ -51,6 +64,10 @@ export function useUserProfile(walletAddress: string | null) {
   const saveProfile = useCallback(
     async (updates: Partial<Pick<UserProfile, "email" | "notification_preferences">>) => {
       if (!walletAddress) return
+      if (IS_E2E) {
+        setProfile((prev) => (prev ? { ...prev, ...updates } : null))
+        return
+      }
       setSaving(true)
       await supabase.from("user_profiles").upsert(
         {


### PR DESCRIPTION
##  fix: skip Supabase realtime/network calls in useNotifications and useUserProfile during E2E tests

## Summary

`navigation.spec.ts` was failing because `useNotifications` opens a
real Supabase Realtime WebSocket connection on mount, unconditionally,
regardless of environment. In the E2E test environment, the Supabase
URL is a deliberate placeholder (`e2e-placeholder.supabase.co`), so
this connection fails with `ERR_NAME_NOT_RESOLVED` — and since the
notification bell (`useNotifications`) renders globally inside
`dashboard-header.tsx`, this fired on every dashboard page visit during
the test's landing → dashboard → group detail → back journey, tripping
the test's strict "no unexpected console errors" assertion.

This isn't a bug in either PR #81 (E2E suite) or PR #85 (notifications)
individually — it's a gap between them. The notifications feature added
a new always-on side effect after the navigation test was already
written and passing, with no way for that test to have anticipated it.

## Fix

Both `useNotifications.ts` and `useUserProfile.ts` now follow the same
`IS_E2E` pattern already established in `web3-provider.tsx` and
`useJointSaveContracts.ts` — short-circuiting any real network/WebSocket
activity when `NEXT_PUBLIC_E2E=true`, exactly like the wallet and
contract layers already do.

- `useNotifications`: skips the initial fetch, skips opening the
  Realtime channel/WebSocket entirely, and skips the mark-all-read
  network call, in E2E mode.
- `useUserProfile`: same treatment, proactively. It makes the same kind
  of real Supabase call (plain HTTPS, not WebSocket) and would hit the
  same placeholder-URL failure mode if any future test interacted with
  the profile/settings UI. Still returns sensible default profile state
  in E2E mode so a test could verify the UI renders with defaults.

## Also fixed

The Realtime callback's `payload` parameter had no type, which was a
separate, real `tsc --noEmit` error on `main`. Note: PR #95 partially
addressed this with an inline `{ new: AppNotification }` shape — this
PR instead uses Supabase's actual exported
`RealtimePostgresInsertPayload<T>` type, which is more correct and
avoids re-declaring a shape that already exists in the SDK. (PR #95 did
not touch the actual WebSocket/E2E issue this PR fixes — that's a
separate, unrelated feature PR.)

## Verification

- `npx tsc --noEmit` — passes clean, zero errors
- Manually traced the failing assertion in `navigation.spec.ts` against
  the actual call site in `dashboard-header.tsx` → `useNotifications` to
  confirm this is the correct fix location

## Scope

Touches only `frontend/hooks/useNotifications.ts` and
`frontend/hooks/useUserProfile.ts`. No other open PR currently modifies
either file (confirmed by diffing against #82, #83, #84, #79, #81), so
this should merge without conflicts and unblock the E2E check for any
PR that merges `main` in afterward.

Closes the `navigation.spec.ts` regression introduced by #85.