### PR TITLE
[Improvement] Add an empty state to the "Recent Pools" dropdown when the list is empty

### DIFF
--- a/frontend/components/dashboard/dashboard-header.tsx
+++ b/frontend/components/dashboard/dashboard-header.tsx
@@ -165,7 +165,7 @@ export function DashboardHeader() {
               </DropdownMenu>
             )}
 
-            {address && recentPools.length > 0 && (
+            {address && (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button variant="outline" size="sm" className="gap-1.5">
@@ -174,26 +174,32 @@ export function DashboardHeader() {
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-64">
-                  <DropdownMenuLabel>Recent Pools</DropdownMenuLabel>
-                  <DropdownMenuSeparator />
-                  {recentPools.map((pool) => (
-                    <DropdownMenuItem key={pool.contract_address || pool.id} asChild>
-                      <Link
-                        href={`/dashboard/group/${pool.id}`}
-                        className="flex w-full cursor-pointer items-center justify-between gap-2"
-                      >
-                        <span className="flex-1 truncate text-sm">{pool.name}</span>
-                        <span className="flex items-center gap-1.5">
-                          <Badge variant="secondary" className="text-[10px] px-1.5 py-0 capitalize">
-                            {pool.type}
-                          </Badge>
-                          <span className="text-[11px] text-muted-foreground whitespace-nowrap">
-                            {formatRelativeTime(new Date(pool.visitedAt))}
-                          </span>
-                        </span>
-                      </Link>
-                    </DropdownMenuItem>
-                  ))}
+                   <DropdownMenuLabel>Recent Pools</DropdownMenuLabel>
+                   <DropdownMenuSeparator />
+                   {recentPools.length === 0 ? (
+                     <div className="px-2 py-3 text-center text-sm text-muted-foreground">
+                       No recent pools yet
+                     </div>
+                   ) : (
+                     recentPools.map((pool) => (
+                       <DropdownMenuItem key={pool.contract_address || pool.id} asChild>
+                         <Link
+                           href={`/dashboard/group/${pool.id}`}
+                           className="flex w-full cursor-pointer items-center justify-between gap-2"
+                         >
+                           <span className="flex-1 truncate text-sm">{pool.name}</span>
+                           <span className="flex items-center gap-1.5">
+                             <Badge variant="secondary" className="text-[10px] px-1.5 py-0 capitalize">
+                               {pool.type}
+                             </Badge>
+                             <span className="text-[11px] text-muted-foreground whitespace-nowrap">
+                               {formatRelativeTime(new Date(pool.visitedAt))}
+                             </span>
+                           </span>
+                         </Link>
+                       </DropdownMenuItem>
+                     ))
+                   )}
                 </DropdownMenuContent>
               </DropdownMenu>
             )}


### PR DESCRIPTION
## Description

Add an empty state fallback message to the Recent Pools dropdown menu when a user has not visited any pools yet. Also adjust the conditional check so that the Recent pools button is displayed when the user is logged in, allowing them to open the dropdown even when it is empty.

Closes #106 

## Type of Change

- [x] feat: new feature
- [ ] fix: bug fix
- [ ] chore: maintenance, tooling, dependencies
- [ ] docs: documentation only
- [ ] refactor: code restructuring (no functional changes)
- [ ] test: adding or updating tests

## How Has This Been Tested?

- [ ] `cargo test` passes (smart contracts)
- [ ] `pnpm build` succeeds (frontend)
- [x] `pnpm lint` passes (frontend)
- [x] Manual testing (describe below)

Tested by opening the Recent Pools dropdown menu with an empty pools list and verifying the fallback message displays correctly. Also ran ESLint validation.

## Checklist

- [x] My code follows the coding conventions of this project
- [ ] I have added/updated tests if needed
- [ ] I have updated documentation if needed
- [x] My changes generate no new warnings or errors

## Screenshots (if applicable)