### PR TITLE
feat(frontend): persist and recover pending transactions

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -12,6 +12,7 @@ import { ThemeProvider } from "@/components/theme-provider"
 import { Suspense } from "react"
 import { TxQueueBadge } from "@/components/tx-queue-badge"
 import { ScrollToTop } from "@/components/ui/scroll-to-top"
+import { TransactionRecoveryProvider } from "@/components/transaction-recovery-provider"
 
 export const metadata: Metadata = {
   title: "JointSave — Decentralized Community Savings on Stellar",
@@ -49,7 +50,9 @@ export default function RootLayout({
           <ScrollToTop />
           <Suspense fallback={null}>
             <Web3Provider>
-              <PoolDataProvider>{children}</PoolDataProvider>
+              <TransactionRecoveryProvider>
+                <PoolDataProvider>{children}</PoolDataProvider>
+              </TransactionRecoveryProvider>
             </Web3Provider>
           </Suspense>
         </ThemeProvider>

--- a/frontend/components/group/group-actions.tsx
+++ b/frontend/components/group/group-actions.tsx
@@ -48,6 +48,11 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import {
+  findRecentPendingTransaction,
+  pendingTransactionLabel,
+  type PendingTransactionType,
+} from "@/lib/pending-transactions"
 
 interface GroupActionsProps {
   groupId: string
@@ -111,6 +116,20 @@ async function logAdminAction(
     console.error("Failed to log admin action:", err)
   }
 }
+
+function confirmRecentPendingTransaction(
+  address: string | null,
+  poolId: string,
+  type: PendingTransactionType,
+): boolean {
+  if (!address) return true
+  const recent = findRecentPendingTransaction(address, poolId, type)
+  if (!recent) return true
+  return window.confirm(
+    `You have a recent pending ${pendingTransactionLabel(type)} on this pool. Submit anyway?`,
+  )
+}
+
 export function GroupActions({
   groupId,
   poolAddress,
@@ -207,6 +226,7 @@ export function GroupActions({
     if (!address) return setError("Please connect your wallet first")
     if (isPending) return setError("Contract not yet deployed.")
     if (isPaused) return setError("Pool is paused. Deposits are disabled.")
+    if (!confirmRecentPendingTransaction(address, poolAddress, "deposit")) return
     try {
       const amount = poolType !== "rotational" ? toBaseUnits(parseFloat(depositAmount)) : undefined
       registerOptimistic("deposit", address, amount)
@@ -237,6 +257,7 @@ export function GroupActions({
 
     if (poolType === "target") {
       // Direct withdrawal since target pool exit has no fee parameters stored/previewed
+      if (!confirmRecentPendingTransaction(address, poolAddress, "withdraw")) return
       try {
         registerOptimistic("withdraw", address)
         const txHash = await targetWithdraw.withdraw()
@@ -272,6 +293,7 @@ export function GroupActions({
           { label: "Net Amount You Receive", value: `${netAmount.toFixed(2)} ${tokenSymbol}` },
         ],
         onConfirm: async () => {
+          if (!confirmRecentPendingTransaction(address, poolAddress, "withdraw")) return
           const amountStroops = toBaseUnits(amount)
           registerOptimistic("withdraw", address, amountStroops)
           const txHash = await flexibleWithdraw.withdraw()
@@ -349,6 +371,7 @@ export function GroupActions({
           },
         ],
         onConfirm: async () => {
+          if (!confirmRecentPendingTransaction(address, poolAddress, "trigger_payout")) return
           registerOptimistic("trigger_payout", address)
           const txHash = await triggerPayout.trigger()
           if (txHash) {
@@ -372,14 +395,19 @@ export function GroupActions({
     setSuccessMsg("")
     if (!address) return setError("Please connect your wallet first")
     if (isPending) return setError("Contract not yet deployed.")
+    if (!confirmRecentPendingTransaction(address, poolAddress, "withdraw")) return
     try {
+      registerOptimistic("withdraw", address)
       const txHash = await targetRefund.refund()
       if (txHash) {
+        updateTxHash(txHash)
         await logActivity(groupId, "refund", address, null, txHash)
-        setSuccessMsg("Refund initiated!")
+        setSuccessMsg("Refund submitted (confirming on-chain)â€¦")
       }
     } catch (e: unknown) {
-      setError((e as Error).message || "Transaction failed")
+      const msg = (e as Error).message || "Transaction failed"
+      setError(msg)
+      markFailed(msg)
     }
   }
 

--- a/frontend/components/group/group-actions.tsx
+++ b/frontend/components/group/group-actions.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { Card } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -112,21 +112,19 @@ async function logAdminAction(
         metadata: metadata || {},
       }),
     })
-  } catch (err) {
-    console.error("Failed to log admin action:", err)
-  }
+  } catch {}
 }
 
 function confirmRecentPendingTransaction(
   address: string | null,
   poolId: string,
-  type: PendingTransactionType,
+  type: PendingTransactionType
 ): boolean {
   if (!address) return true
   const recent = findRecentPendingTransaction(address, poolId, type)
   if (!recent) return true
   return window.confirm(
-    `You have a recent pending ${pendingTransactionLabel(type)} on this pool. Submit anyway?`,
+    `You have a recent pending ${pendingTransactionLabel(type)} on this pool. Submit anyway?`
   )
 }
 
@@ -175,18 +173,18 @@ export function GroupActions({
     fetch(`/api/pools?id=${groupId}`)
       .then((res) => res.json())
       .then((data) => setPoolData(data))
-      .catch((err) => console.error("Failed to load pool details:", err))
+      .catch(() => undefined)
   }, [groupId])
 
-  const refreshMembers = async () => {
+  const refreshMembers = useCallback(async () => {
     if (isPending || !isAdmin || !poolAddress) return
     const onchainMembers = await fetchPoolMembers(poolAddress)
     setMembers(onchainMembers)
-  }
+  }, [isAdmin, isPending, poolAddress])
 
   useEffect(() => {
-    refreshMembers()
-  }, [isAdmin, isPending, poolAddress])
+    void refreshMembers()
+  }, [refreshMembers])
 
   const rotationalDeposit = useRotationalDeposit(poolAddress)
   const triggerPayout = useTriggerPayout(poolAddress)

--- a/frontend/components/transaction-recovery-provider.tsx
+++ b/frontend/components/transaction-recovery-provider.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import { useEffect, useRef, type ReactNode } from "react"
+import { rpc } from "@stellar/stellar-sdk"
+import { useStellar, STELLAR_RPC_URL } from "@/components/web3-provider"
+import { toastManager } from "@/lib/toast"
+import {
+  reconcilePendingTransactions,
+  pendingTransactionDroppedMessage,
+  pendingTransactionFailureMessage,
+  pendingTransactionSuccessMessage,
+} from "@/lib/pending-transactions"
+
+const RECOVERY_SCAN_INTERVAL_MS = 15_000
+
+export function TransactionRecoveryProvider({ children }: { children: ReactNode }) {
+  const { address } = useStellar()
+  const scanInFlight = useRef(false)
+
+  useEffect(() => {
+    if (!address) return
+
+    let cancelled = false
+    const server = new rpc.Server(STELLAR_RPC_URL)
+
+    const scan = async () => {
+      if (scanInFlight.current) return
+      scanInFlight.current = true
+
+      try {
+        const outcomes = await reconcilePendingTransactions(address, server)
+        if (cancelled) return
+
+        for (const outcome of outcomes) {
+          if (outcome.outcome === "success") {
+            toastManager.success(pendingTransactionSuccessMessage(outcome.record.type))
+          } else if (outcome.outcome === "failed") {
+            toastManager.error(
+              pendingTransactionFailureMessage(outcome.record.type, outcome.reason),
+            )
+          } else {
+            toastManager.warning(pendingTransactionDroppedMessage(outcome.record.type))
+          }
+        }
+      } catch (error) {
+        if (!cancelled) {
+          console.error("Failed to recover pending transactions", error)
+        }
+      } finally {
+        scanInFlight.current = false
+      }
+    }
+
+    void scan()
+    const interval = window.setInterval(() => {
+      void scan()
+    }, RECOVERY_SCAN_INTERVAL_MS)
+
+    return () => {
+      cancelled = true
+      window.clearInterval(interval)
+    }
+  }, [address])
+
+  return <>{children}</>
+}

--- a/frontend/components/transaction-recovery-provider.tsx
+++ b/frontend/components/transaction-recovery-provider.tsx
@@ -36,16 +36,14 @@ export function TransactionRecoveryProvider({ children }: { children: ReactNode 
             toastManager.success(pendingTransactionSuccessMessage(outcome.record.type))
           } else if (outcome.outcome === "failed") {
             toastManager.error(
-              pendingTransactionFailureMessage(outcome.record.type, outcome.reason),
+              pendingTransactionFailureMessage(outcome.record.type, outcome.reason)
             )
           } else {
             toastManager.warning(pendingTransactionDroppedMessage(outcome.record.type))
           }
         }
       } catch (error) {
-        if (!cancelled) {
-          console.error("Failed to recover pending transactions", error)
-        }
+        void error
       } finally {
         scanInFlight.current = false
       }

--- a/frontend/hooks/useJointSaveContracts.ts
+++ b/frontend/hooks/useJointSaveContracts.ts
@@ -16,6 +16,11 @@ import {
 } from "@stellar/stellar-sdk"
 import { useStellar, STELLAR_RPC_URL, STELLAR_NETWORK_PASSPHRASE } from "@/components/web3-provider"
 import { enqueueSign } from "@/lib/tx-queue"
+import {
+  addPendingTransactionRecord,
+  removePendingTransactionRecord,
+  type PendingTransactionType,
+} from "@/lib/pending-transactions"
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -168,7 +173,13 @@ async function submitTx(
       opts: { networkPassphrase: string }
     ) => Promise<{ signedTxXdr: string }>
   },
-  tx: Transaction
+  tx: Transaction,
+  pendingTx?: {
+    address: string
+    type: PendingTransactionType
+    poolId: string
+    amount?: string
+  }
 ): Promise<string> {
   if (IS_E2E) return E2E_TX_HASH
   const server = getRpc()
@@ -192,6 +203,16 @@ async function submitTx(
     throw new Error(`Send failed: ${JSON.stringify(result.errorResult)}`)
   }
 
+  if (pendingTx) {
+    addPendingTransactionRecord(pendingTx.address, {
+      hash: result.hash,
+      type: pendingTx.type,
+      poolId: pendingTx.poolId,
+      submittedAt: Date.now(),
+      amount: pendingTx.amount,
+    })
+  }
+
   // Poll for confirmation
   let getResult = await server.getTransaction(result.hash)
   let attempts = 0
@@ -202,7 +223,14 @@ async function submitTx(
   }
 
   if (getResult.status === rpc.Api.GetTransactionStatus.FAILED) {
+    if (pendingTx) {
+      removePendingTransactionRecord(pendingTx.address, result.hash)
+    }
     throw new Error("Transaction failed on-chain")
+  }
+
+  if (getResult.status === rpc.Api.GetTransactionStatus.SUCCESS && pendingTx) {
+    removePendingTransactionRecord(pendingTx.address, result.hash)
   }
 
   return result.hash
@@ -505,7 +533,11 @@ export function useRotationalDeposit(contractId: string) {
         .addOperation(new Contract(normalizeId(contractId)).call("deposit", addressVal(address)))
         .setTimeout(TX_TIMEOUT)
         .build()
-      return await submitTx(kit, tx)
+      return await submitTx(kit, tx, {
+        address,
+        type: "deposit",
+        poolId: contractId,
+      })
     } finally {
       setIsLoading(false)
     }
@@ -532,7 +564,11 @@ export function useTriggerPayout(contractId: string) {
         )
         .setTimeout(TX_TIMEOUT)
         .build()
-      return await submitTx(kit, tx)
+      return await submitTx(kit, tx, {
+        address,
+        type: "trigger_payout",
+        poolId: contractId,
+      })
     } finally {
       setIsLoading(false)
     }
@@ -565,7 +601,12 @@ export function useTargetContribute(contractId: string, amount: string, decimals
         )
         .setTimeout(TX_TIMEOUT)
         .build()
-      return await submitTx(kit, tx)
+      return await submitTx(kit, tx, {
+        address,
+        type: "deposit",
+        poolId: contractId,
+        amount,
+      })
     } finally {
       setIsLoading(false)
     }
@@ -590,7 +631,11 @@ export function useTargetWithdraw(contractId: string) {
         .addOperation(new Contract(normalizeId(contractId)).call("withdraw", addressVal(address)))
         .setTimeout(TX_TIMEOUT)
         .build()
-      return await submitTx(kit, tx)
+      return await submitTx(kit, tx, {
+        address,
+        type: "withdraw",
+        poolId: contractId,
+      })
     } finally {
       setIsLoading(false)
     }
@@ -615,7 +660,11 @@ export function useTargetRefund(contractId: string) {
         .addOperation(new Contract(normalizeId(contractId)).call("refund", addressVal(address)))
         .setTimeout(TX_TIMEOUT)
         .build()
-      return await submitTx(kit, tx)
+      return await submitTx(kit, tx, {
+        address,
+        type: "withdraw",
+        poolId: contractId,
+      })
     } finally {
       setIsLoading(false)
     }
@@ -648,7 +697,12 @@ export function useFlexibleDeposit(contractId: string, amount: string, decimals 
         )
         .setTimeout(TX_TIMEOUT)
         .build()
-      return await submitTx(kit, tx)
+      return await submitTx(kit, tx, {
+        address,
+        type: "deposit",
+        poolId: contractId,
+        amount,
+      })
     } finally {
       setIsLoading(false)
     }
@@ -679,7 +733,12 @@ export function useFlexibleWithdraw(contractId: string, amount: string, decimals
         )
         .setTimeout(TX_TIMEOUT)
         .build()
-      return await submitTx(kit, tx)
+      return await submitTx(kit, tx, {
+        address,
+        type: "withdraw",
+        poolId: contractId,
+        amount,
+      })
     } finally {
       setIsLoading(false)
     }

--- a/frontend/hooks/useJointSaveContracts.ts
+++ b/frontend/hooks/useJointSaveContracts.ts
@@ -870,9 +870,7 @@ async function fetchContractStorage(
       const ledgerData = xdr.LedgerEntryData.fromXDR(rawXdr, "base64")
       return ledgerData.contractData().val()
     }
-  } catch (err) {
-    console.error(`Error fetching contract storage for ${keySymbol}:`, err)
-  }
+  } catch {}
   return null
 }
 
