### PR TITLE
feat(frontend): add per-pool health score badge

### DIFF
--- a/frontend/app/api/pools/route.ts
+++ b/frontend/app/api/pools/route.ts
@@ -175,6 +175,24 @@ export async function GET(req: NextRequest) {
       }
 
       return NextResponse.json({ data: data || [], total: count ?? 0, page, pageSize: PAGE_SIZE })
+    } else if (req.nextUrl.searchParams.get('explore') !== null) {
+      // Explore feed — all pools, paginated, newest first, for prospective members.
+      const PAGE_SIZE = 6
+      const page = Math.max(0, parseInt(req.nextUrl.searchParams.get('page') || '0', 10))
+      const from = page * PAGE_SIZE
+      const to = from + PAGE_SIZE - 1
+
+      const { data, error, count } = await supabase
+        .from('pools')
+        .select('*', { count: 'exact' })
+        .order('created_at', { ascending: false })
+        .range(from, to)
+
+      if (error) {
+        throw error
+      }
+
+      return NextResponse.json({ data: data || [], total: count ?? 0, page, pageSize: PAGE_SIZE })
     } else {
       // Fetch all pools
       const { data, error } = await supabase

--- a/frontend/components/dashboard/dashboard-tabs.tsx
+++ b/frontend/components/dashboard/dashboard-tabs.tsx
@@ -3,11 +3,12 @@
 import { useState, useCallback } from "react"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { MyGroups } from "@/components/dashboard/my-groups"
+import { Explore } from "@/components/dashboard/explore"
 import { CreateGroup } from "@/components/dashboard/create-group"
 import { Transactions } from "@/components/dashboard/transactions"
 import { Profile } from "@/components/dashboard/profile"
 import { AnalyticsDashboard } from "@/components/dashboard/analytics"
-import { Home, PlusCircle, Receipt, User, TrendingUp } from "lucide-react"
+import { Home, Compass, PlusCircle, Receipt, User, TrendingUp } from "lucide-react"
 
 export function DashboardTabs({
   activeTab: controlledActiveTab,
@@ -26,10 +27,14 @@ export function DashboardTabs({
 
   return (
     <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-      <TabsList className="grid w-full grid-cols-5 mb-8">
+      <TabsList className="grid w-full grid-cols-6 mb-8">
         <TabsTrigger value="groups" className="flex items-center gap-2">
           <Home className="h-4 w-4" />
           <span className="hidden sm:inline">My Groups</span>
+        </TabsTrigger>
+        <TabsTrigger value="explore" className="flex items-center gap-2">
+          <Compass className="h-4 w-4" />
+          <span className="hidden sm:inline">Explore</span>
         </TabsTrigger>
         <TabsTrigger value="create" className="flex items-center gap-2">
           <PlusCircle className="h-4 w-4" />
@@ -51,6 +56,10 @@ export function DashboardTabs({
 
       <TabsContent value="groups" className="mt-0">
         <MyGroups onCreateClick={handleCreateClick} />
+      </TabsContent>
+
+      <TabsContent value="explore" className="mt-0">
+        <Explore />
       </TabsContent>
 
       <TabsContent value="create" className="mt-0">

--- a/frontend/components/dashboard/explore.tsx
+++ b/frontend/components/dashboard/explore.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { Card } from "@/components/ui/card"
-import { Skeleton } from "@/components/ui/skeleton"
 import {
   Pagination,
   PaginationContent,
@@ -9,28 +8,24 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from "@/components/ui/pagination"
+import { Compass } from "lucide-react"
 import { motion } from "framer-motion"
 import { useState, useEffect, useCallback } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
-import { useStellar } from "@/components/web3-provider"
-import { EmptyState } from "@/components/dashboard/empty-state"
-import { FirstPoolTooltip } from "@/components/dashboard/first-pool-tooltip"
-import { PoolCard, PoolCardSkeleton, type Pool } from "@/components/dashboard/pool-card"
+import {
+  PoolCard,
+  PoolCardSkeleton,
+  type Pool,
+} from "@/components/dashboard/pool-card"
 
 const PAGE_SIZE = 6
-
-interface MyGroupsProps {
-  onCreateClick?: () => void
-}
 
 const container = {
   hidden: { opacity: 0 },
   show: { opacity: 1, transition: { staggerChildren: 0.1 } },
 }
 
-// ── Main MyGroups component ───────────────────────────────────────────────────
-export function MyGroups({ onCreateClick }: MyGroupsProps) {
-  const { address } = useStellar()
+export function Explore() {
   const router = useRouter()
   const searchParams = useSearchParams()
 
@@ -39,33 +34,29 @@ export function MyGroups({ onCreateClick }: MyGroupsProps) {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState("")
 
-  const page = Math.max(0, parseInt(searchParams.get("page") || "0", 10))
+  // Use a dedicated query param so it doesn't collide with My Groups pagination.
+  const page = Math.max(0, parseInt(searchParams.get("explorePage") || "0", 10))
   const totalPages = Math.ceil(total / PAGE_SIZE)
 
   const setPage = useCallback(
     (p: number) => {
       const params = new URLSearchParams(searchParams.toString())
-      params.set("page", String(p))
+      params.set("explorePage", String(p))
       router.push(`?${params.toString()}`, { scroll: false })
     },
     [router, searchParams]
   )
 
   useEffect(() => {
-    if (!address) {
-      setLoading(false)
-      return
-    }
     loadPools(page)
-  }, [address, page])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page])
 
   const loadPools = async (currentPage: number) => {
     try {
       setLoading(true)
       setError("")
-      const res = await fetch(
-        `/api/pools?creator=${address?.toLowerCase()}&page=${currentPage}`
-      )
+      const res = await fetch(`/api/pools?explore=true&page=${currentPage}`)
       if (!res.ok) throw new Error("Failed to fetch pools")
       const json = await res.json()
       const data: Pool[] = Array.isArray(json) ? json : (json.data ?? [])
@@ -83,12 +74,14 @@ export function MyGroups({ onCreateClick }: MyGroupsProps) {
     return (
       <div className="space-y-6">
         <div>
-          <h2 className="text-3xl font-bold">My Groups</h2>
-          <Skeleton className="h-4 w-40 mt-2" />
+          <h2 className="text-3xl font-bold">Explore Pools</h2>
+          <p className="text-muted-foreground mt-1">
+            Browse savings circles and see how reliably their members participate
+          </p>
         </div>
         <div
           className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
-          aria-label="Loading groups"
+          aria-label="Loading pools"
         >
           {Array.from({ length: PAGE_SIZE }).map((_, i) => (
             <PoolCardSkeleton key={i} />
@@ -102,7 +95,7 @@ export function MyGroups({ onCreateClick }: MyGroupsProps) {
     return (
       <div className="space-y-6">
         <div>
-          <h2 className="text-3xl font-bold">My Groups</h2>
+          <h2 className="text-3xl font-bold">Explore Pools</h2>
         </div>
         <Card className="p-6 bg-destructive/10 text-destructive">
           <p>{error}</p>
@@ -117,24 +110,28 @@ export function MyGroups({ onCreateClick }: MyGroupsProps) {
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
-        className="flex items-center justify-between"
       >
-        <div>
-          <h2 className="text-3xl font-bold">My Groups</h2>
-          <p className="text-muted-foreground mt-1">
-            {total === 0
-              ? "Manage your savings circles"
-              : `${total} active group${total !== 1 ? "s" : ""}`}
-          </p>
-        </div>
+        <h2 className="text-3xl font-bold">Explore Pools</h2>
+        <p className="text-muted-foreground mt-1">
+          {total === 0
+            ? "No pools to explore yet"
+            : `Browse ${total} pool${total !== 1 ? "s" : ""} — the health badge shows how reliably members have been depositing`}
+        </p>
       </motion.div>
 
       {pools.length === 0 ? (
-        <EmptyState onCreateClick={onCreateClick} />
+        <Card className="p-12 flex flex-col items-center text-center gap-3">
+          <div className="rounded-full bg-muted p-3">
+            <Compass className="h-6 w-6 text-muted-foreground" />
+          </div>
+          <p className="font-medium">Nothing to explore just yet</p>
+          <p className="text-sm text-muted-foreground max-w-sm">
+            Once people start creating savings pools, they&apos;ll show up here
+            for you to browse.
+          </p>
+        </Card>
       ) : (
         <>
-          <FirstPoolTooltip poolCount={pools.length} />
-
           <motion.div
             variants={container}
             initial="hidden"

--- a/frontend/components/dashboard/pool-card.tsx
+++ b/frontend/components/dashboard/pool-card.tsx
@@ -1,0 +1,225 @@
+"use client"
+
+import { Card } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Users, TrendingUp, Calendar, ArrowRight } from "lucide-react"
+import Link from "next/link"
+import { motion } from "framer-motion"
+import { usePoolData } from "@/lib/data-layer/PoolDataProvider"
+import {
+  formatTokenAmount,
+  RotationalPoolState,
+  TargetPoolState,
+  FlexiblePoolState,
+} from "@/hooks/useJointSaveContracts"
+import { usePoolHealth } from "@/hooks/usePoolHealth"
+import { PoolHealthBadge } from "@/components/dashboard/pool-health-badge"
+
+export interface Pool {
+  id: string
+  name: string
+  type: "rotational" | "target" | "flexible"
+  status: "active" | "completed" | "paused"
+  members_count: number
+  total_saved: number
+  progress: number
+  frequency?: string
+  next_payout?: string
+  contract_address: string
+  target_amount: number | null
+  contribution_amount: number | null
+  minimum_deposit: number | null
+  token_symbol?: string | null
+  token_decimals?: number | null
+}
+
+const item = { hidden: { opacity: 0, y: 20 }, show: { opacity: 1, y: 0 } }
+
+// ── Skeleton for a single pool card ──────────────────────────────────────────
+export function PoolCardSkeleton() {
+  return (
+    <Card className="p-6 h-full flex flex-col" aria-hidden="true">
+      {/* header row */}
+      <div className="flex items-start justify-between mb-4">
+        <div className="space-y-2">
+          <Skeleton className="h-6 w-36" />
+          <Skeleton className="h-5 w-20 rounded-full" />
+        </div>
+        <div className="flex flex-col items-end gap-2">
+          <Skeleton className="h-5 w-16 rounded-full" />
+          <Skeleton className="h-5 w-20 rounded-full" />
+        </div>
+      </div>
+
+      {/* stat rows */}
+      <div className="space-y-3 mb-4 flex-1">
+        {[0, 1, 2].map((i) => (
+          <div key={i} className="flex items-center justify-between">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-4 w-16" />
+          </div>
+        ))}
+      </div>
+
+      {/* progress bar */}
+      <div className="mb-4 space-y-2">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-4 w-16" />
+          <Skeleton className="h-4 w-10" />
+        </div>
+        <Skeleton className="h-2 w-full rounded-full" />
+      </div>
+
+      {/* button */}
+      <Skeleton className="h-9 w-full rounded-md" />
+    </Card>
+  )
+}
+
+// ── Per-pool card that hydrates live balances from the unified cache ──────────
+export function PoolCard({ pool }: { pool: Pool }) {
+  const cacheKey =
+    pool.contract_address && pool.contract_address !== "pending_deployment"
+      ? pool.contract_address
+      : pool.id
+  const { data, isLoading } = usePoolData(cacheKey)
+  const { health, isLoading: healthLoading } = usePoolHealth(cacheKey, pool.type)
+  const tokenSymbol = pool.token_symbol ?? "XLM"
+  const tokenDecimals = pool.token_decimals ?? 7
+  const fmt = (v: bigint) => formatTokenAmount(v, tokenDecimals)
+
+  const getLiveStats = (): {
+    totalSaved: number
+    progress: number
+    progressLabel: string
+  } => {
+    const onchain = data?.onchain ?? null
+    if (pool.type === "rotational" && onchain) {
+      const s = onchain as RotationalPoolState
+      const totalMembers = s.members.length || pool.members_count || 1
+      const progress = Math.min(
+        100,
+        Math.round((s.currentRound / totalMembers) * 100)
+      )
+      const perRound = (pool.contribution_amount || 0) * totalMembers
+      const totalSaved = s.currentRound * perRound
+      return {
+        totalSaved,
+        progress,
+        progressLabel: `Round ${s.currentRound + 1} of ${totalMembers}`,
+      }
+    }
+    if (pool.type === "target" && onchain) {
+      const s = onchain as TargetPoolState
+      const saved = fmt(s.totalDeposited)
+      const target = pool.target_amount || fmt(s.targetAmount) || 1
+      const progress = Math.min(100, Math.round((saved / target) * 100))
+      return {
+        totalSaved: saved,
+        progress,
+        progressLabel: `${saved.toFixed(2)} / ${target.toFixed(2)} ${tokenSymbol}`,
+      }
+    }
+    if (pool.type === "flexible" && onchain) {
+      const s = onchain as FlexiblePoolState
+      const totalSaved = fmt(s.totalBalance)
+      const softGoal = (pool.minimum_deposit || 0) * (pool.members_count || 1)
+      const progress =
+        softGoal > 0
+          ? Math.min(100, Math.round((totalSaved / softGoal) * 100))
+          : s.isActive
+          ? 50
+          : 100
+      return {
+        totalSaved,
+        progress,
+        progressLabel:
+          softGoal > 0
+            ? `${totalSaved.toFixed(2)} / ${softGoal.toFixed(2)} ${tokenSymbol}`
+            : `${totalSaved.toFixed(2)} ${tokenSymbol} saved`,
+      }
+    }
+    return {
+      totalSaved: pool.total_saved ?? 0,
+      progress: pool.progress ?? 0,
+      progressLabel: "",
+    }
+  }
+
+  const { totalSaved, progress, progressLabel } = getLiveStats()
+  const formatXlm = (n: number) => `${n.toFixed(2)} ${tokenSymbol}`
+
+  return (
+    <motion.div variants={item}>
+      <Card className="p-6 hover:shadow-lg transition-all duration-300 hover:-translate-y-1 h-full flex flex-col">
+        <div className="flex items-start justify-between mb-4 gap-3">
+          <div>
+            <h3 className="text-xl font-semibold mb-1">{pool.name}</h3>
+            <Badge variant="secondary">
+              {pool.type.charAt(0).toUpperCase() + pool.type.slice(1)}
+            </Badge>
+          </div>
+          <div className="flex flex-col items-end gap-2 shrink-0">
+            <Badge className="bg-primary/10 text-primary hover:bg-primary/20">
+              {pool.status}
+            </Badge>
+            <PoolHealthBadge health={health} isLoading={healthLoading} />
+          </div>
+        </div>
+        <div className="space-y-3 mb-4 flex-1">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground flex items-center gap-2">
+              <Users className="h-4 w-4" />
+              Members
+            </span>
+            <span className="font-medium">{pool.members_count}</span>
+          </div>
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground flex items-center gap-2">
+              <TrendingUp className="h-4 w-4" />
+              Total Saved
+            </span>
+            <span className="font-medium">
+              {isLoading && !data?.onchain ? (
+                <Skeleton className="h-4 w-16 inline-block" />
+              ) : (
+                formatXlm(totalSaved)
+              )}
+            </span>
+          </div>
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground flex items-center gap-2">
+              <Calendar className="h-4 w-4" />
+              {pool.type === "rotational" ? "Frequency" : "Status"}
+            </span>
+            <span className="font-medium">{pool.frequency || pool.status}</span>
+          </div>
+        </div>
+        <div className="mb-4">
+          <div className="flex items-center justify-between text-sm mb-2">
+            <span className="text-muted-foreground">Progress</span>
+            <span className="font-medium">{progress.toFixed(1)}%</span>
+          </div>
+          <div className="h-2 bg-muted rounded-full overflow-hidden">
+            <motion.div
+              initial={{ width: 0 }}
+              animate={{ width: `${progress}%` }}
+              transition={{ duration: 1, delay: 0.5 }}
+              className="h-full bg-primary"
+            />
+          </div>
+          {progressLabel && (
+            <p className="text-xs text-muted-foreground mt-1">{progressLabel}</p>
+          )}
+        </div>
+        <Button className="w-full bg-transparent" variant="outline" asChild>
+          <Link href={`/dashboard/group/${pool.id}`}>
+            View Details <ArrowRight className="ml-2 h-4 w-4" />
+          </Link>
+        </Button>
+      </Card>
+    </motion.div>
+  )
+}

--- a/frontend/components/dashboard/pool-health-badge.tsx
+++ b/frontend/components/dashboard/pool-health-badge.tsx
@@ -1,0 +1,117 @@
+"use client"
+
+import { Activity, HelpCircle } from "lucide-react"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { cn } from "@/lib/utils"
+import type { PoolHealth, PoolHealthBand } from "@/lib/pool-health"
+import { HEALTHY_THRESHOLD, FAIR_THRESHOLD } from "@/lib/pool-health"
+
+const BAND_STYLES: Record<PoolHealthBand, { dot: string; chip: string }> = {
+  healthy: {
+    dot: "bg-emerald-500",
+    chip: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 border-emerald-500/20",
+  },
+  fair: {
+    dot: "bg-amber-500",
+    chip: "bg-amber-500/10 text-amber-700 dark:text-amber-400 border-amber-500/20",
+  },
+  "at-risk": {
+    dot: "bg-rose-500",
+    chip: "bg-rose-500/10 text-rose-700 dark:text-rose-400 border-rose-500/20",
+  },
+}
+
+const NEUTRAL_CHIP =
+  "bg-muted text-muted-foreground border-border"
+
+function chipBase(extra: string) {
+  return cn(
+    "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium",
+    extra,
+  )
+}
+
+/**
+ * Plain-language explanation of the score, shown in the tooltip so the badge
+ * never reads as an opaque or unfair label.
+ */
+function HealthTooltipBody({ health }: { health: PoolHealth }) {
+  return (
+    <div className="max-w-[240px] space-y-1.5 text-left">
+      <p className="font-semibold">Pool health</p>
+      {health.state === "new" ? (
+        <p className="text-background/80">
+          This pool hasn&apos;t completed a full round of deposits yet, so there
+          isn&apos;t enough history to score it reliably. The score will appear
+          once members start participating.
+        </p>
+      ) : (
+        <p className="text-background/80">
+          The average on-time deposit rate across this pool&apos;s{" "}
+          {health.memberCount} current member
+          {health.memberCount === 1 ? "" : "s"}, based on their track record so
+          far. Higher means members have been depositing more reliably.
+        </p>
+      )}
+      <p className="text-background/60 pt-0.5">
+        {HEALTHY_THRESHOLD}%+ healthy · {FAIR_THRESHOLD}–{HEALTHY_THRESHOLD - 1}%
+        fair · under {FAIR_THRESHOLD}% at risk
+      </p>
+    </div>
+  )
+}
+
+export function PoolHealthBadge({
+  health,
+  isLoading,
+  className,
+}: {
+  health: PoolHealth | null
+  isLoading?: boolean
+  className?: string
+}) {
+  if (isLoading || !health) {
+    return <Skeleton className={cn("h-5 w-20 rounded-full", className)} />
+  }
+
+  const isNew = health.state === "new"
+  const styles = !isNew && health.band ? BAND_STYLES[health.band] : null
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className={chipBase(cn(styles ? styles.chip : NEUTRAL_CHIP, className))}
+          role="status"
+          aria-label={
+            isNew
+              ? "Pool health: new pool, not enough history to score"
+              : `Pool health: ${health.score}% on-time, ${health.label}`
+          }
+        >
+          {isNew ? (
+            <HelpCircle className="h-3 w-3" />
+          ) : (
+            <span className={cn("h-2 w-2 rounded-full", styles?.dot)} aria-hidden />
+          )}
+          {isNew ? (
+            "New pool"
+          ) : (
+            <>
+              <Activity className="h-3 w-3" aria-hidden />
+              {health.score}%
+            </>
+          )}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        <HealthTooltipBody health={health} />
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/frontend/hooks/usePoolHealth.ts
+++ b/frontend/hooks/usePoolHealth.ts
@@ -1,0 +1,109 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { usePoolData } from "@/lib/data-layer/PoolDataProvider"
+import {
+  fetchReputation,
+  type ReputationScore,
+  type RotationalPoolState,
+} from "@/hooks/useJointSaveContracts"
+import {
+  computePoolHealth,
+  hasTrackRecord,
+  type PoolHealth,
+} from "@/lib/pool-health"
+
+interface PoolMemberRow {
+  member_address: string
+}
+
+/**
+ * Computes a pool's health badge data from the reputation system.
+ *
+ * Reuses the unified pool cache (members + on-chain state) and layers per-member
+ * reputation lookups on top, mirroring the pattern already used on the group
+ * members panel. Returns `health: null` while data is still loading.
+ */
+export function usePoolHealth(
+  cacheKey: string,
+  poolType: "rotational" | "target" | "flexible",
+): { health: PoolHealth | null; isLoading: boolean } {
+  const { data, isLoading: poolLoading } = usePoolData(cacheKey)
+
+  const members: PoolMemberRow[] = data?.db?.pool_members ?? []
+  const onchain = data?.onchain ?? null
+
+  // Stable key so the effect only re-runs when the actual member set changes.
+  const memberKey = useMemo(
+    () =>
+      members
+        .map((m) => m.member_address)
+        .sort()
+        .join(","),
+    [members],
+  )
+
+  const [reputations, setReputations] = useState<Record<string, ReputationScore>>({})
+  const [repsLoading, setRepsLoading] = useState(true)
+
+  useEffect(() => {
+    if (members.length === 0) {
+      setReputations({})
+      // Only "done" loading reps once the underlying pool data has loaded;
+      // otherwise an empty members list is just the not-yet-fetched state.
+      setRepsLoading(poolLoading)
+      return
+    }
+    let cancelled = false
+    setRepsLoading(true)
+    ;(async () => {
+      const entries = await Promise.allSettled(
+        members.map(
+          async (m) =>
+            [m.member_address, await fetchReputation(m.member_address)] as const,
+        ),
+      )
+      if (cancelled) return
+      setReputations(
+        Object.fromEntries(
+          entries
+            .filter(
+              (r): r is PromiseFulfilledResult<readonly [string, ReputationScore]> =>
+                r.status === "fulfilled",
+            )
+            .map((r) => r.value),
+        ),
+      )
+      setRepsLoading(false)
+    })()
+    return () => {
+      cancelled = true
+    }
+    // memberKey captures the member set; poolLoading gates the empty case.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [memberKey, poolLoading])
+
+  const health = useMemo<PoolHealth | null>(() => {
+    if (poolLoading || repsLoading) return null
+
+    const reps = members
+      .map((m) => reputations[m.member_address])
+      .filter((r): r is ReputationScore => Boolean(r))
+
+    // How much real history the pool has observed — the confidence gate.
+    // Rotational pools expose elapsed rounds directly; for target/flexible
+    // pools (which have no rounds) we use how many members already carry a
+    // participation track record from their reputation.
+    let historyObserved: number
+    if (poolType === "rotational" && onchain) {
+      historyObserved = (onchain as RotationalPoolState).currentRound ?? 0
+    } else {
+      historyObserved = reps.filter(hasTrackRecord).length
+    }
+
+    return computePoolHealth(reps, historyObserved)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [memberKey, reputations, onchain, poolType, poolLoading, repsLoading])
+
+  return { health, isLoading: poolLoading || repsLoading }
+}

--- a/frontend/lib/pool-health.test.ts
+++ b/frontend/lib/pool-health.test.ts
@@ -1,0 +1,75 @@
+// Unit tests for the per-pool health calculation.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import {
+  computePoolHealth,
+  hasTrackRecord,
+  MIN_HISTORY,
+  type MemberReputation,
+} from './pool-health';
+
+// Build a member reputation; on-time rate given in PERCENT for readability.
+function member(onTimePercent: number, extra: Partial<MemberReputation> = {}): MemberReputation {
+  return {
+    onTimeRate: onTimePercent * 100, // percent → basis points
+    totalDeposits: 1n,
+    missedRounds: 0,
+    poolsCompleted: 0,
+    ...extra,
+  };
+}
+
+test('computePoolHealth - averages member on-time rates into a percent score', () => {
+  const reps = [member(100), member(80), member(60)]; // avg = 80%
+  const result = computePoolHealth(reps, 3);
+  assert.strictEqual(result.state, 'scored');
+  assert.strictEqual(result.score, 80);
+  assert.strictEqual(result.band, 'fair');
+  assert.strictEqual(result.memberCount, 3);
+});
+
+test('computePoolHealth - bands: healthy / fair / at-risk', () => {
+  assert.strictEqual(computePoolHealth([member(90), member(95)], 2).band, 'healthy'); // 92.5 -> 93
+  assert.strictEqual(computePoolHealth([member(85), member(85)], 2).band, 'healthy'); // exactly 85
+  assert.strictEqual(computePoolHealth([member(70), member(70)], 2).band, 'fair');
+  assert.strictEqual(computePoolHealth([member(60), member(60)], 2).band, 'fair'); // exactly 60
+  assert.strictEqual(computePoolHealth([member(40), member(50)], 2).band, 'at-risk'); // 45
+});
+
+test('computePoolHealth - rounding matches basis-point average', () => {
+  // 100% and 75% -> avg 87.5% -> rounds to 88
+  const result = computePoolHealth([member(100), member(75)], 2);
+  assert.strictEqual(result.score, 88);
+});
+
+test('computePoolHealth - new pool with no history is neutral, not inflated', () => {
+  // Members default to a perfect 100% on-time rate, but zero rounds observed.
+  const reps = [member(100), member(100)];
+  const result = computePoolHealth(reps, 0);
+  assert.strictEqual(result.state, 'new');
+  assert.strictEqual(result.score, null);
+  assert.strictEqual(result.band, null);
+  assert.strictEqual(result.label, 'New pool');
+});
+
+test('computePoolHealth - no members is neutral', () => {
+  const result = computePoolHealth([], 5);
+  assert.strictEqual(result.state, 'new');
+  assert.strictEqual(result.score, null);
+});
+
+test('computePoolHealth - exactly MIN_HISTORY rounds is enough to score', () => {
+  const result = computePoolHealth([member(90)], MIN_HISTORY);
+  assert.strictEqual(result.state, 'scored');
+  assert.strictEqual(result.score, 90);
+});
+
+test('hasTrackRecord - distinguishes real activity from the default record', () => {
+  // Default record handed to unseen addresses: 100% on-time, no activity.
+  const fresh: MemberReputation = { onTimeRate: 10000, totalDeposits: 0n, missedRounds: 0, poolsCompleted: 0 };
+  assert.strictEqual(hasTrackRecord(fresh), false);
+
+  assert.strictEqual(hasTrackRecord({ ...fresh, totalDeposits: 5n }), true);
+  assert.strictEqual(hasTrackRecord({ ...fresh, missedRounds: 1 }), true);
+  assert.strictEqual(hasTrackRecord({ ...fresh, poolsCompleted: 1 }), true);
+});

--- a/frontend/lib/pool-health.ts
+++ b/frontend/lib/pool-health.ts
@@ -1,0 +1,100 @@
+// Per-pool health score derived from the reputation system.
+//
+// A pool's health reflects how reliably its current members have been making
+// their deposits on time. We take the average on-time deposit rate across all
+// current members (from the on-chain reputation tracker) and gate it on how
+// much real history the pool actually has, so a brand-new pool — where every
+// member defaults to a perfect 100% on-time rate with no real data behind it —
+// is shown as a neutral "New pool" rather than a misleadingly high score.
+
+/** Minimum rounds/history a pool must have observed before we show a score. */
+export const MIN_HISTORY = 1
+
+/** Score (percent) at/above which a pool is considered healthy. */
+export const HEALTHY_THRESHOLD = 85
+/** Score (percent) at/above which a pool is considered fair (below = at risk). */
+export const FAIR_THRESHOLD = 60
+
+export type PoolHealthBand = "healthy" | "fair" | "at-risk"
+export type PoolHealthState = "new" | "scored"
+
+export interface PoolHealth {
+  /** "scored" when there's enough history to show a number; "new" otherwise. */
+  state: PoolHealthState
+  /** Average on-time rate as a 0–100 percent. Null when state is "new". */
+  score: number | null
+  /** Colour band for the badge. Null when state is "new". */
+  band: PoolHealthBand | null
+  /** Human label: "Healthy" | "Fair" | "At risk" | "New pool". */
+  label: string
+  /** Number of current members the score was averaged over. */
+  memberCount: number
+  /**
+   * How much participation history the pool has observed. For rotational pools
+   * this is the number of rounds that have elapsed; for other pool types it's
+   * the number of current members who already have an on-chain track record.
+   */
+  historyObserved: number
+}
+
+/** A member's reputation, as needed for the health calculation. */
+export interface MemberReputation {
+  /** On-time deposit rate in basis points (10000 = 100%). */
+  onTimeRate: number
+  /** Total deposits this member has ever made (base units). */
+  totalDeposits: bigint
+  /** Rounds this member has missed across all their pools. */
+  missedRounds: number
+  /** Pools this member has seen through to a completed payout. */
+  poolsCompleted: number
+}
+
+/**
+ * True when a member has any real participation track record, as opposed to the
+ * default reputation handed to addresses the tracker has never seen (which
+ * reports a perfect 100% on-time rate with zero activity).
+ */
+export function hasTrackRecord(rep: MemberReputation): boolean {
+  return rep.totalDeposits > 0n || rep.missedRounds > 0 || rep.poolsCompleted > 0
+}
+
+function bandFor(score: number): { band: PoolHealthBand; label: string } {
+  if (score >= HEALTHY_THRESHOLD) return { band: "healthy", label: "Healthy" }
+  if (score >= FAIR_THRESHOLD) return { band: "fair", label: "Fair" }
+  return { band: "at-risk", label: "At risk" }
+}
+
+/**
+ * Compute a pool's health from its current members' reputations.
+ *
+ * @param reputations  reputation of each current member
+ * @param historyObserved  rounds elapsed (rotational) or members-with-history
+ *                         (other types) — the confidence gate
+ */
+export function computePoolHealth(
+  reputations: MemberReputation[],
+  historyObserved: number,
+): PoolHealth {
+  const memberCount = reputations.length
+
+  // Not enough to say anything meaningful: no members, or the pool hasn't
+  // observed a full round / any member track record yet.
+  if (memberCount === 0 || historyObserved < MIN_HISTORY) {
+    return {
+      state: "new",
+      score: null,
+      band: null,
+      label: "New pool",
+      memberCount,
+      historyObserved,
+    }
+  }
+
+  // Average on-time rate across members (basis points → percent).
+  const avgBps =
+    reputations.reduce((sum, r) => sum + r.onTimeRate, 0) / memberCount
+  const score = Math.round(avgBps / 100)
+  const { band, label } = bandFor(score)
+
+  return { state: "scored", score, band, label, memberCount, historyObserved }
+}


### PR DESCRIPTION
Surface a per-pool "health score" so prospective members can gauge how reliably a pool's existing members participate before joining.

- lib/pool-health.ts: pure calculation — average member on_time_rate (from the reputation tracker), gated by how much participation history the pool has observed. Pools with too little history return a neutral "New pool" state instead of a misleadingly high default-100% score.
- usePoolHealth hook: joins cached members + on-chain state with per-member reputation lookups; rotational pools gate on elapsed rounds, others on members with a track record.
- PoolHealthBadge: green/yellow/red badge + percentage with a plain-language tooltip explaining the calculation and the bands.
- Extract a shared PoolCard (from MyGroups) rendering the badge, reused by both My Groups and a new Explore tab listing all pools for browsing.
- Unit tests cross-checking the calculation.

## Description



Closes #94  

## Type of Change

- [x] feat: new feature
- [x] fix: bug fix
- [ ] chore: maintenance, tooling, dependencies
- [x] docs: documentation only
- [x] refactor: code restructuring (no functional changes)
- [x] test: adding or updating tests

## How Has This Been Tested?


- [x] `cargo test` passes (smart contracts)
- [x] `pnpm build` succeeds (frontend)
- [x] `pnpm lint` passes (frontend)
- [x] Manual testing (describe below)

## Checklist

- [x] My code follows the coding conventions of this project
- [x] I have added/updated tests if needed
- [x] I have updated documentation if needed
- [x] My changes generate no new warnings or errors

## Screenshots (if applicable)


