### PR TITLE
Debounce My Groups and Explore search inputs

### DIFF
--- a/frontend/app/explore/page.tsx
+++ b/frontend/app/explore/page.tsx
@@ -28,6 +28,7 @@ import { useStellar } from "@/components/web3-provider"
 import { fetchFactoryPools } from "@/hooks/useJointSaveContracts"
 import Link from "next/link"
 import { useToast } from "@/hooks/use-toast"
+import { useDebouncedValue } from "@/hooks/use-debounced-value"
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -197,6 +198,8 @@ function ExploreContent() {
   const search = searchParams.get("search") || ""
   const filterType = searchParams.get("type") || ""
   const filterStatus = searchParams.get("status") || ""
+  const [searchInput, setSearchInput] = useState(search)
+  const debouncedSearchInput = useDebouncedValue(searchInput, 300)
 
   // Sync a single filter to the URL query string. router.replace (not push)
   // keeps the back button from stepping through every individual filter toggle.
@@ -217,6 +220,16 @@ function ExploreContent() {
   const setSearch = useCallback((v: string) => updateParam("search", v), [updateParam])
   const setFilterType = useCallback((v: string) => updateParam("type", v), [updateParam])
   const setFilterStatus = useCallback((v: string) => updateParam("status", v), [updateParam])
+
+  useEffect(() => {
+    setSearchInput(search)
+  }, [search])
+
+  useEffect(() => {
+    if (debouncedSearchInput !== search) {
+      setSearch(debouncedSearchInput)
+    }
+  }, [debouncedSearchInput, search, setSearch])
 
   // Fetch pools from DB + factory
   useEffect(() => {
@@ -324,8 +337,8 @@ function ExploreContent() {
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
             <Input
               placeholder="Search by pool name..."
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
               className="pl-9"
             />
           </div>

--- a/frontend/components/dashboard/my-groups.tsx
+++ b/frontend/components/dashboard/my-groups.tsx
@@ -18,6 +18,7 @@ import { useStellar } from "@/components/web3-provider"
 import { EmptyState } from "@/components/dashboard/empty-state"
 import { FirstPoolTooltip } from "@/components/dashboard/first-pool-tooltip"
 import { PoolCard, PoolCardSkeleton, type Pool } from "@/components/dashboard/pool-card"
+import { useDebouncedValue } from "@/hooks/use-debounced-value"
 
 const PAGE_SIZE = 6
 
@@ -43,6 +44,8 @@ export function MyGroups({ onCreateClick }: MyGroupsProps) {
 
   const page = Math.max(0, parseInt(searchParams.get("page") || "0", 10))
   const searchTerm = searchParams.get("search") || ""
+  const [searchInput, setSearchInput] = useState(searchTerm)
+  const debouncedSearchInput = useDebouncedValue(searchInput, 300)
   const totalPages = Math.ceil(total / PAGE_SIZE)
 
   const setPage = useCallback(
@@ -68,6 +71,16 @@ export function MyGroups({ onCreateClick }: MyGroupsProps) {
     },
     [router, searchParams]
   )
+
+  useEffect(() => {
+    setSearchInput(searchTerm)
+  }, [searchTerm])
+
+  useEffect(() => {
+    if (debouncedSearchInput !== searchTerm) {
+      setSearchTerm(debouncedSearchInput)
+    }
+  }, [debouncedSearchInput, searchTerm, setSearchTerm])
 
   useEffect(() => {
     if (!address) {
@@ -162,8 +175,8 @@ export function MyGroups({ onCreateClick }: MyGroupsProps) {
         <Input
           type="text"
           placeholder="Search pools by name..."
-          value={searchTerm}
-          onChange={(e) => setSearchTerm(e.target.value)}
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
           className="pl-9"
         />
       </div>
@@ -179,7 +192,7 @@ export function MyGroups({ onCreateClick }: MyGroupsProps) {
           <p className="text-sm text-muted-foreground max-w-sm">
             Try adjusting your search term or{" "}
             <button
-              onClick={() => setSearchTerm("")}
+              onClick={() => setSearchInput("")}
               className="text-primary hover:underline"
             >
               clear the search

--- a/frontend/hooks/use-debounced-value.ts
+++ b/frontend/hooks/use-debounced-value.ts
@@ -1,0 +1,17 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+export function useDebouncedValue<T>(value: T, delay = 300) {
+  const [debouncedValue, setDebouncedValue] = useState(value)
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedValue(value)
+    }, delay)
+
+    return () => window.clearTimeout(timeoutId)
+  }, [value, delay])
+
+  return debouncedValue
+}


### PR DESCRIPTION
## Description

Adds a reusable `useDebouncedValue` hook and uses it for the My Groups and Explore search inputs.

The visible input value still updates immediately while typing, but the URL-backed search/filter state is only applied after a 300ms debounce.

Closes #145

## Type of Change

- [ ] feat: new feature
- [x] fix: bug fix
- [ ] chore: maintenance, tooling, dependencies
- [ ] docs: documentation only
- [ ] refactor: code restructuring (no functional changes)
- [ ] test: adding or updating tests

## How Has This Been Tested?

- [x] `git diff --check`
- [ ] `pnpm build` succeeds (frontend)
- [ ] `pnpm lint` passes (frontend)
- [ ] Manual testing (describe below)

Local frontend dependency installation timed out before Next was available, so I could not complete the build/lint checks in this environment.

## Checklist

- [x] My code follows the coding conventions of this project
- [x] I have added/updated tests if needed
- [x] I have updated documentation if needed
- [x] My changes generate no new warnings or errors

## Screenshots (if applicable)

N/A
