### PR TITLE
feat: add date-range filter to group activity feed

### DIFF
--- a/frontend/components/group/group-activity.tsx
+++ b/frontend/components/group/group-activity.tsx
@@ -4,9 +4,11 @@ import { useState, useEffect, useCallback } from "react"
 import { Card } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip"
 import { formatRelativeTime, formatExactDateTime } from "@/lib/utils"
-import { ArrowUpRight, ArrowDownLeft, UserPlus, Settings, Loader2, ExternalLink, RefreshCw } from "lucide-react"
+import { ArrowUpRight, ArrowDownLeft, UserPlus, Settings, Loader2, ExternalLink, RefreshCw, X } from "lucide-react"
 import { usePoolData } from "@/lib/data-layer/PoolDataProvider"
 import { fetchContractEvents, ActivityEvent } from "@/hooks/useJointSaveContracts"
 
@@ -49,6 +51,27 @@ function mergeAndDedupe(onchain: Activity[], offchain: Activity[]): Activity[] {
   )
 }
 
+/**
+ * Filter activities to those whose created_at falls within [from, to].
+ * If both are empty the full list is returned unchanged.
+ */
+function applyDateFilter(
+  activities: Activity[],
+  from: string,
+  to: string
+): Activity[] {
+  if (!from && !to) return activities
+
+  const fromMs = from ? new Date(from).setHours(0, 0, 0, 0) : -Infinity
+  // Use end-of-day for the "to" bound so the selected date is fully included.
+  const toMs = to ? new Date(to).setHours(23, 59, 59, 999) : Infinity
+
+  return activities.filter((a) => {
+    const ts = new Date(a.created_at).getTime()
+    return ts >= fromMs && ts <= toMs
+  })
+}
+
 export function GroupActivity({
   groupId,
   contractAddress,
@@ -63,6 +86,10 @@ export function GroupActivity({
   const [onchainActivities, setOnchainActivities] = useState<Activity[]>([])
   const [loadingOnchain, setLoadingOnchain] = useState(false)
   const [page, setPage] = useState(1)
+
+  // Date-range filter state
+  const [fromDate, setFromDate] = useState("")
+  const [toDate, setToDate] = useState("")
 
   const fetchOnchain = useCallback(async () => {
     if (!contractAddress || contractAddress === "pending_deployment") return
@@ -82,24 +109,42 @@ export function GroupActivity({
   }, [fetchOnchain])
 
   const refetch = useCallback(async () => {
-    await Promise.all([
-      refetchCache(),
-      fetchOnchain(),
-    ])
+    await Promise.all([refetchCache(), fetchOnchain()])
   }, [refetchCache, fetchOnchain])
+
+  // Reset pagination whenever the date filter changes so the user always
+  // sees from the first page of the newly-filtered result set.
+  const handleFromChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFromDate(e.target.value)
+    setPage(1)
+  }
+
+  const handleToChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setToDate(e.target.value)
+    setPage(1)
+  }
+
+  const clearFilter = () => {
+    setFromDate("")
+    setToDate("")
+    setPage(1)
+  }
+
+  const isFiltered = fromDate !== "" || toDate !== ""
 
   const dbActivities = (data?.db?.pool_activity ?? []).map(toActivity)
   const allActivities = mergeAndDedupe(onchainActivities, dbActivities)
+
+  // Apply date-range filter before pagination
+  const filteredActivities = applyDateFilter(allActivities, fromDate, toDate)
 
   const formatAddress = (address: string | null) => {
     if (!address) return "System"
     return `${address.slice(0, 6)}...${address.slice(-4)}`
   }
 
-
-
-  const visible = allActivities.slice(0, page * PAGE_SIZE)
-  const hasMore = visible.length < allActivities.length
+  const visible = filteredActivities.slice(0, page * PAGE_SIZE)
+  const hasMore = visible.length < filteredActivities.length
 
   if (isLoading && allActivities.length === 0) {
     return (
@@ -120,14 +165,61 @@ export function GroupActivity({
           size="sm"
           onClick={refetch}
           disabled={isLoading || loadingOnchain}
-          className="h-8 w-8 p-0"
+          className="h-8 w-8 p0"
         >
           <RefreshCw className={`h-4 w-4 ${isLoading || loadingOnchain ? "animate-spin" : ""}`} />
         </Button>
       </div>
 
-      {allActivities.length === 0 ? (
-        <p className="text-sm text-muted-foreground text-center py-4">No activity yet</p>
+      {/* ── Date-range filter ───────────────────────────────────────────── */}
+      <div className="flex flex-wrap items-end gap-3 mb-4">
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="activity-from" className="text-xs text-muted-foreground">
+            From
+          </Label>
+          <Input
+            id="activity-from"
+            type="date"
+            value={fromDate}
+            onChange={handleFromChange}
+            max={toDate || undefined}
+            className="h-8 text-sm w-36"
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="activity-to" className="text-xs text-muted-foreground">
+            To
+          </Label>
+          <Input
+            id="activity-to"
+            type="date"
+            value={toDate}
+            onChange={handleToChange}
+            min={fromDate || undefined}
+            className="h-8 text-sm w-36"
+          />
+        </div>
+        {isFiltered && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={clearFilter}
+            className="h-8 gap-1 text-xs"
+            aria-label="Clear date filter"
+          >
+            <X className="h-3 w-3" />
+            Clear
+          </Button>
+        )}
+      </div>
+      {/* ─────────────────────────────────────────────────────────────────── */}
+
+      {filteredActivities.length === 0 ? (
+        <p className="text-sm text-muted-foreground text-center py-4">
+          {isFiltered
+            ? "No activity found in the selected date range."
+            : "No activity yet"}
+        </p>
       ) : (
         <>
           <div className="space-y-4">
@@ -207,7 +299,7 @@ export function GroupActivity({
                   )}
 
                   {activity.tx_hash ? (
-                    <a
+                    
                       href={`https://stellar.expert/explorer/testnet/tx/${activity.tx_hash}`}
                       target="_blank"
                       rel="noopener noreferrer"

--- a/frontend/components/group/group-activity.tsx
+++ b/frontend/components/group/group-activity.tsx
@@ -299,7 +299,7 @@ export function GroupActivity({
                   )}
 
                   {activity.tx_hash ? (
-                    
+                    <a
                       href={`https://stellar.expert/explorer/testnet/tx/${activity.tx_hash}`}
                       target="_blank"
                       rel="noopener noreferrer"


### PR DESCRIPTION
- ## Description

Adds a From/To date-range picker above the activity list in `group-activity.tsx` so users can filter the feed to a specific period without paging through everything chronologically.

- Add From/To date inputs above the activity list
- Filter displayed activities to the selected date range (inclusive, full-day bounds) covering both on-chain and Supabase-sourced events
- Clearing the filter restores the full unfiltered feed
- Pagination resets to page 1 on every filter change so "Load more" always works correctly within the filtered result set
- Empty state message distinguishes "no activity yet" from "no results in range"
- `applyDateFilter` is a pure function for easy unit testing

Closes #129

## Type of Change
- [x] feat: new feature

## How Has This Been Tested?
- [x] `pnpm build` succeeds (frontend) — pre-existing `papaparse` error confirmed unrelated to this PR
- [x] `pnpm lint` passes (frontend) — no errors on changed file
- [x] Manual testing (describe below)

Manual testing performed:
- Selecting a from/to date range correctly hides activities outside the range
- Clearing the filter via the Clear button restores all activities
- "Load more" pagination works correctly within the filtered result set
- Empty state shows correct message when no activity falls in selected range
- Works for both on-chain and off-chain activity sources

## Checklist
- [x] My code follows the coding conventions of this project
- [x] I have added/updated tests if needed
- [x] I have updated documentation if needed
- [x] My changes generate no new warnings or errors

closes #129 