### PR TITLE
fix: standardize copy-address feedback with icon swap and toast everywhere

### DIFF
--- a/frontend/components/dashboard/dashboard-header.tsx
+++ b/frontend/components/dashboard/dashboard-header.tsx
@@ -48,6 +48,7 @@ export function DashboardHeader() {
     if (!address) return
     await navigator.clipboard.writeText(address)
     setCopied(true)
+    toast({ title: "Address copied", description: "Wallet address copied to clipboard." })
     setTimeout(() => setCopied(false), 2500)
   }
 

--- a/frontend/components/group/group-members.tsx
+++ b/frontend/components/group/group-members.tsx
@@ -4,17 +4,21 @@ import { Card } from "@/components/ui/card";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
 import {
   CheckCircle2,
   Clock,
   XCircle,
   AlertCircle,
   Award,
+  Copy,
+  Check,
 } from "lucide-react";
 import { useState, useEffect } from "react";
 import { usePoolData } from "@/lib/data-layer/PoolDataProvider";
 import { useOptimisticTransactions } from "@/hooks/useOptimisticTransactions";
 import { RotationalPoolState, fetchReputation, type ReputationScore } from "@/hooks/useJointSaveContracts";
+import { useToast } from "@/hooks/use-toast";
 
 interface Member {
   id: string;
@@ -44,11 +48,24 @@ export function GroupMembers({
 
   const { data, isLoading } = usePoolData(cacheKey);
   const { optimisticState } = useOptimisticTransactions(cacheKey);
+  const { toast } = useToast();
 
   const members: Member[] = data?.db?.pool_members ?? [];
   const onchainState = data?.onchain;
 
   const [reputations, setReputations] = useState<Record<string, ReputationScore>>({});
+  const [copiedAddress, setCopiedAddress] = useState<string | null>(null);
+
+  const handleCopyMemberAddress = async (address: string) => {
+    try {
+      await navigator.clipboard.writeText(address);
+      setCopiedAddress(address);
+      toast({ title: "Address copied", description: "Member address copied to clipboard." });
+      setTimeout(() => setCopiedAddress(null), 2500);
+    } catch {
+      toast({ title: "Failed to copy", description: "Please copy the address manually.", variant: "destructive" });
+    }
+  };
 
   useEffect(() => {
     if (members.length === 0) return;
@@ -138,9 +155,24 @@ export function GroupMembers({
                     </AvatarFallback>
                   </Avatar>
                   <div>
-                    <p className="font-medium text-sm font-mono">
-                      {formatAddress(member.member_address)}
-                    </p>
+                    <div className="flex items-center gap-1.5">
+                      <p className="font-medium text-sm font-mono">
+                        {formatAddress(member.member_address)}
+                      </p>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-5 w-5 shrink-0"
+                        onClick={() => handleCopyMemberAddress(member.member_address)}
+                        aria-label="Copy member address"
+                      >
+                        {copiedAddress === member.member_address ? (
+                          <Check className="h-3 w-3 text-green-500" />
+                        ) : (
+                          <Copy className="h-3 w-3 text-muted-foreground" />
+                        )}
+                      </Button>
+                    </div>
                     <p className="text-xs text-muted-foreground">
                       {member.contribution_amount.toFixed(2)} XLM
                     </p>

--- a/frontend/components/landing/header.tsx
+++ b/frontend/components/landing/header.tsx
@@ -41,6 +41,7 @@ export function Header() {
     if (!address) return
     await navigator.clipboard.writeText(address)
     setCopied(true)
+    toast({ title: "Address copied", description: "Wallet address copied to clipboard." })
     setTimeout(() => setCopied(false), 2500)
   }
 


### PR DESCRIPTION
closes #111

## Summary

- **dashboard-header.tsx** - `handleCopyAddress` now fires a `useToast` notification ("Address copied") in addition to the existing icon swap. Previously it only swapped the icon with no toast.
- **group-members.tsx** - Added full copy-to-clipboard support for each member address. Each row now has a copy button that swaps to a checkmark icon and fires a toast ("Address copied"). Previously there was no copy functionality for member addresses.
- **landing/header.tsx** - Same fix as dashboard-header: `handleCopyAddress` now fires a toast in addition to the icon swap.
- **group-details.tsx** - Already had both icon swap and toast; no changes needed.

## Audit: all copy-to-clipboard locations found

| File | Location | Before | After |
|---|---|---|---|
| `frontend/components/dashboard/dashboard-header.tsx` | Wallet address in header dropdown | Icon swap only, no toast | Icon swap + toast |
| `frontend/components/group/group-details.tsx` | Contract address on group detail page | Icon swap + toast (already correct) | No change needed |
| `frontend/components/group/group-members.tsx` | Member addresses in member list | No copy button at all | Copy button with icon swap + toast |
| `frontend/components/landing/header.tsx` | Wallet address in landing page header dropdown | Icon swap only, no toast | Icon swap + toast |

## Approach

Used the existing `useToast` hook (`@/hooks/use-toast`) in all locations - no new patterns introduced. The toast title is "Address copied" with a contextual description. The checkmark icon reverts after 2500 ms, matching the existing timing.