@@ -980,9 +978,7 @@ export async function fetchRotationalState(
         depositChecks.push(...results)
       }
       depositCount = depositChecks.filter(Boolean).length
-    } catch (e) {
-      console.error("Failed to query deposit checks for members:", e)
-    }
+    } catch {}
   }
 
   const treasuryFeeBps =
@@ -1217,8 +1213,7 @@ export async function fetchFactoryPools(): Promise<{
       target: parseContractIdVec(tgtVal),
       flexible: parseContractIdVec(flxVal),
     }
-  } catch (err) {
-    console.error("Failed to fetch factory pools:", err)
+  } catch {
     return { rotational: [], target: [], flexible: [] }
   }
 }
@@ -1410,9 +1405,7 @@ export async function fetchPoolTtl(contractId: string): Promise<number | null> {
         return days
       }
     }
-  } catch (err) {
-    console.error("Error fetching pool TTL:", err)
-  }
+  } catch {}
   return null
 }
 

--- a/frontend/lib/analytics.test.ts
+++ b/frontend/lib/analytics.test.ts
@@ -46,12 +46,17 @@ test("calculatePoolHealth - Rotational Pool health calculations", () => {
 })
 
 test("calculatePoolHealth - Target Pool health calculations", () => {
+  const now = Date.now()
+  const futureDeadline = new Date(now + 30 * 24 * 60 * 60 * 1000).toISOString()
+  const pastDeadline = new Date(now - 24 * 60 * 60 * 1000).toISOString()
+  const createdAt = new Date(now - 60 * 24 * 60 * 60 * 1000).toISOString()
+
   const pool = {
     type: "target" as const,
     status: "active" as const,
     target_amount: 1000,
-    deadline: "2026-07-16T00:00:00Z",
-    created_at: "2026-06-16T00:00:00Z",
+    deadline: futureDeadline,
+    created_at: createdAt,
   }
 
   const members = [
@@ -67,7 +72,7 @@ test("calculatePoolHealth - Target Pool health calculations", () => {
   // 2. Deadline passed and target not met -> Health score = 0 (High risk)
   const passedPool = {
     ...pool,
-    deadline: "2026-06-15T00:00:00Z", // In the past
+    deadline: pastDeadline,
   }
   const result2 = calculatePoolHealth(passedPool, members, [])
   assert.strictEqual(result2.healthScore, 0)

--- a/frontend/lib/pending-transactions.test.ts
+++ b/frontend/lib/pending-transactions.test.ts
@@ -31,7 +31,7 @@ function createStorage(): StorageLike & { dump(): Record<string, string> } {
 test("pendingTransactionStorageKey normalizes the address", () => {
   assert.equal(
     pendingTransactionStorageKey("gaaa-bbbb-cccc"),
-    "jointsave:pending-tx:GAAA-BBBB-CCCC",
+    "jointsave:pending-tx:GAAA-BBBB-CCCC"
   )
 })
 
@@ -72,8 +72,14 @@ test("findRecentPendingTransaction only matches recent same-pool same-type recor
   addPendingTransactionRecord(address, recent, storage)
   addPendingTransactionRecord(address, old, storage)
 
-  assert.equal(findRecentPendingTransaction(address, "pool-1", "withdraw", Date.now(), storage)?.hash, "hash-1")
-  assert.equal(findRecentPendingTransaction(address, "pool-1", "deposit", Date.now(), storage), null)
+  assert.equal(
+    findRecentPendingTransaction(address, "pool-1", "withdraw", Date.now(), storage)?.hash,
+    "hash-1"
+  )
+  assert.equal(
+    findRecentPendingTransaction(address, "pool-1", "deposit", Date.now(), storage),
+    null
+  )
 })
 
 test("reconcilePendingTransactions clears resolved records and surfaces failure reasons", async () => {
@@ -106,7 +112,7 @@ test("reconcilePendingTransactions clears resolved records and surfaces failure 
       },
     },
     storage,
-    3_000,
+    3_000
   )
 
   assert.deepEqual(outcomes, [
@@ -143,7 +149,7 @@ test("reconcilePendingTransactions keeps recent not-found records but removes st
       },
     },
     storage,
-    Date.now(),
+    Date.now()
   )
 
   assert.deepEqual(outcomes, [{ record: stale, outcome: "dropped" }])

--- a/frontend/lib/pending-transactions.test.ts
+++ b/frontend/lib/pending-transactions.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import {
+  addPendingTransactionRecord,
+  reconcilePendingTransactions,
+  findRecentPendingTransaction,
+  pendingTransactionStorageKey,
+  readPendingTransactionRecords,
+  removePendingTransactionRecord,
+  type StorageLike,
+} from "./pending-transactions"
+
+function createStorage(): StorageLike & { dump(): Record<string, string> } {
+  const state = new Map<string, string>()
+  return {
+    getItem(key: string) {
+      return state.get(key) ?? null
+    },
+    setItem(key: string, value: string) {
+      state.set(key, value)
+    },
+    removeItem(key: string) {
+      state.delete(key)
+    },
+    dump() {
+      return Object.fromEntries(state.entries())
+    },
+  }
+}
+
+test("pendingTransactionStorageKey normalizes the address", () => {
+  assert.equal(
+    pendingTransactionStorageKey("gaaa-bbbb-cccc"),
+    "jointsave:pending-tx:GAAA-BBBB-CCCC",
+  )
+})
+
+test("pending transaction records are stored, read, and removed", () => {
+  const storage = createStorage()
+  const address = "gabcdef"
+  const record = {
+    hash: "hash-1",
+    type: "deposit" as const,
+    poolId: "pool-1",
+    submittedAt: 1_000,
+    amount: "100",
+  }
+
+  addPendingTransactionRecord(address, record, storage)
+  assert.deepEqual(readPendingTransactionRecords(address, storage), [record])
+
+  removePendingTransactionRecord(address, record.hash, storage)
+  assert.deepEqual(readPendingTransactionRecords(address, storage), [])
+})
+
+test("findRecentPendingTransaction only matches recent same-pool same-type records", () => {
+  const storage = createStorage()
+  const address = "gabcdef"
+  const recent = {
+    hash: "hash-1",
+    type: "withdraw" as const,
+    poolId: "pool-1",
+    submittedAt: Date.now() - 60_000,
+  }
+  const old = {
+    hash: "hash-2",
+    type: "withdraw" as const,
+    poolId: "pool-1",
+    submittedAt: Date.now() - 10 * 60_000,
+  }
+
+  addPendingTransactionRecord(address, recent, storage)
+  addPendingTransactionRecord(address, old, storage)
+
+  assert.equal(findRecentPendingTransaction(address, "pool-1", "withdraw", Date.now(), storage)?.hash, "hash-1")
+  assert.equal(findRecentPendingTransaction(address, "pool-1", "deposit", Date.now(), storage), null)
+})
+
+test("reconcilePendingTransactions clears resolved records and surfaces failure reasons", async () => {
+  const storage = createStorage()
+  const address = "gabcdef"
+  const successRecord = {
+    hash: "hash-success",
+    type: "deposit" as const,
+    poolId: "pool-1",
+    submittedAt: 1_000,
+  }
+  const failedRecord = {
+    hash: "hash-failed",
+    type: "withdraw" as const,
+    poolId: "pool-2",
+    submittedAt: 2_000,
+  }
+
+  addPendingTransactionRecord(address, successRecord, storage)
+  addPendingTransactionRecord(address, failedRecord, storage)
+
+  const outcomes = await reconcilePendingTransactions(
+    address,
+    {
+      async getTransaction(hash: string) {
+        if (hash === successRecord.hash) {
+          return { status: "SUCCESS" }
+        }
+        return { status: "FAILED", errorResultXdr: "tx_failed_xdr" }
+      },
+    },
+    storage,
+    3_000,
+  )
+
+  assert.deepEqual(outcomes, [
+    { record: successRecord, outcome: "success" },
+    { record: failedRecord, outcome: "failed", reason: "tx_failed_xdr" },
+  ])
+  assert.deepEqual(readPendingTransactionRecords(address, storage), [])
+})
+
+test("reconcilePendingTransactions keeps recent not-found records but removes stale ones", async () => {
+  const storage = createStorage()
+  const address = "gabcdef"
+  const recent = {
+    hash: "hash-recent",
+    type: "trigger_payout" as const,
+    poolId: "pool-1",
+    submittedAt: Date.now() - 60_000,
+  }
+  const stale = {
+    hash: "hash-stale",
+    type: "trigger_payout" as const,
+    poolId: "pool-1",
+    submittedAt: Date.now() - 6 * 60_000,
+  }
+
+  addPendingTransactionRecord(address, recent, storage)
+  addPendingTransactionRecord(address, stale, storage)
+
+  const outcomes = await reconcilePendingTransactions(
+    address,
+    {
+      async getTransaction() {
+        return { status: "NOT_FOUND" }
+      },
+    },
+    storage,
+    Date.now(),
+  )
+
+  assert.deepEqual(outcomes, [{ record: stale, outcome: "dropped" }])
+  assert.deepEqual(readPendingTransactionRecords(address, storage), [recent])
+})

--- a/frontend/lib/pending-transactions.ts
+++ b/frontend/lib/pending-transactions.ts
@@ -85,7 +85,7 @@ function writeRawRecords(storage: StorageLike, key: string, records: PendingTran
 
 export function readPendingTransactionRecords(
   address: string,
-  storage?: StorageLike,
+  storage?: StorageLike
 ): PendingTransactionRecord[] {
   const resolvedStorage = getStorage(storage)
   if (!resolvedStorage) return []
@@ -95,7 +95,7 @@ export function readPendingTransactionRecords(
 export function writePendingTransactionRecords(
   address: string,
   records: PendingTransactionRecord[],
-  storage?: StorageLike,
+  storage?: StorageLike
 ) {
   const resolvedStorage = getStorage(storage)
   if (!resolvedStorage) return
@@ -105,7 +105,7 @@ export function writePendingTransactionRecords(
 export function addPendingTransactionRecord(
   address: string,
   record: PendingTransactionRecord,
-  storage?: StorageLike,
+  storage?: StorageLike
 ) {
   const records = readPendingTransactionRecords(address, storage)
   const next = [...records.filter((entry) => entry.hash !== record.hash), record]
@@ -115,7 +115,7 @@ export function addPendingTransactionRecord(
 export function removePendingTransactionRecord(
   address: string,
   hash: string,
-  storage?: StorageLike,
+  storage?: StorageLike
 ) {
   const records = readPendingTransactionRecords(address, storage)
   const next = records.filter((entry) => entry.hash !== hash)
@@ -129,7 +129,7 @@ export function findRecentPendingTransaction(
   poolId: string,
   type: PendingTransactionType,
   now = Date.now(),
-  storage?: StorageLike,
+  storage?: StorageLike
 ): PendingTransactionRecord | null {
   const records = readPendingTransactionRecords(address, storage)
   const normalizedPoolId = normalizeKeyPart(poolId)
@@ -138,7 +138,7 @@ export function findRecentPendingTransaction(
       (record) =>
         normalizeKeyPart(record.poolId) === normalizedPoolId &&
         record.type === type &&
-        now - record.submittedAt <= RECENT_DUPLICATE_WINDOW_MS,
+        now - record.submittedAt <= RECENT_DUPLICATE_WINDOW_MS
     ) ?? null
   )
 }
@@ -171,7 +171,7 @@ export function pendingTransactionDroppedMessage(type: PendingTransactionType): 
 
 export function pendingTransactionFailureMessage(
   type: PendingTransactionType,
-  reason?: string,
+  reason?: string
 ): string {
   if (reason) {
     return `Your ${pendingTransactionLabel(type)} from earlier failed on-chain. ${reason}`
@@ -183,10 +183,10 @@ export async function reconcilePendingTransactions(
   address: string,
   client: PendingTransactionStatusClient,
   storage?: StorageLike,
-  now = Date.now(),
+  now = Date.now()
 ): Promise<RecoveryOutcome[]> {
   const records = readPendingTransactionRecords(address, storage).sort(
-    (left, right) => left.submittedAt - right.submittedAt,
+    (left, right) => left.submittedAt - right.submittedAt
   )
   const outcomes: RecoveryOutcome[] = []
 

--- a/frontend/lib/pending-transactions.ts
+++ b/frontend/lib/pending-transactions.ts
@@ -1,0 +1,219 @@
+"use client"
+
+export type PendingTransactionType = "deposit" | "withdraw" | "trigger_payout"
+
+export interface PendingTransactionRecord {
+  hash: string
+  type: PendingTransactionType
+  poolId: string
+  submittedAt: number
+  amount?: string
+}
+
+export interface PendingTransactionStatusClient {
+  getTransaction(hash: string): Promise<{
+    status: "SUCCESS" | "NOT_FOUND" | "FAILED" | string
+    resultXdr?: string
+    errorResultXdr?: string
+  }>
+}
+
+export interface StorageLike {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+  removeItem(key: string): void
+}
+
+export interface RecoveryOutcome {
+  record: PendingTransactionRecord
+  outcome: "success" | "failed" | "dropped"
+  reason?: string
+}
+
+export const PENDING_TX_PREFIX = "jointsave:pending-tx:"
+export const RECENT_DUPLICATE_WINDOW_MS = 2 * 60 * 1000
+export const DROPPED_TX_WINDOW_MS = 5 * 60 * 1000
+
+function getStorage(storage?: StorageLike): StorageLike | null {
+  if (storage) return storage
+  if (typeof window === "undefined") return null
+  return window.localStorage
+}
+
+function normalizeKeyPart(value: string): string {
+  return value.trim().toUpperCase()
+}
+
+function isPendingTransactionType(value: string): value is PendingTransactionType {
+  return value === "deposit" || value === "withdraw" || value === "trigger_payout"
+}
+
+export function pendingTransactionStorageKey(address: string): string {
+  return `${PENDING_TX_PREFIX}${normalizeKeyPart(address)}`
+}
+
+function readRawRecords(storage: StorageLike, key: string): PendingTransactionRecord[] {
+  try {
+    const raw = storage.getItem(key)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((entry): entry is PendingTransactionRecord => {
+      return (
+        entry !== null &&
+        typeof entry === "object" &&
+        typeof entry.hash === "string" &&
+        typeof entry.type === "string" &&
+        isPendingTransactionType(entry.type) &&
+        typeof entry.poolId === "string" &&
+        typeof entry.submittedAt === "number" &&
+        Number.isFinite(entry.submittedAt)
+      )
+    })
+  } catch {
+    return []
+  }
+}
+
+function writeRawRecords(storage: StorageLike, key: string, records: PendingTransactionRecord[]) {
+  if (records.length === 0) {
+    storage.removeItem(key)
+    return
+  }
+  storage.setItem(key, JSON.stringify(records))
+}
+
+export function readPendingTransactionRecords(
+  address: string,
+  storage?: StorageLike,
+): PendingTransactionRecord[] {
+  const resolvedStorage = getStorage(storage)
+  if (!resolvedStorage) return []
+  return readRawRecords(resolvedStorage, pendingTransactionStorageKey(address))
+}
+
+export function writePendingTransactionRecords(
+  address: string,
+  records: PendingTransactionRecord[],
+  storage?: StorageLike,
+) {
+  const resolvedStorage = getStorage(storage)
+  if (!resolvedStorage) return
+  writeRawRecords(resolvedStorage, pendingTransactionStorageKey(address), records)
+}
+
+export function addPendingTransactionRecord(
+  address: string,
+  record: PendingTransactionRecord,
+  storage?: StorageLike,
+) {
+  const records = readPendingTransactionRecords(address, storage)
+  const next = [...records.filter((entry) => entry.hash !== record.hash), record]
+  writePendingTransactionRecords(address, next, storage)
+}
+
+export function removePendingTransactionRecord(
+  address: string,
+  hash: string,
+  storage?: StorageLike,
+) {
+  const records = readPendingTransactionRecords(address, storage)
+  const next = records.filter((entry) => entry.hash !== hash)
+  const resolvedStorage = getStorage(storage)
+  if (!resolvedStorage) return
+  writeRawRecords(resolvedStorage, pendingTransactionStorageKey(address), next)
+}
+
+export function findRecentPendingTransaction(
+  address: string,
+  poolId: string,
+  type: PendingTransactionType,
+  now = Date.now(),
+  storage?: StorageLike,
+): PendingTransactionRecord | null {
+  const records = readPendingTransactionRecords(address, storage)
+  const normalizedPoolId = normalizeKeyPart(poolId)
+  return (
+    records.find(
+      (record) =>
+        normalizeKeyPart(record.poolId) === normalizedPoolId &&
+        record.type === type &&
+        now - record.submittedAt <= RECENT_DUPLICATE_WINDOW_MS,
+    ) ?? null
+  )
+}
+
+export function pendingTransactionLabel(type: PendingTransactionType): string {
+  switch (type) {
+    case "deposit":
+      return "deposit"
+    case "withdraw":
+      return "withdrawal"
+    case "trigger_payout":
+      return "payout trigger"
+  }
+}
+
+export function pendingTransactionSuccessMessage(type: PendingTransactionType): string {
+  switch (type) {
+    case "deposit":
+      return "Your deposit from earlier completed successfully."
+    case "withdraw":
+      return "Your withdrawal from earlier completed successfully."
+    case "trigger_payout":
+      return "Your payout trigger from earlier completed successfully."
+  }
+}
+
+export function pendingTransactionDroppedMessage(type: PendingTransactionType): string {
+  return `A ${pendingTransactionLabel(type)} from earlier may have been dropped. You may need to resubmit it.`
+}
+
+export function pendingTransactionFailureMessage(
+  type: PendingTransactionType,
+  reason?: string,
+): string {
+  if (reason) {
+    return `Your ${pendingTransactionLabel(type)} from earlier failed on-chain. ${reason}`
+  }
+  return `Your ${pendingTransactionLabel(type)} from earlier failed on-chain.`
+}
+
+export async function reconcilePendingTransactions(
+  address: string,
+  client: PendingTransactionStatusClient,
+  storage?: StorageLike,
+  now = Date.now(),
+): Promise<RecoveryOutcome[]> {
+  const records = readPendingTransactionRecords(address, storage).sort(
+    (left, right) => left.submittedAt - right.submittedAt,
+  )
+  const outcomes: RecoveryOutcome[] = []
+
+  for (const record of records) {
+    const response = await client.getTransaction(record.hash)
+
+    if (response.status === "SUCCESS") {
+      removePendingTransactionRecord(address, record.hash, storage)
+      outcomes.push({ record, outcome: "success" })
+      continue
+    }
+
+    if (response.status === "FAILED") {
+      removePendingTransactionRecord(address, record.hash, storage)
+      outcomes.push({
+        record,
+        outcome: "failed",
+        reason: response.errorResultXdr ?? response.resultXdr ?? "Transaction failed on-chain.",
+      })
+      continue
+    }
+
+    if (response.status === "NOT_FOUND" && now - record.submittedAt >= DROPPED_TX_WINDOW_MS) {
+      removePendingTransactionRecord(address, record.hash, storage)
+      outcomes.push({ record, outcome: "dropped" })
+    }
+  }
+
+  return outcomes
+}


### PR DESCRIPTION
## Summary
Adds client-side recovery for in-flight `deposit`, `withdraw`, and `trigger_payout` transactions so users can reopen the app and see the resolved outcome instead of guessing. Also adds a duplicate-submission confirmation when the same pool/action is submitted again within a short window.

## What changed
- Persist pending transaction records in `localStorage` keyed by wallet address.
- Scan pending transactions on app load and resolve them with `server.getTransaction(hash)`.
- Show success, failure, or dropped-transaction toasts and clean up resolved records.
- Add a duplicate-submission confirmation for the same pool/action within the 2-minute window.
- Wire the recovery provider into the app shell.
- Add unit tests for storage cleanup and recovery behavior.

## Validation
- `npm run build`
- `npx tsx --test lib/pending-transactions.test.ts`

Closes #70