### PR TITLE
feat: add sitemap and robots for seo discoverability

### DIFF
--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -1,0 +1,14 @@
+import { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://jointsave.org';
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: ['/', '/explore'],
+      disallow: ['/dashboard/'],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -1,0 +1,20 @@
+import { MetadataRoute } from 'next';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://jointsave.org';
+
+  return [
+    {
+      url: `${baseUrl}`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/explore`,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 0.8,
+    },
+  ];
+}


### PR DESCRIPTION
What was done

Implemented frontend/app/sitemap.ts to generate an automated XML sitemap covering the landing page (/) and the Explore page (/explore).
Implemented frontend/app/robots.ts to generate robots.txt, explicitly allowing public indexation while disallowing the authenticated dashboard routes (/dashboard/).
Why it was done

To resolve search engines having no guidance on what to index. This update improves organic discoverability for the public-facing pages to foster project growth, while keeping user dashboards private.
How it was verified

Verified locally via Next.js standard MetadataRoute configuration, ensuring sitemap.xml and robots.txt render correctly from the app directory without causing build regressions.
closes #128 