### PR TITLE
Add "View all notifications" page and link for notifications beyond the first 10

### DIFF
--- a/frontend/app/api/notifications/route.ts
+++ b/frontend/app/api/notifications/route.ts
@@ -2,10 +2,34 @@ import { getAdminClient } from '@/lib/supabase-admin'
 import { NextRequest, NextResponse } from 'next/server'
 
 // GET /api/notifications?wallet=<address>
+// GET /api/notifications?wallet=<address>&page=<n>  — paginated full history
 export async function GET(req: NextRequest) {
   const wallet = req.nextUrl.searchParams.get('wallet')?.toLowerCase()
   if (!wallet) return NextResponse.json({ error: 'wallet required' }, { status: 400 })
 
+  const pageParam = req.nextUrl.searchParams.get('page')
+
+  // Paginated mode (used by /dashboard/notifications): returns
+  // { data, total, page, pageSize } so the page can render the same
+  // Pagination UI used by My Groups.
+  if (pageParam !== null) {
+    const PAGE_SIZE = 10
+    const page = Math.max(0, parseInt(pageParam || '0', 10))
+    const from = page * PAGE_SIZE
+    const to = from + PAGE_SIZE - 1
+
+    const { data, error, count } = await getAdminClient()
+      .from('notifications')
+      .select('id, pool_id, activity_type, message, read, created_at', { count: 'exact' })
+      .eq('wallet_address', wallet)
+      .order('created_at', { ascending: false })
+      .range(from, to)
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+    return NextResponse.json({ data: data ?? [], total: count ?? 0, page, pageSize: PAGE_SIZE })
+  }
+
+  // Default mode (used by the notification bell dropdown): most recent 10.
   const { data, error } = await getAdminClient()
     .from('notifications')
     .select('id, pool_id, activity_type, message, read, created_at')

--- a/frontend/app/dashboard/notifications/page.tsx
+++ b/frontend/app/dashboard/notifications/page.tsx
@@ -1,0 +1,184 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import Link from "next/link"
+import { useRouter, useSearchParams } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { Card } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination"
+import { DashboardHeader } from "@/components/dashboard/dashboard-header"
+import { useStellar } from "@/components/web3-provider"
+import { ArrowLeft, Bell } from "lucide-react"
+import { formatRelativeTime } from "@/lib/utils"
+import type { AppNotification } from "@/hooks/useNotifications"
+
+const PAGE_SIZE = 10
+
+export default function NotificationsPage() {
+  const { address, isInitializing } = useStellar()
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const [notifications, setNotifications] = useState<AppNotification[]>([])
+  const [total, setTotal] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState("")
+
+  const page = Math.max(0, parseInt(searchParams.get("page") || "0", 10))
+  const totalPages = Math.ceil(total / PAGE_SIZE)
+
+  const setPage = useCallback(
+    (p: number) => {
+      const params = new URLSearchParams(searchParams.toString())
+      params.set("page", String(p))
+      router.push(`?${params.toString()}`, { scroll: false })
+    },
+    [router, searchParams]
+  )
+
+  const loadNotifications = useCallback(async (currentPage: number) => {
+    if (!address) {
+      setLoading(false)
+      return
+    }
+    try {
+      setLoading(true)
+      setError("")
+      const res = await fetch(
+        `/api/notifications?wallet=${encodeURIComponent(address.toLowerCase())}&page=${currentPage}`
+      )
+      if (!res.ok) throw new Error("Failed to fetch notifications")
+      const json = await res.json()
+      setNotifications(json.data ?? [])
+      setTotal(json.total ?? 0)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch notifications")
+      setNotifications([])
+    } finally {
+      setLoading(false)
+    }
+  }, [address])
+
+  useEffect(() => {
+    loadNotifications(page)
+  }, [page, loadNotifications])
+
+  return (
+    <div className="min-h-screen bg-background">
+      <DashboardHeader />
+      <main className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 max-w-3xl">
+        <Button variant="ghost" className="mb-6" asChild>
+          <Link href="/dashboard">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to Dashboard
+          </Link>
+        </Button>
+
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold">Notifications</h1>
+          <p className="text-muted-foreground mt-1">
+            {isInitializing || loading
+              ? "Loading your notifications…"
+              : total === 0
+              ? "You're all caught up"
+              : `${total} notification${total !== 1 ? "s" : ""}`}
+          </p>
+        </div>
+
+        {!address && !isInitializing ? (
+          <Card className="p-6 text-center text-muted-foreground">
+            Connect your wallet to view notifications.
+          </Card>
+        ) : error ? (
+          <Card className="p-6 bg-destructive/10 text-destructive">
+            <p>{error}</p>
+          </Card>
+        ) : loading ? (
+          <div className="space-y-3">
+            {[0, 1, 2, 3, 4].map((i) => (
+              <Card key={i} className="p-4">
+                <Skeleton className="h-4 w-3/4 mb-2" />
+                <Skeleton className="h-3 w-24" />
+              </Card>
+            ))}
+          </div>
+        ) : notifications.length === 0 ? (
+          <Card className="flex flex-col items-center gap-3 p-10 text-center">
+            <Bell className="h-8 w-8 text-muted-foreground" />
+            <p className="text-muted-foreground">No notifications yet</p>
+          </Card>
+        ) : (
+          <>
+            <div className="space-y-2">
+              {notifications.map((n) => {
+                const content = (
+                  <>
+                    <span className={`block text-sm leading-snug ${!n.read ? "font-medium" : "text-muted-foreground"}`}>
+                      {n.message}
+                    </span>
+                    <span className="text-[11px] text-muted-foreground">
+                      {formatRelativeTime(new Date(n.created_at))}
+                    </span>
+                  </>
+                )
+                return (
+                  <Card key={n.id} className="p-4 transition-colors hover:bg-muted/50">
+                    {n.pool_id ? (
+                      <Link href={`/dashboard/group/${n.pool_id}`} className="block">
+                        {content}
+                      </Link>
+                    ) : (
+                      <div>{content}</div>
+                    )}
+                  </Card>
+                )
+              })}
+            </div>
+
+            {totalPages > 1 && (
+              <div className="flex flex-col items-center gap-3 mt-6">
+                <p className="text-sm text-muted-foreground">
+                  Showing {page * PAGE_SIZE + 1}–
+                  {Math.min((page + 1) * PAGE_SIZE, total)} of {total} notifications
+                </p>
+                <Pagination>
+                  <PaginationContent>
+                    <PaginationItem>
+                      <PaginationPrevious
+                        onClick={() => setPage(page - 1)}
+                        aria-disabled={page === 0}
+                        className={
+                          page === 0
+                            ? "pointer-events-none opacity-50"
+                            : "cursor-pointer"
+                        }
+                      />
+                    </PaginationItem>
+                    <PaginationItem>
+                      <PaginationNext
+                        onClick={() => setPage(page + 1)}
+                        aria-disabled={page >= totalPages - 1}
+                        className={
+                          page >= totalPages - 1
+                            ? "pointer-events-none opacity-50"
+                            : "cursor-pointer"
+                        }
+                      />
+                    </PaginationItem>
+                  </PaginationContent>
+                </Pagination>
+              </div>
+            )}
+          </>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/frontend/components/dashboard/dashboard-header.tsx
+++ b/frontend/components/dashboard/dashboard-header.tsx
@@ -133,6 +133,14 @@ export function DashboardHeader() {
                       </DropdownMenuItem>
                     ))
                   )}
+                  {!initialLoading && notifications.length > 0 && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem asChild className="justify-center text-sm font-medium text-primary cursor-pointer">
+                        <Link href="/dashboard/notifications">View all notifications</Link>
+                      </DropdownMenuItem>
+                    </>
+                  )}
                 </DropdownMenuContent>
               </DropdownMenu>
             )}


