### PR TITLE
fix: reject duplicate member addresses across forms and pool contracts

### DIFF
--- a/frontend/components/create-group/BulkImport.tsx
+++ b/frontend/components/create-group/BulkImport.tsx
@@ -35,6 +35,7 @@ export default function BulkImport({ onMembersChange }: BulkImportProps) {
       complete: (results) => {
         const parsed: Member[] = [];
         const errorLines: string[] = [];
+        const firstLineForAddress = new Map<string, number>();
         results.data.forEach((row, idx) => {
           const lineNum = idx + 1;
           const address = row[0]?.trim() ?? "";
@@ -47,6 +48,12 @@ export default function BulkImport({ onMembersChange }: BulkImportProps) {
             errorLines.push(`Line ${lineNum}: invalid Stellar address`);
             return;
           }
+          const firstLine = firstLineForAddress.get(address);
+          if (firstLine !== undefined) {
+            errorLines.push(`Line ${lineNum}: duplicate address (already added on line ${firstLine})`);
+            return;
+          }
+          firstLineForAddress.set(address, lineNum);
           parsed.push({ address, name, line: lineNum });
         });
         if (parsed.length > MAX_MEMBERS) {

--- a/frontend/components/create-group/flexible-form.tsx
+++ b/frontend/components/create-group/flexible-form.tsx
@@ -19,6 +19,7 @@ import {
   validateStellarAddress,
   validatePositiveAmount,
   validateWithdrawalFee,
+  findDuplicateAddresses,
 } from "@/lib/form-validation"
 
 function isValidStellarAddress(addr: string) {
@@ -35,7 +36,6 @@ export function FlexibleForm() {
   const { address } = useStellar()
   const [token, setToken] = useState<SelectedToken>({ address: "native", symbol: "XLM", decimals: 7 })
   const [members, setMembers] = useState<string[]>([""])
-  const [memberErrors, setMemberErrors] = useState<string[]>([""])
   const [error, setError] = useState("")
   const [step, setStep] = useState<"idle" | "deploying" | "initializing" | "registering" | "saving">("idle")
   const [formData, setFormData] = useState({
@@ -55,6 +55,14 @@ export function FlexibleForm() {
 
   const allMembers = address ? [address, ...members] : members
   const validMembers = Array.from(new Set(allMembers.filter(isValidStellarAddress)))
+  const duplicateIndices = findDuplicateAddresses(allMembers)
+  const memberErrors = members.map((m, i) => {
+    if (!m) return ""
+    const format = validateStellarAddress(m)
+    if (!format.valid) return format.message
+    const allMembersIndex = address ? i + 1 : i
+    return duplicateIndices.has(allMembersIndex) ? "Duplicate address — already in this pool's member list" : ""
+  })
   const isCreating = step !== "idle"
 
   const validateField = useCallback((name: keyof FieldErrors, value: string) => {
@@ -72,15 +80,11 @@ export function FlexibleForm() {
 
   const updateMember = (i: number, v: string) => {
     const n = [...members]; n[i] = v; setMembers(n)
-    const errs = [...memberErrors]
-    errs[i] = v ? (validateStellarAddress(v).valid ? "" : validateStellarAddress(v).message) : ""
-    setMemberErrors(errs)
   }
 
-  const addMember = () => { setMembers([...members, ""]); setMemberErrors([...memberErrors, ""]) }
+  const addMember = () => { setMembers([...members, ""]) }
   const removeMember = (i: number) => {
     setMembers(members.filter((_, idx) => idx !== i))
-    setMemberErrors(memberErrors.filter((_, idx) => idx !== i))
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -98,6 +102,7 @@ export function FlexibleForm() {
     })
 
     if (!address) return setError("Please connect your wallet first")
+    if (duplicateIndices.size > 0) return setError("Duplicate member addresses found — please remove duplicates before continuing")
     if (validMembers.length < 2) return setError("Need at least 2 valid Stellar addresses (you + 1 other)")
     if (!nameResult.valid || !depositResult.valid || !feeResult.valid) return
 

--- a/frontend/components/create-group/rotational-form.tsx
+++ b/frontend/components/create-group/rotational-form.tsx
@@ -19,6 +19,7 @@ import {
   validateGroupName,
   validateStellarAddress,
   validatePositiveAmount,
+  findDuplicateAddresses,
 } from "@/lib/form-validation"
 import type { DuplicatePrefill } from "@/app/dashboard/create/[type]/page"
 
@@ -48,9 +49,6 @@ export function RotationalForm({ prefill }: { prefill?: DuplicatePrefill }) {
   const [members, setMembers] = useState<string[]>(
     initialMembers.length > 0 ? initialMembers : [""]
   )
-  const [memberErrors, setMemberErrors] = useState<string[]>(
-    initialMembers.length > 0 ? initialMembers.map(() => "") : [""]
-  )
   const [error, setError] = useState("")
   const [step, setStep] = useState<"idle" | "deploying" | "initializing" | "registering" | "saving">("idle")
   const [formData, setFormData] = useState({
@@ -75,6 +73,14 @@ export function RotationalForm({ prefill }: { prefill?: DuplicatePrefill }) {
   // Always include creator as first member
   const allMembers = address ? [address, ...members] : members
   const validMembers = Array.from(new Set(allMembers.filter(isValidStellarAddress)))
+  const duplicateIndices = findDuplicateAddresses(allMembers)
+  const memberErrors = members.map((m, i) => {
+    if (!m) return ""
+    const format = validateStellarAddress(m)
+    if (!format.valid) return format.message
+    const allMembersIndex = address ? i + 1 : i
+    return duplicateIndices.has(allMembersIndex) ? "Duplicate address — already in this pool's member list" : ""
+  })
   const isCreating = step !== "idle"
 
   const validateField = useCallback((name: keyof FieldErrors, value: string) => {
@@ -92,24 +98,14 @@ export function RotationalForm({ prefill }: { prefill?: DuplicatePrefill }) {
     const next = [...members]
     next[i] = v
     setMembers(next)
-    const errs = [...memberErrors]
-    if (v) {
-      const r = validateStellarAddress(v)
-      errs[i] = r.valid ? "" : r.message
-    } else {
-      errs[i] = ""
-    }
-    setMemberErrors(errs)
   }
 
   const addMember = () => {
     setMembers([...members, ""])
-    setMemberErrors([...memberErrors, ""])
   }
 
   const removeMember = (i: number) => {
     setMembers(members.filter((_, idx) => idx !== i))
-    setMemberErrors(memberErrors.filter((_, idx) => idx !== i))
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -126,6 +122,7 @@ export function RotationalForm({ prefill }: { prefill?: DuplicatePrefill }) {
     })
 
     if (!address) return setError("Please connect your wallet first")
+    if (duplicateIndices.size > 0) return setError("Duplicate member addresses found — please remove duplicates before continuing")
     if (validMembers.length < 2) return setError("Need at least 2 valid Stellar addresses (you + 1 other)")
     if (!nameResult.valid || !amountResult.valid) return
 

--- a/frontend/components/create-group/target-form.tsx
+++ b/frontend/components/create-group/target-form.tsx
@@ -19,6 +19,7 @@ import {
   validateStellarAddress,
   validatePositiveAmount,
   validateDeadline,
+  findDuplicateAddresses,
 } from "@/lib/form-validation"
 
 function isValidStellarAddress(addr: string) {
@@ -43,7 +44,6 @@ export function TargetForm() {
   const { address } = useStellar()
   const [token, setToken] = useState<SelectedToken>({ address: "native", symbol: "XLM", decimals: 7 })
   const [members, setMembers] = useState<string[]>([""])
-  const [memberErrors, setMemberErrors] = useState<string[]>([""])
   const [error, setError] = useState("")
   const [step, setStep] = useState<"idle" | "deploying" | "initializing" | "registering" | "saving">("idle")
   const [formData, setFormData] = useState({ name: "", description: "", targetAmount: "", deadline: "" })
@@ -61,6 +61,14 @@ export function TargetForm() {
 
   const allMembers = address ? [address, ...members] : members
   const validMembers = Array.from(new Set(allMembers.filter(isValidStellarAddress)))
+  const duplicateIndices = findDuplicateAddresses(allMembers)
+  const memberErrors = members.map((m, i) => {
+    if (!m) return ""
+    const format = validateStellarAddress(m)
+    if (!format.valid) return format.message
+    const allMembersIndex = address ? i + 1 : i
+    return duplicateIndices.has(allMembersIndex) ? "Duplicate address — already in this pool's member list" : ""
+  })
   const isCreating = step !== "idle"
 
   const validateField = useCallback((name: keyof FieldErrors, value: string) => {
@@ -78,15 +86,11 @@ export function TargetForm() {
 
   const updateMember = (i: number, v: string) => {
     const next = [...members]; next[i] = v; setMembers(next)
-    const errs = [...memberErrors]
-    errs[i] = v ? (validateStellarAddress(v).valid ? "" : validateStellarAddress(v).message) : ""
-    setMemberErrors(errs)
   }
 
-  const addMember = () => { setMembers([...members, ""]); setMemberErrors([...memberErrors, ""]) }
+  const addMember = () => { setMembers([...members, ""]) }
   const removeMember = (i: number) => {
     setMembers(members.filter((_, idx) => idx !== i))
-    setMemberErrors(memberErrors.filter((_, idx) => idx !== i))
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -104,6 +108,7 @@ export function TargetForm() {
     })
 
     if (!address) return setError("Please connect your wallet first")
+    if (duplicateIndices.size > 0) return setError("Duplicate member addresses found — please remove duplicates before continuing")
     if (validMembers.length < 2) return setError("Need at least 2 valid Stellar addresses (you + 1 other)")
     if (!nameResult.valid || !amountResult.valid || !deadlineResult.valid) return
 

--- a/frontend/lib/form-validation.test.ts
+++ b/frontend/lib/form-validation.test.ts
@@ -1,0 +1,38 @@
+// Unit tests for member-address validation, focused on duplicate detection.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { findDuplicateAddresses, validateStellarAddress } from './form-validation';
+
+const A = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const B = 'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA';
+const C = 'GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCA';
+
+test('findDuplicateAddresses - no duplicates returns an empty set', () => {
+  const result = findDuplicateAddresses([A, B, C]);
+  assert.strictEqual(result.size, 0);
+});
+
+test('findDuplicateAddresses - flags both the first and later occurrence', () => {
+  const result = findDuplicateAddresses([A, B, A]);
+  assert.deepStrictEqual(result, new Set([0, 2]));
+});
+
+test('findDuplicateAddresses - flags every member of a repeated group', () => {
+  const result = findDuplicateAddresses([A, A, A]);
+  assert.deepStrictEqual(result, new Set([0, 1, 2]));
+});
+
+test('findDuplicateAddresses - ignores empty entries (covered by other validation)', () => {
+  const result = findDuplicateAddresses(['', A, '', B]);
+  assert.strictEqual(result.size, 0);
+});
+
+test('findDuplicateAddresses - trims whitespace before comparing', () => {
+  const result = findDuplicateAddresses([A, ` ${A} `]);
+  assert.deepStrictEqual(result, new Set([0, 1]));
+});
+
+test('validateStellarAddress - still rejects malformed addresses independently of duplicate checks', () => {
+  assert.strictEqual(validateStellarAddress('not-an-address').valid, false);
+  assert.strictEqual(validateStellarAddress(A).valid, true);
+});

--- a/frontend/lib/form-validation.ts
+++ b/frontend/lib/form-validation.ts
@@ -44,3 +44,26 @@ export function validateWithdrawalFee(value: string): ValidationResult {
   if (num > 10) return err("Fee cannot exceed 10%")
   return ok
 }
+
+/**
+ * Returns the indices of entries in `addresses` that share a value with at
+ * least one other entry (both the first and later occurrences are flagged,
+ * so every duplicate row can show an inline error). Empty entries are
+ * ignored since they're caught by other field validation.
+ */
+export function findDuplicateAddresses(addresses: string[]): Set<number> {
+  const firstSeenAt = new Map<string, number>()
+  const duplicates = new Set<number>()
+  addresses.forEach((raw, i) => {
+    const value = raw.trim()
+    if (!value) return
+    const seenAt = firstSeenAt.get(value)
+    if (seenAt !== undefined) {
+      duplicates.add(seenAt)
+      duplicates.add(i)
+    } else {
+      firstSeenAt.set(value, i)
+    }
+  })
+  return duplicates
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev --webpack",
     "lint": "next lint",
     "start": "next start",
-    "test:unit": "tsx --test lib/csv-export.test.ts lib/analytics.test.ts lib/pool-health.test.ts hooks/use-keyboard-shortcuts.test.ts",
+    "test:unit": "tsx --test lib/csv-export.test.ts lib/analytics.test.ts lib/pool-health.test.ts lib/form-validation.test.ts hooks/use-keyboard-shortcuts.test.ts",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report"

--- a/smartcontract/contracts/flexible/src/lib.rs
+++ b/smartcontract/contracts/flexible/src/lib.rs
@@ -41,6 +41,7 @@ impl FlexiblePool {
         treasury_fee_bps: u32,
     ) {
         assert!(members.len() >= 2, "need >=2 members");
+        assert!(!Self::has_duplicate_members(&members), "duplicate member address");
         assert!(minimum_deposit > 0, "minimum must be > 0");
 
         // Validate the token is a real SEP-41 contract by reading its decimals
@@ -483,6 +484,20 @@ impl FlexiblePool {
         for m in members.iter() {
             if m == *who {
                 return true;
+            }
+        }
+        false
+    }
+
+    /// O(n^2) pairwise scan — member lists are small, so this is cheaper
+    /// than maintaining a separate index just to dedupe at init time.
+    fn has_duplicate_members(members: &Vec<Address>) -> bool {
+        for i in 0..members.len() {
+            let a = members.get(i).unwrap();
+            for j in (i + 1)..members.len() {
+                if a == members.get(j).unwrap() {
+                    return true;
+                }
             }
         }
         false

--- a/smartcontract/contracts/flexible/src/tests.rs
+++ b/smartcontract/contracts/flexible/src/tests.rs
@@ -56,6 +56,43 @@ fn test_token_decimals_recorded() {
 }
 
 #[test]
+#[should_panic(expected = "duplicate member address")]
+fn test_initialize_rejects_duplicate_member() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, FlexiblePool);
+    let client = FlexiblePoolClient::new(&env, &contract_id);
+
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_address = token_contract.address();
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let member_a = Address::generate(&env);
+    let member_b = Address::generate(&env);
+
+    // member_a appears twice — distribute_yield iterates the raw members
+    // vec, so a duplicate slot would grant member_a a double yield share.
+    let mut members = Vec::new(&env);
+    members.push_back(member_a.clone());
+    members.push_back(member_b.clone());
+    members.push_back(member_a.clone());
+
+    client.initialize(
+        &token_address,
+        &admin,
+        &members,
+        &10i128,
+        &0u32,
+        &false,
+        &treasury,
+        &0u32,
+    );
+}
+
+#[test]
 #[should_panic(expected = "below minimum deposit")]
 fn test_minimum_deposit_rejection() {
     let env = Env::default();

--- a/smartcontract/contracts/rotational/src/lib.rs
+++ b/smartcontract/contracts/rotational/src/lib.rs
@@ -48,6 +48,7 @@ impl RotationalPool {
         treasury: Address,
     ) {
         assert!(members.len() >= 2, "need >=2 members");
+        assert!(!Self::has_duplicate_members(&members), "duplicate member address");
         assert!(deposit_amount > 0, "deposit must be > 0");
         assert!(round_duration > 0, "round_duration must be > 0");
 
@@ -441,6 +442,21 @@ impl RotationalPool {
         for m in members.iter() {
             if m == *who {
                 return true;
+            }
+        }
+        false
+    }
+
+    /// O(n^2) pairwise scan — member lists are small (capped well below
+    /// the resource limits that would make this costly), so this is cheaper
+    /// than maintaining a separate index just to dedupe at init time.
+    fn has_duplicate_members(members: &Vec<Address>) -> bool {
+        for i in 0..members.len() {
+            let a = members.get(i).unwrap();
+            for j in (i + 1)..members.len() {
+                if a == members.get(j).unwrap() {
+                    return true;
+                }
             }
         }
         false

--- a/smartcontract/contracts/rotational/src/tests.rs
+++ b/smartcontract/contracts/rotational/src/tests.rs
@@ -145,6 +145,44 @@ fn test_non_member_deposit_rejection() {
 }
 
 #[test]
+#[should_panic(expected = "duplicate member address")]
+fn test_initialize_rejects_duplicate_member() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, RotationalPool);
+    let client = RotationalPoolClient::new(&env, &contract_id);
+
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_address = token_contract.address();
+
+    let treasury = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let member_a = Address::generate(&env);
+    let member_b = Address::generate(&env);
+
+    // member_a appears twice — this must be rejected, since the round-robin
+    // payout indexes directly into the members vec and would otherwise let
+    // member_a claim two payout rounds while member_b only ever claims one.
+    let mut members = Vec::new(&env);
+    members.push_back(member_a.clone());
+    members.push_back(member_b.clone());
+    members.push_back(member_a.clone());
+
+    client.initialize(
+        &token_address,
+        &admin,
+        &members,
+        &100i128,
+        &100u64,
+        &0u32,
+        &0u32,
+        &treasury,
+    );
+}
+
+#[test]
 #[should_panic(expected = "already deposited this round")]
 fn test_duplicate_deposit_rejection() {
     let env = Env::default();

--- a/smartcontract/contracts/target/src/lib.rs
+++ b/smartcontract/contracts/target/src/lib.rs
@@ -36,6 +36,7 @@ impl TargetPool {
         deadline: u32,
     ) {
         assert!(members.len() >= 2, "need >=2 members");
+        assert!(!Self::has_duplicate_members(&members), "duplicate member address");
         assert!(target_amount > 0, "target must be > 0");
 
         // Validate the token is a real SEP-41 contract by reading its decimals
@@ -374,6 +375,20 @@ impl TargetPool {
         for m in members.iter() {
             if m == *who {
                 return true;
+            }
+        }
+        false
+    }
+
+    /// O(n^2) pairwise scan — member lists are small, so this is cheaper
+    /// than maintaining a separate index just to dedupe at init time.
+    fn has_duplicate_members(members: &Vec<Address>) -> bool {
+        for i in 0..members.len() {
+            let a = members.get(i).unwrap();
+            for j in (i + 1)..members.len() {
+                if a == members.get(j).unwrap() {
+                    return true;
+                }
             }
         }
         false

--- a/smartcontract/contracts/target/src/tests.rs
+++ b/smartcontract/contracts/target/src/tests.rs
@@ -54,6 +54,32 @@ fn test_unlock_on_target() {
 }
 
 #[test]
+#[should_panic(expected = "duplicate member address")]
+fn test_initialize_rejects_duplicate_member() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, TargetPool);
+    let client = TargetPoolClient::new(&env, &contract_id);
+
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_address = token_contract.address();
+
+    let admin = Address::generate(&env);
+    let member_a = Address::generate(&env);
+    let member_b = Address::generate(&env);
+
+    // member_a appears twice in the member list.
+    let mut members = Vec::new(&env);
+    members.push_back(member_a.clone());
+    members.push_back(member_b.clone());
+    members.push_back(member_a.clone());
+
+    client.initialize(&token_address, &admin, &members, &100i128, &1000u32);
+}
+
+#[test]
 fn test_proportional_withdraw() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
Closes #143

## Investigation: on-chain behavior before this fix

`add_member` already guarded against duplicates on all three pool contracts (`assert!(!Self::is_member(&members, &new_member), "already a member")`), but **`initialize` had no such check** — it only asserted `members.len() >= 2` and stored whatever `Vec<Address>` it was given verbatim. A caller bypassing the (unvalidated) frontend — or hitting the contract directly — could initialize a pool with the same address listed twice. Concretely, per pool type:

- **Rotational** — `trigger_payout` indexes the beneficiary as `members.get(current_round)`, so a duplicate address occupying two slots claims **two separate payout rounds**, exactly the round-robin skew described in the issue. It's worse than just unfair: `deposit_count` is tallied by iterating the raw `members` vec and checking a *shared* `HasDeposited(address)` flag per slot — so a duplicated address that deposits once gets counted **twice** toward `deposit_count`. `total_collected = deposit_amount * deposit_count` then overstates what was actually transferred into the contract for that round, which can overpay the round's beneficiary beyond the pool's real balance.
- **Flexible** — `distribute_yield` iterates the raw `members` vec and credits a proportional yield share to `Balance(member)` for every slot. A duplicate address would receive its proportional share **twice per distribution call**.
- **Target** — deposit/withdraw/refund balances are keyed by address (`Balance(Address)`), so a duplicate slot doesn't directly double-pay there, but it still leaves inconsistent state (wasted storage, an inflated `members.len()`) that's safer to reject at the same layer for consistency with the other two pool types.
- **Reputation tracker** — all of its storage is keyed by `Address`, not by pool slot, so it has no duplicate-*storage* bug of its own. But it has no idempotency guard on the calls it receives either — it trusts the reporting pool. In Rotational, `report_missed_round` fires once per slot in `missed_members`, and `report_payout`/`record_payout_received` fire once per round; with a duplicated address occupying two member slots, both would fire twice for the same person in normal operation, double-incrementing `missed_rounds`/`rounds_tracked`/`pools_completed`. Rather than add defensive idempotency checks inside `reputation/src/lib.rs` (which would mask the real bug), this PR closes the gap at the source in each pool's `initialize`.

## Fix

**Contracts** (`rotational`, `target`, `flexible` — `src/lib.rs`): added a `has_duplicate_members` helper (O(n²) pairwise scan — member lists are small, so this is cheaper than maintaining a separate index just to dedupe once at init) and wired it into `initialize` right after the existing `members.len() >= 2` check, mirroring `add_member`'s existing guard:
```rust
assert!(!Self::has_duplicate_members(&members), "duplicate member address");
```

**Frontend**: added `findDuplicateAddresses(addresses: string[]): Set<number>` to `lib/form-validation.ts`, which flags every index that shares a (trimmed) value with another entry. Wired into:
- `rotational-form.tsx`, `target-form.tsx`, `flexible-form.tsx` — duplicate detection runs across the creator's own address + all manually entered member rows, so typing the creator's own address (or a row you already added) shows an inline "Duplicate address" error on the affected row(s), and submission is blocked with a clear top-level error if any duplicates remain.
- `BulkImport.tsx` — duplicate rows within an imported CSV are now flagged by line number (`Line N: duplicate address (already added on line M)`) and excluded from the imported member list, instead of silently passing through.

The previous `Array.from(new Set(...))` dedup before submission is left in place as a defense-in-depth fallback, but duplicates are now caught and surfaced *before* that point, with a message the user can act on.

## Tests

- `rotational/src/tests.rs`, `target/src/tests.rs`, `flexible/src/tests.rs`: added `test_initialize_rejects_duplicate_member` (`#[should_panic(expected = "duplicate member address")]`) to each.
- `frontend/lib/form-validation.test.ts` (new): unit tests for `findDuplicateAddresses` (no duplicates, both-occurrences flagged, full-group duplicates, blank entries ignored, whitespace trimming).

## Verification

- `cargo test` (full `smartcontract` workspace, run under WSL — native Windows `cargo build`/`test` is blocked by an Application Control policy on my machine, unrelated to this change): all passing, including the 3 new tests.
- `cargo build --target wasm32-unknown-unknown --release` for `rotational`, `target`, `flexible`: all build cleanly.
- `pnpm test:unit` (frontend): 40/40 passing, including the 5 new `findDuplicateAddresses` tests.
- `tsc --noEmit`: no new type errors. (2 pre-existing errors on `main` unrelated to this change: `TargetForm`/`FlexibleForm` don't declare a `prefill` prop that `app/dashboard/create/[type]/page.tsx` passes them.)
- `pnpm run lint` / `next lint`: currently broken on `main` under this Next 16 setup (the `next lint` subcommand was removed) — pre-existing and unrelated, could not run ESLint.