### PR TITLE
docs: confirm logo links already navigate to home

### DIFF
--- a/docs/logo-links-verified.md
+++ b/docs/logo-links-verified.md
@@ -1,0 +1,8 @@
+﻿# Header/Footer Logo Links - Verified
+
+All logos are already wrapped in Link components:
+- rontend/components/dashboard/dashboard-header.tsx - Logo links to /
+- rontend/components/landing/header.tsx - Logo links to /
+- rontend/components/landing/footer.tsx - Logo links to /
+
+No changes needed. Issue #113 verified as already resolved.


### PR DESCRIPTION
Verified that dashboard-header.tsx, landing/header.tsx, and landing/footer.tsx all have the JointSave logo/wordmark wrapped in a <Link href="/"> component. No changes needed — the behavior is already correct.

Closes #113