### PR TITLE
add loading skeleton to notification bell dropdown on first fetch

### DIFF
--- a/frontend/components/dashboard/dashboard-header.tsx
+++ b/frontend/components/dashboard/dashboard-header.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
 import { useRecentPools } from "@/hooks/useRecentPools"
 import { useNotifications } from "@/hooks/useNotifications"
 import { formatRelativeTime } from "@/lib/utils"
@@ -28,7 +29,7 @@ export function DashboardHeader() {
   const { toast } = useToast()
   const [copied, setCopied] = useState(false)
   const { recentPools } = useRecentPools(address)
-  const { notifications, unreadCount, markAllRead } = useNotifications(address)
+  const { notifications, initialLoading, unreadCount, markAllRead } = useNotifications(address)
 
   const truncatedAddress = address
     ? `${address.slice(0, 4)}...${address.slice(-4)}`
@@ -92,7 +93,14 @@ export function DashboardHeader() {
                 <DropdownMenuContent align="end" className="w-80">
                   <DropdownMenuLabel>Notifications</DropdownMenuLabel>
                   <DropdownMenuSeparator />
-                  {notifications.length === 0 ? (
+                  {initialLoading ? (
+                    [0, 1, 2].map((i) => (
+                      <div key={i} className="flex flex-col gap-1.5 px-3 py-2.5">
+                        <Skeleton className="h-4 w-full" />
+                        <Skeleton className="h-3 w-24" />
+                      </div>
+                    ))
+                  ) : notifications.length === 0 ? (
                     <p className="px-3 py-6 text-center text-sm text-muted-foreground">
                       No notifications yet
                     </p>

--- a/frontend/hooks/useNotifications.ts
+++ b/frontend/hooks/useNotifications.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect, useCallback, useRef } from "react"
 import { supabase } from "@/lib/supabase"
 import type { RealtimePostgresInsertPayload } from "@supabase/supabase-js"
 
@@ -18,14 +18,25 @@ export interface AppNotification {
 export function useNotifications(walletAddress: string | null) {
   const [notifications, setNotifications] = useState<AppNotification[]>([])
   const [loading, setLoading] = useState(false)
+  const [initialLoading, setInitialLoading] = useState(false)
+  const hasLoadedOnce = useRef(false)
+
+  useEffect(() => {
+    hasLoadedOnce.current = false
+  }, [walletAddress])
 
   const loadNotifications = useCallback(async () => {
     if (!walletAddress || IS_E2E) { setNotifications([]); return }
     setLoading(true)
+    if (!hasLoadedOnce.current) setInitialLoading(true)
     const res = await window.fetch(`/api/notifications?wallet=${encodeURIComponent(walletAddress.toLowerCase())}`)
     const data = res.ok ? await res.json() : []
     setNotifications(data)
     setLoading(false)
+    if (!hasLoadedOnce.current) {
+      hasLoadedOnce.current = true
+      setInitialLoading(false)
+    }
   }, [walletAddress])
 
   useEffect(() => {
@@ -65,5 +76,5 @@ export function useNotifications(walletAddress: string | null) {
 
   const unreadCount = notifications.filter((n) => !n.read).length
 
-  return { notifications, loading, unreadCount, markAllRead, refetch: loadNotifications }
+  return { notifications, loading, initialLoading, unreadCount, markAllRead, refetch: loadNotifications }
 }


### PR DESCRIPTION
## What changed

`useNotifications` already exposed a `loading` boolean but the notification dropdown in `dashboard-header.tsx` never consumed it, so the first open would briefly flash an empty "No notifications yet" state before data arrived.

Two files changed:

**`hooks/useNotifications.ts`**
- Added `initialLoading` state (true only while the very first fetch is in-flight) tracked via a `hasLoadedOnce` ref.
- A separate `useEffect` resets `hasLoadedOnce` when `walletAddress` changes so a new wallet session shows the skeleton again.
- `initialLoading` is returned alongside the existing exports.

**`components/dashboard/dashboard-header.tsx`**
- Imports `Skeleton` from the existing `@/components/ui/skeleton`.
- Destructures `initialLoading` from `useNotifications`.
- Renders 3 skeleton rows (message line + timestamp line each) when `initialLoading` is true; falls through to the normal empty/list states once data has loaded.

## Acceptance criteria

- Opening the dropdown for the first time shows 3 skeleton rows, not an empty list.
- Subsequent opens (data already in state) show the real list with no skeleton flicker.
- No new dependencies introduced.

Closes #109