### PR TITLE
add character counter and limit to pool name and description fields

### DIFF
--- a/frontend/components/create-group/flexible-form.tsx
+++ b/frontend/components/create-group/flexible-form.tsx
@@ -188,15 +188,21 @@ export function FlexibleForm() {
       <FormProgress fields={progressFields} />
 
       <div className="space-y-1">
-        <FieldTooltip
-          htmlFor="name"
-          label="Group Name"
-          tooltip="A name for your flexible savings pool — e.g. 'Emergency Fund'. Visible to all members."
-          required
-        />
+        <div className="flex items-center justify-between">
+          <FieldTooltip
+            htmlFor="name"
+            label="Group Name"
+            tooltip="A name for your flexible savings pool — e.g. 'Emergency Fund'. Visible to all members."
+            required
+          />
+          <span className={`text-xs tabular-nums ${formData.name.length > 45 ? "text-destructive" : "text-muted-foreground"}`}>
+            {formData.name.length}/50
+          </span>
+        </div>
         <Input
           id="name"
           placeholder="e.g., Emergency Fund"
+          maxLength={50}
           value={formData.name}
           onChange={(e) => {
             setFormData({ ...formData, name: e.target.value })
@@ -208,14 +214,20 @@ export function FlexibleForm() {
       </div>
 
       <div className="space-y-1">
-        <FieldTooltip
-          htmlFor="description"
-          label="Description"
-          tooltip="Optional notes about this pool's purpose, deposit rules, or any agreements between members."
-        />
+        <div className="flex items-center justify-between">
+          <FieldTooltip
+            htmlFor="description"
+            label="Description"
+            tooltip="Optional notes about this pool's purpose, deposit rules, or any agreements between members."
+          />
+          <span className={`text-xs tabular-nums ${formData.description.length > 270 ? "text-destructive" : "text-muted-foreground"}`}>
+            {formData.description.length}/300
+          </span>
+        </div>
         <Textarea
           id="description"
           placeholder="Describe the purpose of this flexible pool"
+          maxLength={300}
           value={formData.description}
           onChange={(e) => setFormData({ ...formData, description: e.target.value })}
           rows={3}

--- a/frontend/components/create-group/rotational-form.tsx
+++ b/frontend/components/create-group/rotational-form.tsx
@@ -226,15 +226,21 @@ export function RotationalForm({ prefill }: { prefill?: DuplicatePrefill }) {
       <FormProgress fields={progressFields} />
 
       <div className="space-y-1">
-        <FieldTooltip
-          htmlFor="name"
-          label="Group Name"
-          tooltip="A short, memorable name for your savings circle — e.g. 'Family Trip Fund'. Visible to all members."
-          required
-        />
+        <div className="flex items-center justify-between">
+          <FieldTooltip
+            htmlFor="name"
+            label="Group Name"
+            tooltip="A short, memorable name for your savings circle — e.g. 'Family Trip Fund'. Visible to all members."
+            required
+          />
+          <span className={`text-xs tabular-nums ${formData.name.length > 45 ? "text-destructive" : "text-muted-foreground"}`}>
+            {formData.name.length}/50
+          </span>
+        </div>
         <Input
           id="name"
           placeholder="e.g., Family Savings Circle"
+          maxLength={50}
           value={formData.name}
           onChange={(e) => {
             setFormData({ ...formData, name: e.target.value })
@@ -247,14 +253,20 @@ export function RotationalForm({ prefill }: { prefill?: DuplicatePrefill }) {
       </div>
 
       <div className="space-y-1">
-        <FieldTooltip
-          htmlFor="description"
-          label="Description"
-          tooltip="Optional details about the group's purpose, rules, or goals. Helps members understand what they're joining."
-        />
+        <div className="flex items-center justify-between">
+          <FieldTooltip
+            htmlFor="description"
+            label="Description"
+            tooltip="Optional details about the group's purpose, rules, or goals. Helps members understand what they're joining."
+          />
+          <span className={`text-xs tabular-nums ${formData.description.length > 270 ? "text-destructive" : "text-muted-foreground"}`}>
+            {formData.description.length}/300
+          </span>
+        </div>
         <Textarea
           id="description"
           placeholder="Describe the purpose of this savings group"
+          maxLength={300}
           value={formData.description}
           onChange={(e) => setFormData({ ...formData, description: e.target.value })}
           rows={3}

--- a/frontend/components/create-group/target-form.tsx
+++ b/frontend/components/create-group/target-form.tsx
@@ -195,15 +195,21 @@ export function TargetForm() {
       <FormProgress fields={progressFields} />
 
       <div className="space-y-1">
-        <FieldTooltip
-          htmlFor="name"
-          label="Group Name"
-          tooltip="A descriptive name for your savings goal — e.g. 'Wedding Fund'. Visible to all members."
-          required
-        />
+        <div className="flex items-center justify-between">
+          <FieldTooltip
+            htmlFor="name"
+            label="Group Name"
+            tooltip="A descriptive name for your savings goal — e.g. 'Wedding Fund'. Visible to all members."
+            required
+          />
+          <span className={`text-xs tabular-nums ${formData.name.length > 45 ? "text-destructive" : "text-muted-foreground"}`}>
+            {formData.name.length}/50
+          </span>
+        </div>
         <Input
           id="name"
           placeholder="e.g., Wedding Fund"
+          maxLength={50}
           value={formData.name}
           onChange={(e) => {
             setFormData({ ...formData, name: e.target.value })
@@ -215,14 +221,20 @@ export function TargetForm() {
       </div>
 
       <div className="space-y-1">
-        <FieldTooltip
-          htmlFor="description"
-          label="Description"
-          tooltip="Optional context about the savings goal — what you're saving for, any rules, or milestones to reach."
-        />
+        <div className="flex items-center justify-between">
+          <FieldTooltip
+            htmlFor="description"
+            label="Description"
+            tooltip="Optional context about the savings goal — what you're saving for, any rules, or milestones to reach."
+          />
+          <span className={`text-xs tabular-nums ${formData.description.length > 270 ? "text-destructive" : "text-muted-foreground"}`}>
+            {formData.description.length}/300
+          </span>
+        </div>
         <Textarea
           id="description"
           placeholder="Describe the savings goal"
+          maxLength={300}
           value={formData.description}
           onChange={(e) => setFormData({ ...formData, description: e.target.value })}
           rows={3}


### PR DESCRIPTION
## Constraint investigation

**Pool name**: `validateGroupName` in `lib/form-validation.ts` already enforces a 3–50 character limit. The Supabase `pools` table uses unbounded `TEXT` for the name column — no DB-level constraint. No on-chain constraint either (names are stored in Supabase only, not in contract storage).

**Description**: No limit existed anywhere — not in validation, not in the DB schema, not on-chain.

## What changed

All three creation forms (`rotational-form.tsx`, `target-form.tsx`, `flexible-form.tsx`) received the same treatment:

- **Name field**: Added a `{count}/50` counter in the label row (right-aligned). Counter turns red past 45 characters. Added `maxLength={50}` to hard-stop input at the existing validation limit.
- **Description field**: Introduced a 300-character limit via `maxLength={300}` on the textarea. Added a `{count}/300` counter in the label row that turns red past 270 characters.

300 characters for description is enough for a meaningful explanation of a pool's purpose while preventing runaway text that would break pool cards and dropdowns elsewhere in the app.

## Existing pools

Unaffected — `maxLength` only applies at input time. No DB migration needed since the `TEXT` column accepts any length and existing rows are not touched.

Closes #112