### PR TITLE
feat: sync filters with URL and add loading fallback for explore page

### DIFF
--- a/frontend/app/explore/page.tsx
+++ b/frontend/app/explore/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { useState, useEffect, useMemo, useCallback } from "react"
+import { useState, useEffect, useMemo, useCallback, Suspense } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
 import { Card } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -181,18 +182,41 @@ function PoolCard({
 
 // ── Explore Page ──────────────────────────────────────────────────────────────
 
-export default function ExplorePage() {
+function ExploreContent() {
   const { address } = useStellar()
   const { toast } = useToast()
+  const router = useRouter()
+  const searchParams = useSearchParams()
 
   const [pools, setPools] = useState<Pool[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState("")
   const [joining, setJoining] = useState<string | null>(null)
 
-  const [search, setSearch] = useState("")
-  const [filterType, setFilterType] = useState("")
-  const [filterStatus, setFilterStatus] = useState("")
+  // Filter state is derived from the URL so it survives refresh and can be shared.
+  const search = searchParams.get("search") || ""
+  const filterType = searchParams.get("type") || ""
+  const filterStatus = searchParams.get("status") || ""
+
+  // Sync a single filter to the URL query string. router.replace (not push)
+  // keeps the back button from stepping through every individual filter toggle.
+  const updateParam = useCallback(
+    (key: string, value: string) => {
+      const params = new URLSearchParams(searchParams.toString())
+      if (value) {
+        params.set(key, value)
+      } else {
+        params.delete(key)
+      }
+      const qs = params.toString()
+      router.replace(qs ? `?${qs}` : "?", { scroll: false })
+    },
+    [router, searchParams]
+  )
+
+  const setSearch = useCallback((v: string) => updateParam("search", v), [updateParam])
+  const setFilterType = useCallback((v: string) => updateParam("type", v), [updateParam])
+  const setFilterStatus = useCallback((v: string) => updateParam("status", v), [updateParam])
 
   // Fetch pools from DB + factory
   useEffect(() => {
@@ -384,5 +408,29 @@ export default function ExplorePage() {
         )}
       </div>
     </div>
+  )
+}
+
+// Loading fallback shown while useSearchParams resolves on the client.
+function ExploreFallback() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <PoolCardSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// useSearchParams requires a Suspense boundary at the page level.
+export default function ExplorePage() {
+  return (
+    <Suspense fallback={<ExploreFallback />}>
+      <ExploreContent />
+    </Suspense>
   )
 }


### PR DESCRIPTION
Closes #124 

# Sync Explore page filters to the URL

## Summary

The Explore page (`frontend/app/explore/page.tsx`) previously held its filter
state (pool **type**, **status**, and **name search**) in local React state. As a
result, applying any filter was invisible to the URL — so the view was lost on
refresh and could not be shared via a link.

This PR brings the Explore page up to the same standard already used by
`my-groups.tsx` (which syncs its pagination/search to the URL): the active
filters are now stored in the URL query string, read back on load, and updated
with `router.replace`.


All changes are in `frontend/app/explore/page.tsx`:

- **Filter state derived from the URL.** `search`, `filterType`, and
  `filterStatus` are now read from `useSearchParams()` (query keys `search`,
  `type`, `status`) instead of `useState`. A refreshed or shared link reproduces
  the exact same filtered view.
- **`updateParam` helper** writes a single filter to the query string via
  `router.replace(..., { scroll: false })`. Empty values are removed from the URL
  (e.g. switching back to "All Types" cleans up the param rather than leaving
  `type=`).
- **`router.replace` instead of `router.push`** so the browser back button does
  not have to step through every individual filter toggle.
- **`setSearch` / `setFilterType` / `setFilterStatus`** are thin wrappers over
  `updateParam`, preserving the existing JSX call sites unchanged.
- **Suspense boundary.** The page is split into an inner `ExploreContent` and a
  default `ExplorePage` that wraps it in `<Suspense>` with a `ExploreFallback`
  skeleton. Next.js requires a Suspense boundary when `useSearchParams` is used
  at the page level.

No new dependencies were added — only Next.js/React built-ins
(`next/navigation`, `Suspense`).

## How it follows the existing pattern

Mirrors `frontend/components/dashboard/my-groups.tsx`:

| my-groups.tsx                                    | explore/page.tsx (this PR)                          |
| ------------------------------------------------ | --------------------------------------------------- |
| `useRouter` + `useSearchParams`                  | same                                                |
| `searchParams.get("page")` / `get("search")`     | `get("search")`, `get("type")`, `get("status")`     |
| build `URLSearchParams`, `set`/`delete`, navigate | same via `updateParam` helper                       |
| `{ scroll: false }`                              | same                                                |

The one intentional difference: my-groups uses `router.push`, while this page
uses `router.replace` (per the requirement) so filter toggles don't pollute
browser history.

## Acceptance criteria

- [x] Applying a filter updates the URL without a full page reload
- [x] Refreshing the page with filters in the URL restores the same filtered view
- [x] Sharing a filtered URL reproduces the same view for someone else
- [x] Browser back/forward behaves sensibly (no clicking through every filter change)

## Testing

- `npx tsc --noEmit` — no errors introduced by these changes in
  `frontend/app/explore/page.tsx`.
- Manual: applying type/status/search filters updates the query string live;
  reloading the URL restores the filters; clearing a filter removes its param.

> Note: pre-existing TypeScript errors in
> `frontend/components/group/group-actions.tsx` are unrelated to this PR and that
> file is untouched.
