### PR TITLE
feat: add per-pool notification muting (#146)

### DIFF
--- a/frontend/app/api/user-profile/route.ts
+++ b/frontend/app/api/user-profile/route.ts
@@ -10,7 +10,7 @@ export async function GET(req: NextRequest) {
 
   const { data, error } = await getAdminClient()
     .from("user_profiles")
-    .select("wallet_address, email, notification_preferences")
+    .select("wallet_address, email, notification_preferences, muted_pools")
     .eq("wallet_address", wallet)
     .maybeSingle()
 

--- a/frontend/components/group/GroupMuteNotificationsToggle.tsx
+++ b/frontend/components/group/GroupMuteNotificationsToggle.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { useStellar } from "@/components/web3-provider"
+import { useUserProfile } from "@/hooks/useUserProfile"
+import { Button } from "@/components/ui/button"
+
+export function GroupMuteNotificationsToggle({ poolId }: { poolId: string }) {
+  const { address } = useStellar()
+  const { profile, loading, saving, saveProfile } = useUserProfile(address || null)
+  const [localMuted, setLocalMuted] = useState(false)
+
+  useEffect(() => {
+    const muted = !!profile?.muted_pools?.includes(poolId)
+    setLocalMuted(muted)
+  }, [profile?.muted_pools, poolId])
+
+  const isMuted = useMemo(() => localMuted, [localMuted])
+
+  const toggle = async () => {
+    if (!address || !poolId) return
+    const current = profile?.muted_pools ?? []
+    const next = isMuted
+      ? current.filter((id) => id !== poolId)
+      : Array.from(new Set([...current, poolId]))
+
+    setLocalMuted(!isMuted)
+    await saveProfile({ muted_pools: next })
+  }
+
+  return (
+    <div className="mb-4 p-3 rounded-lg bg-muted/30 flex items-center justify-between gap-4">
+      <div>
+        <p className="text-sm font-medium">Mute notifications for this pool</p>
+        <p className="text-xs text-muted-foreground">
+          Stops email notifications for this pool only.
+        </p>
+      </div>
+      <Button
+        type="button"
+        variant={isMuted ? "destructive" : "outline"}
+        onClick={toggle}
+        disabled={loading || saving || !profile}
+        className="shrink-0"
+      >
+        {isMuted ? "Muted" : "On"}
+      </Button>
+    </div>
+  )
+}

--- a/frontend/components/group/group-details.tsx
+++ b/frontend/components/group/group-details.tsx
@@ -30,6 +30,7 @@ import {
 import { usePoolData } from "@/lib/data-layer/PoolDataProvider"
 import { useToast } from "@/hooks/use-toast"
 import { useOptimisticTransactions } from "@/hooks/useOptimisticTransactions"
+import { GroupMuteNotificationsToggle } from "@/components/group/GroupMuteNotificationsToggle"
 
 interface GroupDetailsProps {
   groupId: string
@@ -482,6 +483,12 @@ export function GroupDetails({ groupId, contractAddress }: GroupDetailsProps) {
             </Button>
           </div>
         )}
+
+        {/* Per-pool notification mute (email only) */}
+        <div className="mb-4">
+          {/* pool_id in DB is the same as groupId route param */}
+          <GroupMuteNotificationsToggle poolId={groupId} />
+        </div>
 
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
           {stats.map((stat, i) => (

--- a/frontend/hooks/useUserProfile.ts
+++ b/frontend/hooks/useUserProfile.ts
@@ -16,6 +16,7 @@ export interface UserProfile {
   wallet_address: string
   email: string | null
   notification_preferences: NotificationPreferences
+  muted_pools: string[]
 }
 
 const DEFAULT_PREFS: NotificationPreferences = {
@@ -39,11 +40,13 @@ export function useUserProfile(walletAddress: string | null) {
               wallet_address: walletAddress.toLowerCase(),
               email: null,
               notification_preferences: DEFAULT_PREFS,
+              muted_pools: [],
             }
           : null
       )
       return
     }
+
     setLoading(true)
     const res = await fetch(
       `/api/user-profile?wallet=${encodeURIComponent(walletAddress.toLowerCase())}`
@@ -54,8 +57,10 @@ export function useUserProfile(walletAddress: string | null) {
         wallet_address: walletAddress.toLowerCase(),
         email: null,
         notification_preferences: DEFAULT_PREFS,
+        muted_pools: [],
       }
     )
+
     setLoading(false)
   }, [walletAddress])
 
@@ -64,12 +69,15 @@ export function useUserProfile(walletAddress: string | null) {
   }, [fetchProfile])
 
   const saveProfile = useCallback(
-    async (updates: Partial<Pick<UserProfile, "email" | "notification_preferences">>) => {
+    async (
+      updates: Partial<Pick<UserProfile, "email" | "notification_preferences" | "muted_pools">>
+    ) => {
       if (!walletAddress) return
       if (IS_E2E) {
-        setProfile((prev) => (prev ? { ...prev, ...updates } : null))
+        setProfile((prev: UserProfile | null) => (prev ? { ...prev, ...updates } : null))
         return
       }
+
       setSaving(true)
       await fetch("/api/user-profile", {
         method: "POST",

--- a/supabase/functions/notify-pool-event/index.ts
+++ b/supabase/functions/notify-pool-event/index.ts
@@ -9,60 +9,66 @@
 //   RESEND_API_KEY                            — set in Supabase dashboard > Edge Functions > Secrets
 //   RESEND_FROM_EMAIL                         — e.g. "JointSave <noreply@jointsave.app>"
 
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2"
-import { serve } from "https://deno.land/std@0.177.0/http/server.ts"
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
 
-const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY") ?? ""
-const RESEND_FROM = Deno.env.get("RESEND_FROM_EMAIL") ?? "JointSave <noreply@jointsave.app>"
-const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? ""
-const SUPABASE_SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY") ?? "";
+const RESEND_FROM =
+  Deno.env.get("RESEND_FROM_EMAIL") ?? "JointSave <noreply@jointsave.app>";
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
+const SUPABASE_SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
 
-const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY)
+const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
 interface ActivityRecord {
-  id: string
-  pool_id: string
-  activity_type: string
-  user_address: string | null
-  amount: number | null
-  description: string | null
-  created_at: string
+  id: string;
+  pool_id: string;
+  activity_type: string;
+  user_address: string | null;
+  amount: number | null;
+  description: string | null;
+  created_at: string;
 }
 
 interface WebhookPayload {
-  type: "INSERT" | "UPDATE" | "DELETE"
-  table: string
-  record: ActivityRecord
+  type: "INSERT" | "UPDATE" | "DELETE";
+  table: string;
+  record: ActivityRecord;
 }
 
 interface NotificationPreferences {
-  email_on_payout: boolean
-  email_on_deposit: boolean
-  email_on_round: boolean
-  email_on_target: boolean
+  email_on_payout: boolean;
+  email_on_deposit: boolean;
+  email_on_round: boolean;
+  email_on_target: boolean;
 }
 
 interface UserProfile {
-  wallet_address: string
-  email: string | null
-  notification_preferences: NotificationPreferences
+  wallet_address: string;
+  email: string | null;
+  notification_preferences: NotificationPreferences;
+  muted_pools: string[] | null;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 function shortAddress(addr: string): string {
-  return `${addr.slice(0, 6)}…${addr.slice(-4)}`
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
 }
 
 function xlmFromStroops(stroops: number | null): string {
-  if (stroops == null) return "?"
-  return (stroops / 10_000_000).toFixed(2)
+  if (stroops == null) return "?";
+  return (stroops / 10_000_000).toFixed(2);
 }
 
-async function sendEmail(to: string, subject: string, html: string): Promise<void> {
-  if (!RESEND_API_KEY || !to) return
+async function sendEmail(
+  to: string,
+  subject: string,
+  html: string,
+): Promise<void> {
+  if (!RESEND_API_KEY || !to) return;
   const res = await fetch("https://api.resend.com/emails", {
     method: "POST",
     headers: {
@@ -70,9 +76,9 @@ async function sendEmail(to: string, subject: string, html: string): Promise<voi
       Authorization: `Bearer ${RESEND_API_KEY}`,
     },
     body: JSON.stringify({ from: RESEND_FROM, to, subject, html }),
-  })
+  });
   if (!res.ok) {
-    console.error("Resend error:", await res.text())
+    console.error("Resend error:", await res.text());
   }
 }
 
@@ -86,22 +92,22 @@ function emailHtml(bodyContent: string): string {
         You're receiving this because you're a member of a JointSave pool.
         Manage preferences in your profile settings.
       </p>
-    </div>`
+    </div>`;
 }
 
 // ── Main handler ─────────────────────────────────────────────────────────────
 
 serve(async (req) => {
   try {
-    const payload: WebhookPayload = await req.json()
-    if (payload.type !== "INSERT") return new Response("ok", { status: 200 })
+    const payload: WebhookPayload = await req.json();
+    if (payload.type !== "INSERT") return new Response("ok", { status: 200 });
 
-    const act = payload.record
-    const { activity_type, pool_id, user_address, amount } = act
+    const act = payload.record;
+    const { activity_type, pool_id, user_address, amount } = act;
 
-    const HANDLED = ["payout", "deposit", "round_advance", "target_reached"]
+    const HANDLED = ["payout", "deposit", "round_advance", "target_reached"];
     if (!HANDLED.includes(activity_type)) {
-      return new Response("ok", { status: 200 })
+      return new Response("ok", { status: 200 });
     }
 
     // Fetch pool info
@@ -109,72 +115,74 @@ serve(async (req) => {
       .from("pools")
       .select("id, name")
       .eq("id", pool_id)
-      .single()
-    if (!pool) return new Response("pool not found", { status: 200 })
+      .single();
+    if (!pool) return new Response("pool not found", { status: 200 });
 
     // Fetch all pool members
     const { data: members } = await sb
       .from("pool_members")
       .select("member_address")
-      .eq("pool_id", pool_id)
-    const allMembers: string[] = (members ?? []).map((m: { member_address: string }) => m.member_address)
+      .eq("pool_id", pool_id);
+    const allMembers: string[] = (members ?? []).map(
+      (m: { member_address: string }) => m.member_address,
+    );
 
     // Fetch user profiles for email + preferences lookup
     const { data: profiles } = await sb
       .from("user_profiles")
-      .select("wallet_address, email, notification_preferences")
-      .in("wallet_address", allMembers)
+      .select("wallet_address, email, notification_preferences, muted_pools")
+      .in("wallet_address", allMembers);
     const profileMap = new Map<string, UserProfile>(
-      (profiles ?? []).map((p: UserProfile) => [p.wallet_address, p])
-    )
+      (profiles ?? []).map((p: UserProfile) => [p.wallet_address, p]),
+    );
 
-    const poolName = pool.name
-    const xlm = xlmFromStroops(amount)
-    const senderShort = user_address ? shortAddress(user_address) : "A member"
+    const poolName = pool.name;
+    const xlm = xlmFromStroops(amount);
+    const senderShort = user_address ? shortAddress(user_address) : "A member";
 
     // Determine recipients, preference key, message content
-    let recipients: string[] = []
-    let prefKey: keyof NotificationPreferences = "email_on_deposit"
-    let subject = ""
-    let inAppMsg = ""
-    let bodyHtml = ""
+    let recipients: string[] = [];
+    let prefKey: keyof NotificationPreferences = "email_on_deposit";
+    let subject = "";
+    let inAppMsg = "";
+    let bodyHtml = "";
 
     if (activity_type === "payout") {
-      recipients = user_address ? [user_address] : []
-      prefKey = "email_on_payout"
-      subject = `You received ${xlm} XLM from ${poolName}`
-      inAppMsg = subject
+      recipients = user_address ? [user_address] : [];
+      prefKey = "email_on_payout";
+      subject = `You received ${xlm} XLM from ${poolName}`;
+      inAppMsg = subject;
       bodyHtml = emailHtml(
         `<p>Great news! You received <strong>${xlm} XLM</strong> from your savings pool <strong>${poolName}</strong>.</p>
-         <p>Log in to view your updated balance.</p>`
-      )
+         <p>Log in to view your updated balance.</p>`,
+      );
     } else if (activity_type === "deposit") {
-      recipients = allMembers.filter((a) => a !== user_address)
-      prefKey = "email_on_deposit"
-      subject = `${senderShort} deposited to ${poolName}`
-      inAppMsg = subject
+      recipients = allMembers.filter((a) => a !== user_address);
+      prefKey = "email_on_deposit";
+      subject = `${senderShort} deposited to ${poolName}`;
+      inAppMsg = subject;
       bodyHtml = emailHtml(
-        `<p><strong>${senderShort}</strong> made a deposit of <strong>${xlm} XLM</strong> to <strong>${poolName}</strong>.</p>`
-      )
+        `<p><strong>${senderShort}</strong> made a deposit of <strong>${xlm} XLM</strong> to <strong>${poolName}</strong>.</p>`,
+      );
     } else if (activity_type === "round_advance") {
-      recipients = allMembers
-      prefKey = "email_on_round"
-      const nextMember = act.description ?? "the next member"
-      subject = `Round complete in ${poolName} — ${nextMember} is next`
-      inAppMsg = subject
+      recipients = allMembers;
+      prefKey = "email_on_round";
+      const nextMember = act.description ?? "the next member";
+      subject = `Round complete in ${poolName} — ${nextMember} is next`;
+      inAppMsg = subject;
       bodyHtml = emailHtml(
         `<p>A round is complete in <strong>${poolName}</strong>.</p>
-         <p>The next beneficiary is <strong>${nextMember}</strong>.</p>`
-      )
+         <p>The next beneficiary is <strong>${nextMember}</strong>.</p>`,
+      );
     } else if (activity_type === "target_reached") {
-      recipients = allMembers
-      prefKey = "email_on_target"
-      subject = `${poolName} reached its target! You can now withdraw.`
-      inAppMsg = subject
+      recipients = allMembers;
+      prefKey = "email_on_target";
+      subject = `${poolName} reached its target! You can now withdraw.`;
+      inAppMsg = subject;
       bodyHtml = emailHtml(
         `<p>Your savings pool <strong>${poolName}</strong> has reached its savings target!</p>
-         <p>You are now eligible to withdraw your funds. Log in to proceed.</p>`
-      )
+         <p>You are now eligible to withdraw your funds. Log in to proceed.</p>`,
+      );
     }
 
     // Write in-app notifications for all recipients
@@ -185,33 +193,40 @@ serve(async (req) => {
           pool_id,
           activity_type,
           message: inAppMsg,
-        }))
-      )
+        })),
+      );
     }
 
-    // Send emails, respecting per-user opt-out preferences
+    // Send emails, respecting global preferences AND per-pool mute.
     await Promise.all(
       recipients.map(async (addr) => {
-        const profile = profileMap.get(addr)
-        if (!profile?.email) return
+        const profile = profileMap.get(addr);
+        if (!profile?.email) return;
+
+        const isMutedForThisPool = (profile.muted_pools ?? []).includes(
+          pool_id,
+        );
+        if (isMutedForThisPool) return;
+
         const prefs: NotificationPreferences = {
           email_on_payout: true,
           email_on_deposit: true,
           email_on_round: true,
           email_on_target: true,
           ...(profile.notification_preferences ?? {}),
-        }
-        if (!prefs[prefKey]) return
-        await sendEmail(profile.email, subject, bodyHtml)
-      })
-    )
+        };
+        if (!prefs[prefKey]) return;
+
+        await sendEmail(profile.email, subject, bodyHtml);
+      }),
+    );
 
     return new Response(
       JSON.stringify({ ok: true, notified: recipients.length }),
-      { status: 200, headers: { "Content-Type": "application/json" } }
-    )
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
   } catch (err) {
-    console.error("notify-pool-event error:", err)
-    return new Response("internal error", { status: 500 })
+    console.error("notify-pool-event error:", err);
+    return new Response("internal error", { status: 500 });
   }
-})
+});

--- a/supabase/migrations/20260629010000_add_muted_pools_to_user_profiles.sql
+++ b/supabase/migrations/20260629010000_add_muted_pools_to_user_profiles.sql
@@ -1,0 +1,5 @@
+-- Add per-pool mute preferences to user_profiles
+
+ALTER TABLE user_profiles
+  ADD COLUMN IF NOT EXISTS muted_pools JSONB NOT NULL DEFAULT '[]'::jsonb;
+


### PR DESCRIPTION
Description:
Implemented per-pool notification muting end-to-end (DB → UI toggle → Edge Function email sending).

Changes made:
1) Database: store per-pool mute state

- Added migration: supabase/migrations/20260629010000_add_muted_pools_to_user_profiles.sql
- Adds user_profiles.muted_pools JSONB NOT NULL DEFAULT '[]'::jsonb

2) Edge Function: respect muted pools when sending emails
Updated: supabase/functions/notify-pool-event/index.ts

- Fetches muted_pools alongside global notification_preferences
- When sending email to a recipient:
- If recipientProfile.muted_pools contains the event pool_id, skip sending email for that pool
- In-app notifications inserts are unchanged (still written for all recipients)

3) Frontend model + API payload support
Updated: frontend/hooks/useUserProfile.ts

- Added muted_pools: string[]
- Defaulting logic uses muted_pools: []
- saveProfile typing now allows updating muted_pools

Updated: frontend/app/api/user-profile/route.ts

- GET now selects muted_pools
- POST already upserts ...updates, so it persists muted_pools automatically

4) UI: add toggle on the group detail page
Created: frontend/components/group/GroupMuteNotificationsToggle.tsx

- Renders a “Mute notifications for this pool” button
- Uses useUserProfile(address) and toggles membership in muted_pools
- Updated: frontend/components/group/group-details.tsx
- Imports and renders <GroupMuteNotificationsToggle poolId={groupId} />

Files touched/added:

- Added: supabase/migrations/20260629010000_add_muted_pools_to_user_profiles.sql
- Updated: supabase/functions/notify-pool-event/index.ts
- Updated: frontend/hooks/useUserProfile.ts
- Updated: frontend/app/api/user-profile/route.ts
- Added: frontend/components/group/GroupMuteNotificationsToggle.tsx
- Updated: frontend/components/group/group-details.tsx

Acceptance Criteria coverage:

- Muting stops email notifications for that pool only (Edge Function checks muted_pools per recipient + pool_id)
- Toggle persists (saved into user_profiles.muted_pools)
- Additive with global preferences (mute is checked in addition to existing notification_preferences gating)

Closes #146 