### PR TITLE
fix: migrate dashboard CSV exports to shared utility

### DIFF
--- a/frontend/components/dashboard/analytics.tsx
+++ b/frontend/components/dashboard/analytics.tsx
@@ -41,6 +41,7 @@ import {
   BarChart,
   Bar,
 } from "recharts"
+import { buildCsv, downloadCsv } from "@/lib/csv-export"
 
 interface AnalyticsData {
   totalPools: number
@@ -141,29 +142,23 @@ export function AnalyticsDashboard() {
 
   // Export to CSV Function
   const handleExportCSV = () => {
-    let csvContent = "data:text/csv;charset=utf-8,"
     const headers = ["Date", "Cumulative Deposits (XLM)", "Cumulative Withdrawals (XLM)", "Net Savings/Balance (XLM)"]
-    csvContent += headers.join(",") + "\n"
-
     const dataPoints = selectedPoolId === "overview"
       ? generalData?.globalChartData || []
       : poolData?.chartData || []
 
-    dataPoints.forEach((point) => {
-      const row = [point.date, point.deposits, point.withdrawals, point.balance]
-      csvContent += row.join(",") + "\n"
-    })
+    const rows = dataPoints.map((point) => [
+      point.date,
+      point.deposits,
+      point.withdrawals,
+      point.balance,
+    ])
 
-    const encodedUri = encodeURI(csvContent)
-    const link = document.createElement("a")
-    link.setAttribute("href", encodedUri)
     const filename = selectedPoolId === "overview"
       ? "jointsave_portfolio_analytics.csv"
       : `jointsave_pool_${selectedPoolId}_analytics.csv`
-    link.setAttribute("download", filename)
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
+    const csv = buildCsv(headers, rows)
+    downloadCsv(csv, filename)
   }
 
   if (!address) {

--- a/frontend/components/dashboard/transactions.tsx
+++ b/frontend/components/dashboard/transactions.tsx
@@ -10,6 +10,7 @@ import { useState, useEffect, useMemo } from "react"
 import { supabase } from "@/lib/supabase"
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip"
 import { formatRelativeTime, formatExactDateTime } from "@/lib/utils"
+import { buildCsv, downloadCsv } from "@/lib/csv-export"
 
 interface Activity {
   id: string
@@ -22,6 +23,7 @@ interface Activity {
   tx_hash: string | null
   pool_name: string | null
   pool_type: string | null
+  token_symbol: string | null
 }
 
 export function Transactions() {
@@ -41,7 +43,7 @@ export function Transactions() {
           .from("pool_activity")
           .select(`
             *,
-            pools ( name, type )
+            pools ( name, type, token_symbol )
           `)
           .order("created_at", { ascending: false })
           .limit(500)
@@ -52,6 +54,7 @@ export function Transactions() {
           ...row,
           pool_name: row.pools?.name ?? null,
           pool_type: row.pools?.type ?? null,
+          token_symbol: row.pools?.token_symbol ?? null,
         }))
         setActivities(rows)
       } catch (err) {
@@ -88,27 +91,18 @@ export function Transactions() {
   }, [activities, dateFrom, dateTo, poolFilter, typeFilter])
 
   const exportCSV = () => {
-    const header = ["Date", "Pool Name", "Pool Type", "Activity Type", "Amount", "Transaction Hash"]
+    const headers = ["Date", "Pool Name", "Pool Type", "Activity Type", "Amount", "Transaction Hash"]
     const rows = filtered.map((a) => [
-      new Date(a.created_at).toLocaleDateString(),
+      new Date(a.created_at).toISOString().slice(0, 10),
       a.pool_name ?? "",
       a.pool_type ?? "",
       a.activity_type,
-      a.amount != null ? a.amount.toFixed(2) : "",
+      a.amount != null ? `${a.amount.toFixed(2)} ${a.token_symbol ?? "XLM"}` : "",
       a.tx_hash ?? "",
     ])
 
-    const csv = [header, ...rows]
-      .map((row) => row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(","))
-      .join("\n")
-
-    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement("a")
-    a.href = url
-    a.download = `transactions-${new Date().toISOString().slice(0, 10)}.csv`
-    a.click()
-    URL.revokeObjectURL(url)
+    const csv = buildCsv(headers, rows)
+    downloadCsv(csv, `transactions-${new Date().toISOString().slice(0, 10)}.csv`)
   }
 
   if (loading) {


### PR DESCRIPTION
## Summary

This pull request migrates the Transactions dashboard CSV export to the shared CSV export utility, ensuring consistent CSV generation and formatting across the dashboard.

## Changes Made

- Replaced the Transactions tab's custom CSV generation with the shared `buildCsv()` and `downloadCsv()` utilities
- Updated exported dates to use a fixed ISO `YYYY-MM-DD` format instead of locale-dependent formatting
- Included the token symbol with each exported amount (for example, `50.00 USDC`) to support multi-token pools
- Preserved existing filtering and download behavior
- Migrated the Analytics dashboard CSV export to the shared utility, removing duplicate CSV generation logic and keeping dashboard exports consistent

## Verification

- Ran `pnpm test:unit` successfully
- Ran `pnpm build` successfully
- Verified exported CSVs use the shared RFC 4180-compliant utility
- Confirmed existing TypeScript errors are unrelated to this change (`app/dashboard/create/[type]/page.tsx`)

**Closes #159**
```