### PR TITLE
fix: scroll to top on dashboard tab switch and route navigation

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -21,6 +21,11 @@ export default function DashboardPage() {
     onGoToProfile: () => setActiveTab("profile"),
     onOpenHelp: () => setShowHelp(true),
   })
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, left: 0, behavior: "instant" })
+  }, [activeTab])
+
   useEffect(() => {
     if (!isInitializing && !isConnected) {
       redirect("/")

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -11,6 +11,7 @@ import "@/lib/env"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Suspense } from "react"
 import { TxQueueBadge } from "@/components/tx-queue-badge"
+import { ScrollToTop } from "@/components/ui/scroll-to-top"
 
 export const metadata: Metadata = {
   title: "JointSave — Decentralized Community Savings on Stellar",
@@ -45,6 +46,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body className={`font-sans ${GeistSans.variable} ${GeistMono.variable}`}>
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
+          <ScrollToTop />
           <Suspense fallback={null}>
             <Web3Provider>
               <PoolDataProvider>{children}</PoolDataProvider>

--- a/frontend/components/ui/scroll-to-top.tsx
+++ b/frontend/components/ui/scroll-to-top.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import { usePathname } from "next/navigation"
+
+/**
+ * Scrolls to the top of the page on every client-side route change.
+ *
+ * Skips scroll reset for popstate (browser back/forward) events so that the
+ * browser's native scroll restoration can do its job for those navigations.
+ */
+export function ScrollToTop() {
+  const pathname = usePathname()
+  const isPopStateRef = useRef(false)
+
+  useEffect(() => {
+    const handlePopState = () => {
+      isPopStateRef.current = true
+    }
+    window.addEventListener("popstate", handlePopState)
+    return () => window.removeEventListener("popstate", handlePopState)
+  }, [])
+
+  useEffect(() => {
+    if (isPopStateRef.current) {
+      isPopStateRef.current = false
+      return
+    }
+    window.scrollTo({ top: 0, left: 0, behavior: "instant" })
+  }, [pathname])
+
+  return null
+}


### PR DESCRIPTION
closes #130

## Observed behavior (before fix)

**Dashboard tab switching:** Switching between tabs on `/dashboard` (My Groups, Explore, Create, Transactions, Analytics, Profile) does not reset the window scroll position. If a user is scrolled 800px into the My Groups list and clicks the Analytics tab, the new tab renders at that same 800px offset rather than the top of the page.

**Route changes (My Groups ? group detail, group detail ? back):** Next.js App Router scrolls to the top of the page by default for forward `<Link>` navigations, so this path generally worked correctly. However, this relied entirely on the framework's internal behavior with no explicit guarantee from application code. The `ScrollToTop` component below makes this explicit and handles any edge cases (e.g., programmatic `router.push()` calls).

**Browser back button:** Already worked correctly via App Router's built-in scroll restoration. This behavior is preserved - see the popstate guard below.

## What was changed

### 1. `frontend/components/ui/scroll-to-top.tsx` (new file)

A `ScrollToTop` component mounted in the root layout. It watches `usePathname()` and calls `window.scrollTo({ top: 0, behavior: "instant" })` on each pathname change. A `popstate` event listener guards against overriding the browser's native scroll restoration when the user presses Back or Forward.

### 2. `frontend/app/layout.tsx`

Added `<ScrollToTop />` inside `ThemeProvider` so it is active on every page in the app.

### 3. `frontend/app/dashboard/page.tsx`

Added a `useEffect` on `activeTab` that calls `window.scrollTo({ top: 0, left: 0, behavior: "instant" })` whenever the active tab changes. Because tab switching is pure client-side state with no URL change, Next.js's scroll machinery never fires for it - this effect fills that gap.

## Why `behavior: "instant"`

Using `"smooth"` for a tab/page switch feels wrong - the user initiated a navigation, not a scroll gesture. Instant snaps to the top the same way a real page load would.

## Acceptance criteria

- Switching dashboard tabs (My Groups ? Analytics, Transactions, etc.) now always starts at the top of the new tab's content.
- Navigating from My Groups into a group detail page and back starts each page at the top.
- Pressing the browser Back button after navigating to a group detail page still restores the previous scroll position in My Groups (no regression).