### PR TITLE
#105  Add an aria-label to the refresh button on the group detail pag…

### DIFF
--- a/frontend/components/group/group-details.tsx
+++ b/frontend/components/group/group-details.tsx
@@ -385,6 +385,7 @@ export function GroupDetails({ groupId, contractAddress }: GroupDetailsProps) {
             size="icon"
             onClick={refetch}
             disabled={isLoading}
+            aria-label="Refresh pool data"
           >
             <RefreshCw
               className={`h-4 w-4 ${isLoading ? "animate-spin" : ""}`}


### PR DESCRIPTION
## Description

Adds an accessible `aria-label` to the icon-only refresh button in `frontend/components/group/group-details.tsx`. Screen readers now announce "Refresh pool data" instead of a generic "button". The fix follows the same pattern already used by the nearby "Copy contract address" button.

I also did a quick pass for other icon-only buttons missing `aria-label` and found the following, which are **not** fixed in this PR but should be tracked for a follow-up accessibility pass:

- `frontend/components/group/yield-dashboard.tsx` — refresh button (`loadState`)
- `frontend/components/create-group/BulkImport.tsx` — remove member row button (X icon)
- `frontend/components/create-group/flexible-form.tsx` — remove member button (X icon)
- `frontend/components/create-group/rotational-form.tsx` — remove member button (X icon)
- `frontend/components/create-group/target-form.tsx` — remove member button (X icon)

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] chore: maintenance, tooling, dependencies
- [ ] docs: documentation only
- [ ] refactor: code restructuring (no functional changes)
- [ ] test: adding or updating tests

## How Has This Been Tested?

- [ ] `cargo test` passes (smart contracts)
- [x] `npm run build` succeeds (frontend) — `pnpm build` equivalent
- [ ] `pnpm lint` passes (frontend) — `next lint` is no longer supported in Next.js 16, so the project's lint script is currently non-functional
- [x] Manual testing — verified that the button visually remains identical and only gains the `aria-label` attribute; no new TypeScript errors in `frontend/components/group/group-details.tsx`

## Checklist

- [x] My code follows the coding conventions of this project
- [ ] I have added/updated tests if needed — not needed for a single accessibility attribute change
- [ ] I have updated documentation if needed — not needed for this change
- [x] My changes generate no new warnings or errors

CLOSE #105 