### PR DESCRIPTION
## Summary
Closes #110

`useNotifications` (and the `/api/notifications` route it calls) hardcoded a 10-row limit, so older notifications became permanently inaccessible from the UI once a user accumulated more than 10. This adds a way to view the full history.

## Changes
- **`frontend/app/api/notifications/route.ts`** — `GET` now supports an optional `?page=<n>` query param. When present, it returns paginated results (`{ data, total, page, pageSize }`) using the same `count: 'exact'` + `.range()` pattern already used by `/api/pools` for My Groups. When absent, behavior is unchanged — still returns the most recent 10 for the dropdown.
- **`frontend/app/dashboard/notifications/page.tsx`** (new) — full notification history page for the connected wallet, using the same pagination UI/pattern as My Groups (`Pagination` component, `?page=` URL param).
- **`frontend/components/dashboard/dashboard-header.tsx`** — adds a "View all notifications" link at the bottom of the dropdown, shown whenever there's at least one notification.

## Scope
Per the issue, this is scoped to just the page + link. Filtering/search on the notifications page is left as a follow-up.

## Testing
- Verified the dropdown's existing behavior (10-item cap, mark-all-read, realtime subscription) is unchanged — diff is purely additive.
- Verified wallet scoping: both the paginated and default API paths filter with `.eq('wallet_address', wallet)`, and the page only ever requests the connected wallet's address.
- Verified pagination walks past the first 10 rows using `.range()` with a real `count: 'exact'` total, not capped client-side.