### PR TITLE
Add low member count warning for rotational pools

### DIFF
--- a/frontend/components/group/group-details.tsx
+++ b/frontend/components/group/group-details.tsx
@@ -324,9 +324,14 @@ export function GroupDetails({ groupId, contractAddress }: GroupDetailsProps) {
     return { saved: group.total_saved || 0, target: group.target_amount || 0 };
   };
 
-  const stats = getLiveStats();
-  const progress = getProgress();
-  const targetDisplay = getTargetDisplay();
+const stats = getLiveStats();
+const progress = getProgress();
+const targetDisplay = getTargetDisplay();
+
+const LOW_MEMBER_THRESHOLD = 2;
+const hasLowMemberCount =
+  group.type === "rotational" &&
+  (group.members_count ?? 0) <= LOW_MEMBER_THRESHOLD;
 
   return (
     <motion.div
@@ -396,6 +401,16 @@ export function GroupDetails({ groupId, contractAddress }: GroupDetailsProps) {
         {group.description && (
           <p className="text-muted-foreground mb-6">{group.description}</p>
         )}
+
+        {hasLowMemberCount && (
+  <div className="flex items-center gap-2 p-3 rounded-lg bg-yellow-500/10 text-yellow-700 dark:text-yellow-400 mb-4 text-sm font-medium">
+    <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+    <span>
+      This pool has very few members remaining — consider inviting more
+      members or planning for a shorter cycle.
+    </span>
+  </div>
+)}
 
         {isPaused && !isPending(group.contract_address) && (
           <div className="flex items-center gap-2 p-3 rounded-lg bg-destructive/10 text-destructive mb-4 text-sm font-medium">


### PR DESCRIPTION
## Description

This PR adds a non-blocking warning banner to the Rotational Pool detail page when the pool member count falls to **2 or fewer**.

The banner informs users that the pool has very few members remaining and suggests inviting more members or planning for a shorter cycle.

Closes #150

## Type of Change

* [x] feat: new feature
* [ ] fix: bug fix
* [ ] chore: maintenance, tooling, dependencies
* [ ] docs: documentation only
* [ ] refactor: code restructuring (no functional changes)
* [ ] test: adding or updating tests

## How Has This Been Tested?

* [ ] cargo test passes (smart contracts)
* [ ] pnpm build succeeds (frontend)
* [ ] pnpm lint passes (frontend)
* [x] Manual testing

### Manual Testing

* Verified the warning banner is displayed for rotational pools with 2 or fewer members.
* Verified the banner is informational only and does not block any pool actions.
* Verified pools with more than 2 members are unaffected.

## Checklist

* [x] My code follows the project's coding style.
* [x] I have reviewed my own code.
* [x] I have kept the change focused on the requested feature.

Closes #147 
