### PR TITLE
Feat/my groups search

### DIFF
--- a/frontend/components/dashboard/my-groups.tsx
+++ b/frontend/components/dashboard/my-groups.tsx
@@ -97,6 +97,15 @@ export function MyGroups({ onCreateClick }: MyGroupsProps) {
     }
   }
 
+  // Client-side filtering by pool name
+  // Note: This filters only the currently loaded page (6 pools max).
+  // For a full cross-page search, we would need backend API support.
+  const filteredPools = searchTerm
+    ? pools.filter((pool) =>
+        pool.name.toLowerCase().includes(searchTerm.toLowerCase())
+      )
+    : pools
+
   if (loading) {
     return (
       <div className="space-y-6">
@@ -171,7 +180,7 @@ export function MyGroups({ onCreateClick }: MyGroupsProps) {
             animate="show"
             className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
           >
-            {pools.map((pool) => (
+            {filteredPools.map((pool) => (
               <PoolCard key={pool.id} pool={pool} />
             ))}
           </motion.div>

--- a/frontend/components/dashboard/my-groups.tsx
+++ b/frontend/components/dashboard/my-groups.tsx
@@ -170,6 +170,23 @@ export function MyGroups({ onCreateClick }: MyGroupsProps) {
 
       {pools.length === 0 ? (
         <EmptyState onCreateClick={onCreateClick} />
+      ) : filteredPools.length === 0 ? (
+        <Card className="p-12 flex flex-col items-center text-center gap-3">
+          <div className="rounded-full bg-muted p-3">
+            <Search className="h-6 w-6 text-muted-foreground" />
+          </div>
+          <p className="font-medium">No pools match your search</p>
+          <p className="text-sm text-muted-foreground max-w-sm">
+            Try adjusting your search term or{" "}
+            <button
+              onClick={() => setSearchTerm("")}
+              className="text-primary hover:underline"
+            >
+              clear the search
+            </button>
+            .
+          </p>
+        </Card>
       ) : (
         <>
           <FirstPoolTooltip poolCount={pools.length} />

--- a/frontend/components/dashboard/my-groups.tsx
+++ b/frontend/components/dashboard/my-groups.tsx
@@ -2,6 +2,7 @@
 
 import { Card } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
+import { Input } from "@/components/ui/input"
 import {
   Pagination,
   PaginationContent,
@@ -9,6 +10,7 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from "@/components/ui/pagination"
+import { Search } from "lucide-react"
 import { motion } from "framer-motion"
 import { useState, useEffect, useCallback } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
@@ -40,12 +42,28 @@ export function MyGroups({ onCreateClick }: MyGroupsProps) {
   const [error, setError] = useState("")
 
   const page = Math.max(0, parseInt(searchParams.get("page") || "0", 10))
+  const searchTerm = searchParams.get("search") || ""
   const totalPages = Math.ceil(total / PAGE_SIZE)
 
   const setPage = useCallback(
     (p: number) => {
       const params = new URLSearchParams(searchParams.toString())
       params.set("page", String(p))
+      router.push(`?${params.toString()}`, { scroll: false })
+    },
+    [router, searchParams]
+  )
+
+  const setSearchTerm = useCallback(
+    (term: string) => {
+      const params = new URLSearchParams(searchParams.toString())
+      if (term) {
+        params.set("search", term)
+      } else {
+        params.delete("search")
+      }
+      // Reset to first page when searching
+      params.set("page", "0")
       router.push(`?${params.toString()}`, { scroll: false })
     },
     [router, searchParams]
@@ -128,6 +146,18 @@ export function MyGroups({ onCreateClick }: MyGroupsProps) {
           </p>
         </div>
       </motion.div>
+
+      {/* Search input */}
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Input
+          type="text"
+          placeholder="Search pools by name..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          className="pl-9"
+        />
+      </div>
 
       {pools.length === 0 ? (
         <EmptyState onCreateClick={onCreateClick} />


### PR DESCRIPTION

## Summary

I've successfully implemented search functionality for the My Groups tab with all requirements met. Here's what was delivered:

### ✅ **All Acceptance Criteria Met:**

1. **Typing in the search box filters the visible pools by name** ✓
   - Case-insensitive search that matches pool names
   - Real-time filtering as you type

2. **Search term persists in the URL and survives a refresh** ✓
   - Uses `search` URL parameter
   - Consistent with existing pagination pattern (`page` parameter)
   - Automatically resets to page 0 when searching

3. **Empty state shown when no pools match** ✓
   - Friendly message with Search icon
   - Includes a "clear the search" button
   - Visually consistent with other empty states

4. **Doesn't break existing pagination behavior** ✓
   - Pagination continues to work independently
   - Search and pagination parameters coexist in URL

### 📝 **Implementation Details:**

**Client-side filtering approach chosen because:**
- Pagination caps page size at 6 pools maximum
- Backend API doesn't support search parameters
- Client-side filtering is faster for small datasets
- Simpler implementation without backend changes
- **Trade-off documented:** Search only filters currently loaded page, not across all pages

### 🎯 **Three Commits Delivered:**

1. **`feat: add search input UI with URL sync in My Groups tab`**
   - Added search input with icon
   - URL synchronization logic
   - Resets to page 0 on search

2. **`feat: implement client-side filtering of pools by name`**
   - Filter logic with detailed reasoning in commit message
   - Case-insensitive matching
   - Only filters current page (documented limitation)

3. **`feat: add empty state for no search results`**
   - Friendly "no results" message
   - Clear search button
   - Visual consistency maintained

The implementation is production-ready with no TypeScript errors and follows the existing code patterns in the project.

Closes #125 
