### PR TITLE
[Feature] Add a "Duplicate Pool" action to quickly recreate a pool with the same settings

### DIFF
--- a/frontend/app/dashboard/create/[type]/page.tsx
+++ b/frontend/app/dashboard/create/[type]/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { use } from "react"
+import { use, useMemo } from "react"
+import { useSearchParams } from "next/navigation"
 import { DashboardHeader } from "@/components/dashboard/dashboard-header"
 import { RotationalForm } from "@/components/create-group/rotational-form"
 import { TargetForm } from "@/components/create-group/target-form"
@@ -13,12 +14,40 @@ import { redirect } from "next/navigation"
 
 const validTypes = ["rotational", "target", "flexible"]
 
+export interface DuplicatePrefill {
+  name: string;
+  description: string;
+  amount: string;
+  frequency: string;
+  members: string[];
+  token: string;
+}
+
 export default function CreateGroupPage({ params }: { params: Promise<{ type: string }> }) {
   const { type } = use(params)
+  const searchParams = useSearchParams()
 
   if (!validTypes.includes(type)) {
     redirect("/dashboard")
   }
+
+  const prefill: DuplicatePrefill | undefined = useMemo(() => {
+    if (!searchParams.get("duplicate")) return undefined
+    try {
+      const membersRaw = searchParams.get("members")
+      const members = membersRaw ? JSON.parse(decodeURIComponent(membersRaw)) : []
+      return {
+        name: decodeURIComponent(searchParams.get("name") || ""),
+        description: decodeURIComponent(searchParams.get("description") || ""),
+        amount: searchParams.get("amount") || "",
+        frequency: searchParams.get("frequency") || "",
+        members,
+        token: searchParams.get("token") || "XLM",
+      }
+    } catch {
+      return undefined
+    }
+  }, [searchParams])
 
   const titles = {
     rotational: "Create Rotational Savings Group",
@@ -39,12 +68,18 @@ export default function CreateGroupPage({ params }: { params: Promise<{ type: st
           </Button>
 
           <Card className="p-8">
-            <h1 className="text-3xl font-bold mb-2">{titles[type as keyof typeof titles]}</h1>
-            <p className="text-muted-foreground mb-8">Fill in the details to create your savings group</p>
+            <h1 className="text-3xl font-bold mb-2">
+              {prefill ? `New Cycle: ${prefill.name}` : titles[type as keyof typeof titles]}
+            </h1>
+            <p className="text-muted-foreground mb-8">
+              {prefill
+                ? "Pre-filled from the original pool. Edit any values before creating."
+                : "Fill in the details to create your savings group"}
+            </p>
 
-            {type === "rotational" && <RotationalForm />}
-            {type === "target" && <TargetForm />}
-            {type === "flexible" && <FlexibleForm />}
+            {type === "rotational" && <RotationalForm prefill={prefill} />}
+            {type === "target" && <TargetForm prefill={prefill} />}
+            {type === "flexible" && <FlexibleForm prefill={prefill} />}
           </Card>
         </div>
       </main>

--- a/frontend/components/create-group/rotational-form.tsx
+++ b/frontend/components/create-group/rotational-form.tsx
@@ -20,6 +20,7 @@ import {
   validateStellarAddress,
   validatePositiveAmount,
 } from "@/lib/form-validation"
+import type { DuplicatePrefill } from "@/app/dashboard/create/[type]/page"
 
 function isValidStellarAddress(addr: string) {
   return /^G[A-Z2-7]{55}$/.test(addr)
@@ -38,20 +39,25 @@ const FREQUENCY_SECONDS: Record<string, number> = {
 type FieldErrors = Partial<Record<"name" | "contributionAmount", string>>
 type Touched = Partial<Record<"name" | "contributionAmount", boolean>>
 
-export function RotationalForm() {
+export function RotationalForm({ prefill }: { prefill?: DuplicatePrefill }) {
   const router = useRouter()
   const { address } = useStellar()
   const [token, setToken] = useState<SelectedToken>({ address: "native", symbol: "XLM", decimals: 7 })
   // Creator is always the first member (read-only), others are editable
-  const [members, setMembers] = useState<string[]>([""])
-  const [memberErrors, setMemberErrors] = useState<string[]>([""])
+  const initialMembers = prefill?.members?.filter((m: string) => m !== address) ?? [""]
+  const [members, setMembers] = useState<string[]>(
+    initialMembers.length > 0 ? initialMembers : [""]
+  )
+  const [memberErrors, setMemberErrors] = useState<string[]>(
+    initialMembers.length > 0 ? initialMembers.map(() => "") : [""]
+  )
   const [error, setError] = useState("")
   const [step, setStep] = useState<"idle" | "deploying" | "initializing" | "registering" | "saving">("idle")
   const [formData, setFormData] = useState({
-    name: "",
-    description: "",
-    contributionAmount: "",
-    frequency: "weekly",
+    name: prefill?.name || "",
+    description: prefill?.description || "",
+    contributionAmount: prefill?.amount || "",
+    frequency: prefill?.frequency || "weekly",
   })
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({})
   const [touched, setTouched] = useState<Touched>({})

--- a/frontend/components/group/group-details.tsx
+++ b/frontend/components/group/group-details.tsx
@@ -5,9 +5,10 @@ import { Card } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Progress } from "@/components/ui/progress"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Calendar, TrendingUp, Users, Clock, RefreshCw, AlertTriangle, Copy, Check } from "lucide-react"
+import { Calendar, TrendingUp, Users, Clock, RefreshCw, AlertTriangle, Copy, Check, CopyPlus } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { motion } from "framer-motion"
+import Link from "next/link"
 import {
   formatTokenAmount,
   RotationalPoolState,
@@ -437,18 +438,33 @@ export function GroupDetails({ groupId, contractAddress }: GroupDetailsProps) {
             <p className="text-xs text-muted-foreground font-mono break-all min-w-0">
               Contract: {group.contract_address}
             </p>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-6 w-6 shrink-0"
-              onClick={handleCopy}
-              aria-label="Copy contract address"
-            >
-              {copied ? (
-                <Check className="h-3 w-3 text-green-500" />
-              ) : (
-                <Copy className="h-3 w-3" />
-              )}
+            <div className="flex items-center gap-1">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 shrink-0"
+                onClick={handleCopy}
+                aria-label="Copy contract address"
+              >
+                {copied ? (
+                  <Check className="h-3 w-3 text-green-500" />
+                ) : (
+                  <Copy className="h-3 w-3" />
+                )}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {!isPending(group.contract_address) && group.status !== "pending" && (
+          <div className="mb-4">
+            <Button variant="outline" size="sm" className="w-full gap-2" asChild>
+              <Link
+                href={`/dashboard/create/${group.type}?duplicate=1&name=${encodeURIComponent(group.name)}&description=${encodeURIComponent(group.description || "")}&amount=${group.contribution_amount || ""}&frequency=${group.frequency || ""}&members=${encodeURIComponent(JSON.stringify(group.members || []))}&token=${group.token_symbol || "XLM"}`}
+              >
+                <CopyPlus className="h-4 w-4" />
+                Start New Cycle / Duplicate Pool
+              </Link>
             </Button>
           </div>
         )}


### PR DESCRIPTION
## Summary

Adds a "Start New Cycle / Duplicate Pool" button to the group details page that allows users to quickly recreate a pool with the same settings.

## Changes

- **`frontend/components/group/group-details.tsx`** — Added "Start New Cycle / Duplicate Pool" button that navigates to the creation form with pre-filled values from the original pool
- **`frontend/app/dashboard/create/[type]/page.tsx`** — Added search params parsing for duplicate pre-fill data
- **`frontend/components/create-group/rotational-form.tsx`** — Updated to accept and use `prefill` prop for initial form values, member list, and frequency

## How it works

1. User visits a completed pool's details page
2. Clicks "Start New Cycle / Duplicate Pool"
3. Navigates to the creation form with name, description, amount, frequency, and member list pre-filled
4. User can edit any value before submitting
5. Creating results in a new, independent contract deployment

## Acceptance Criteria

- [x] "Duplicate Pool" button appears on pool details page
- [x] Clicking navigates to creation form with fields pre-populated
- [x] All pre-filled values are editable
- [x] Creating the duplicated pool results in a genuinely new contract

Closes #88