### PR TITLE
feat: duplicate pool / start new cycle action for pool admins

### DIFF
--- a/frontend/app/dashboard/create/[type]/page.tsx
+++ b/frontend/app/dashboard/create/[type]/page.tsx
@@ -17,7 +17,12 @@ const validTypes = ["rotational", "target", "flexible"]
 export interface DuplicatePrefill {
   name: string
   description: string
+  /** Rotational: per-round contribution amount */
   amount: string
+  /** Target pool: total savings goal */
+  targetAmount: string
+  /** Flexible pool: minimum deposit per transaction */
+  minimumDeposit: string
   frequency: string
   members: string[]
   token: string
@@ -40,6 +45,8 @@ export default function CreateGroupPage({ params }: { params: Promise<{ type: st
         name: decodeURIComponent(searchParams.get("name") || ""),
         description: decodeURIComponent(searchParams.get("description") || ""),
         amount: searchParams.get("amount") || "",
+        targetAmount: searchParams.get("targetAmount") || "",
+        minimumDeposit: searchParams.get("minimumDeposit") || "",
         frequency: searchParams.get("frequency") || "",
         members,
         token: searchParams.get("token") || "XLM",

--- a/frontend/app/dashboard/group/[id]/GroupClient.tsx
+++ b/frontend/app/dashboard/group/[id]/GroupClient.tsx
@@ -106,7 +106,7 @@ export default function GroupClient({ params }: { params: Promise<{ id: string }
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           {/* ── Left column: details + timeline + activity ──────────────── */}
           <div className="lg:col-span-2 space-y-6">
-            <GroupDetails groupId={id} contractAddress={cacheKey} />
+            <GroupDetails groupId={id} contractAddress={cacheKey} poolAdmin={poolAdmin} />
             {pool.type === "rotational" && (
               <RotationalTimelineContainer groupId={id} contractAddress={cacheKey} />
             )}

--- a/frontend/app/dashboard/group/[id]/page.tsx
+++ b/frontend/app/dashboard/group/[id]/page.tsx
@@ -100,7 +100,7 @@ export default function GroupPage({ params }: { params: Promise<{ id: string }> 
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           <div className="lg:col-span-2 space-y-6">
-            <GroupDetails groupId={id} contractAddress={cacheKey} />
+            <GroupDetails groupId={id} contractAddress={cacheKey} poolAdmin={poolAdmin} />
             <GroupActivity groupId={id} contractAddress={cacheKey} startLedger={0} />
             {/* Admin audit log with CSV export — only shown to the pool creator */}
             <AdminAuditLog groupId={id} creatorAddress={pool.creator_address} />

--- a/frontend/components/create-group/flexible-form.tsx
+++ b/frontend/components/create-group/flexible-form.tsx
@@ -5,7 +5,7 @@ import { useState, useCallback, useRef, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
-import { Plus, X, Loader2, AlertCircle } from "lucide-react"
+import { Plus, X, Loader2, AlertCircle, CopyPlus } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useStellar } from "@/components/web3-provider"
 import {
@@ -27,6 +27,7 @@ import {
   findDuplicateAddresses,
 } from "@/lib/form-validation"
 import { MAX_POOL_MEMBERS } from "@/lib/constants"
+import type { DuplicatePrefill } from "@/app/dashboard/create/[type]/page"
 
 function isValidStellarAddress(addr: string) {
   return /^G[A-Z2-7]{55}$/.test(addr)
@@ -37,23 +38,26 @@ const TREASURY = process.env.NEXT_PUBLIC_FACTORY_CONTRACT_ID || ""
 type FieldErrors = Partial<Record<"name" | "minimumDeposit" | "withdrawalFee", string>>
 type Touched = Partial<Record<"name" | "minimumDeposit" | "withdrawalFee", boolean>>
 
-export function FlexibleForm() {
+export function FlexibleForm({ prefill }: { prefill?: DuplicatePrefill }) {
   const router = useRouter()
   const { address } = useStellar()
   const [token, setToken] = useState<SelectedToken>({
     address: "native",
-    symbol: "XLM",
+    symbol: prefill?.token || "XLM",
     decimals: 7,
   })
-  const [members, setMembers] = useState<string[]>([""])
+  const initialMembers = prefill?.members?.filter((m: string) => m !== address) ?? [""]
+  const [members, setMembers] = useState<string[]>(
+    initialMembers.length > 0 ? initialMembers : [""]
+  )
   const [error, setError] = useState("")
   const [step, setStep] = useState<
     "idle" | "deploying" | "initializing" | "registering" | "saving"
   >("idle")
   const [formData, setFormData] = useState({
-    name: "",
-    description: "",
-    minimumDeposit: "",
+    name: prefill?.name || "",
+    description: prefill?.description || "",
+    minimumDeposit: prefill?.minimumDeposit || "",
     enableYield: false,
     withdrawalFee: "1",
   })
@@ -227,6 +231,16 @@ export function FlexibleForm() {
       )}
 
       <FormProgress fields={progressFields} />
+
+      {prefill && (
+        <div className="flex items-start gap-2 p-3 rounded-lg bg-primary/5 border border-primary/20 text-sm text-muted-foreground">
+          <CopyPlus className="h-4 w-4 mt-0.5 shrink-0 text-primary" />
+          <span>
+            Pre-filled from the original pool — all values are editable. Submitting will deploy a{" "}
+            <strong>new, independent contract</strong> with no connection to the original.
+          </span>
+        </div>
+      )}
 
       <div className="space-y-1">
         <div className="flex items-center justify-between">

--- a/frontend/components/create-group/target-form.tsx
+++ b/frontend/components/create-group/target-form.tsx
@@ -5,7 +5,7 @@ import { useState, useCallback, useRef, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
-import { Plus, X, Loader2, AlertCircle, Info } from "lucide-react"
+import { Plus, X, Loader2, AlertCircle, Info, CopyPlus } from "lucide-react"
 import { useRouter } from "next/navigation"
 import { useStellar } from "@/components/web3-provider"
 import {
@@ -27,6 +27,7 @@ import {
   findDuplicateAddresses,
 } from "@/lib/form-validation"
 import { MAX_POOL_MEMBERS } from "@/lib/constants"
+import type { DuplicatePrefill } from "@/app/dashboard/create/[type]/page"
 
 function isValidStellarAddress(addr: string) {
   return /^G[A-Z2-7]{55}$/.test(addr)
@@ -42,23 +43,26 @@ function daysToLedgers(days: number): number {
 type FieldErrors = Partial<Record<"name" | "targetAmount" | "deadlineDays", string>>
 type Touched = Partial<Record<"name" | "targetAmount" | "deadlineDays", boolean>>
 
-export function TargetForm() {
+export function TargetForm({ prefill }: { prefill?: DuplicatePrefill }) {
   const router = useRouter()
   const { address } = useStellar()
   const [token, setToken] = useState<SelectedToken>({
     address: "native",
-    symbol: "XLM",
+    symbol: prefill?.token || "XLM",
     decimals: 7,
   })
-  const [members, setMembers] = useState<string[]>([""])
+  const initialMembers = prefill?.members?.filter((m: string) => m !== address) ?? [""]
+  const [members, setMembers] = useState<string[]>(
+    initialMembers.length > 0 ? initialMembers : [""]
+  )
   const [error, setError] = useState("")
   const [step, setStep] = useState<
     "idle" | "deploying" | "initializing" | "registering" | "saving"
   >("idle")
   const [formData, setFormData] = useState({
-    name: "",
-    description: "",
-    targetAmount: "",
+    name: prefill?.name || "",
+    description: prefill?.description || "",
+    targetAmount: prefill?.targetAmount || "",
     deadlineDays: "",
   })
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({})
@@ -261,6 +265,16 @@ export function TargetForm() {
       )}
 
       <FormProgress fields={progressFields} />
+
+      {prefill && (
+        <div className="flex items-start gap-2 p-3 rounded-lg bg-primary/5 border border-primary/20 text-sm text-muted-foreground">
+          <CopyPlus className="h-4 w-4 mt-0.5 shrink-0 text-primary" />
+          <span>
+            Pre-filled from the original pool — all values are editable. Submitting will deploy a{" "}
+            <strong>new, independent contract</strong> with no connection to the original.
+          </span>
+        </div>
+      )}
 
       <div className="space-y-1">
         <div className="flex items-center justify-between">

--- a/frontend/components/group/group-details.tsx
+++ b/frontend/components/group/group-details.tsx
@@ -388,6 +388,27 @@ export function GroupDetails({ groupId, contractAddress, poolAdmin }: GroupDetai
   const hasLowMemberCount =
     group.type === "rotational" && (group.members_count ?? 0) <= LOW_MEMBER_THRESHOLD
 
+  const duplicateMemberAddresses =
+    group.pool_members?.map((m) => m.member_address) ?? group.members ?? []
+  let duplicateTypeParams = ""
+  if (group.type === "rotational") {
+    duplicateTypeParams = `&amount=${group.contribution_amount || ""}&frequency=${encodeURIComponent(group.frequency || "weekly")}`
+  } else if (group.type === "target") {
+    duplicateTypeParams = `&targetAmount=${group.target_amount || ""}`
+  } else {
+    duplicateTypeParams = `&minimumDeposit=${group.minimum_deposit ?? group.contribution_amount ?? ""}`
+  }
+  const duplicateHref =
+    `/dashboard/create/${group.type}?duplicate=1` +
+    `&name=${encodeURIComponent(group.name)}` +
+    `&description=${encodeURIComponent(group.description || "")}` +
+    `&members=${encodeURIComponent(JSON.stringify(duplicateMemberAddresses))}` +
+    `&token=${encodeURIComponent(group.token_symbol || "XLM")}` +
+    duplicateTypeParams
+
+  const showDuplicateButton =
+    !isPending(group.contract_address) && group.status !== "pending" && isAdmin
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
@@ -515,36 +536,23 @@ export function GroupDetails({ groupId, contractAddress, poolAdmin }: GroupDetai
           </div>
         )}
 
-        {!isPending(group.contract_address) && group.status !== "pending" && isAdmin && (() => {
-          const memberAddresses = group.pool_members?.map((m) => m.member_address) ?? group.members ?? []
-          const base = `/dashboard/create/${group.type}?duplicate=1`
-            + `&name=${encodeURIComponent(group.name)}`
-            + `&description=${encodeURIComponent(group.description || "")}`
-            + `&members=${encodeURIComponent(JSON.stringify(memberAddresses))}`
-            + `&token=${encodeURIComponent(group.token_symbol || "XLM")}`
-          const typeParams =
-            group.type === "rotational"
-              ? `&amount=${group.contribution_amount || ""}&frequency=${encodeURIComponent(group.frequency || "weekly")}`
-              : group.type === "target"
-              ? `&targetAmount=${group.target_amount || ""}`
-              : `&minimumDeposit=${group.minimum_deposit ?? group.contribution_amount ?? ""}`
-          return (
-            <div className="mb-4 space-y-2">
-              <div className="flex items-start gap-2 p-3 rounded-lg bg-primary/5 border border-primary/20 text-sm text-muted-foreground">
-                <CopyPlus className="h-4 w-4 mt-0.5 shrink-0 text-primary" />
-                <span>
-                  Starting a new cycle deploys a <strong>fresh, independent contract</strong> — the original pool is unaffected.
-                </span>
-              </div>
-              <Button variant="outline" size="sm" className="w-full gap-2" asChild>
-                <Link href={base + typeParams}>
-                  <CopyPlus className="h-4 w-4" />
-                  Start New Cycle / Duplicate Pool
-                </Link>
-              </Button>
+        {showDuplicateButton && (
+          <div className="mb-4 space-y-2">
+            <div className="flex items-start gap-2 p-3 rounded-lg bg-primary/5 border border-primary/20 text-sm text-muted-foreground">
+              <CopyPlus className="h-4 w-4 mt-0.5 shrink-0 text-primary" />
+              <span>
+                Starting a new cycle deploys a <strong>fresh, independent contract</strong> — the
+                original pool is unaffected.
+              </span>
             </div>
-          )
-        })()}
+            <Button variant="outline" size="sm" className="w-full gap-2" asChild>
+              <Link href={duplicateHref}>
+                <CopyPlus className="h-4 w-4" />
+                Start New Cycle / Duplicate Pool
+              </Link>
+            </Button>
+          </div>
+        )}
 
         {/* Per-pool notification mute (email only) */}
         <div className="mb-4">

--- a/frontend/components/group/group-details.tsx
+++ b/frontend/components/group/group-details.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react"
 import type { FC } from "react"
+import { useStellar } from "@/components/web3-provider"
 import { Card } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Progress } from "@/components/ui/progress"
@@ -48,24 +49,30 @@ interface GroupData {
   next_recipient: string | null
   created_at: string
   contribution_amount: number | null
+  minimum_deposit?: number | null
   frequency: string | null
   deadline: string | null
   contract_address: string
   token_symbol?: string
   token_decimals?: number
   members?: string[]
+  pool_members?: { member_address: string }[]
 }
 
 interface GroupDetailsProps {
   groupId: string
   /** Contract address if already known — avoids a redundant /api/pools fetch */
   contractAddress?: string
+  /** On-chain admin address — passed from the parent page after fetchPoolAdmin resolves */
+  poolAdmin?: string | null
 }
 
-export function GroupDetails({ groupId, contractAddress }: GroupDetailsProps) {
+export function GroupDetails({ groupId, contractAddress, poolAdmin }: GroupDetailsProps) {
   const [copied, setCopied] = useState(false)
   const [currentLedger, setCurrentLedger] = useState<number | null>(null)
   const { toast } = useToast()
+  const { address } = useStellar()
+  const isAdmin = !!address && !!poolAdmin && address.toUpperCase() === poolAdmin.toUpperCase()
 
   // Use contract address as cache key when available; otherwise key on DB id.
   // The provider resolves DB data first, so the DB id key works fine too.
@@ -508,18 +515,36 @@ export function GroupDetails({ groupId, contractAddress }: GroupDetailsProps) {
           </div>
         )}
 
-        {!isPending(group.contract_address) && group.status !== "pending" && (
-          <div className="mb-4">
-            <Button variant="outline" size="sm" className="w-full gap-2" asChild>
-              <Link
-                href={`/dashboard/create/${group.type}?duplicate=1&name=${encodeURIComponent(group.name)}&description=${encodeURIComponent(group.description || "")}&amount=${group.contribution_amount || ""}&frequency=${group.frequency || ""}&members=${encodeURIComponent(JSON.stringify(group.members || []))}&token=${group.token_symbol || "XLM"}`}
-              >
-                <CopyPlus className="h-4 w-4" />
-                Start New Cycle / Duplicate Pool
-              </Link>
-            </Button>
-          </div>
-        )}
+        {!isPending(group.contract_address) && group.status !== "pending" && isAdmin && (() => {
+          const memberAddresses = group.pool_members?.map((m) => m.member_address) ?? group.members ?? []
+          const base = `/dashboard/create/${group.type}?duplicate=1`
+            + `&name=${encodeURIComponent(group.name)}`
+            + `&description=${encodeURIComponent(group.description || "")}`
+            + `&members=${encodeURIComponent(JSON.stringify(memberAddresses))}`
+            + `&token=${encodeURIComponent(group.token_symbol || "XLM")}`
+          const typeParams =
+            group.type === "rotational"
+              ? `&amount=${group.contribution_amount || ""}&frequency=${encodeURIComponent(group.frequency || "weekly")}`
+              : group.type === "target"
+              ? `&targetAmount=${group.target_amount || ""}`
+              : `&minimumDeposit=${group.minimum_deposit ?? group.contribution_amount ?? ""}`
+          return (
+            <div className="mb-4 space-y-2">
+              <div className="flex items-start gap-2 p-3 rounded-lg bg-primary/5 border border-primary/20 text-sm text-muted-foreground">
+                <CopyPlus className="h-4 w-4 mt-0.5 shrink-0 text-primary" />
+                <span>
+                  Starting a new cycle deploys a <strong>fresh, independent contract</strong> — the original pool is unaffected.
+                </span>
+              </div>
+              <Button variant="outline" size="sm" className="w-full gap-2" asChild>
+                <Link href={base + typeParams}>
+                  <CopyPlus className="h-4 w-4" />
+                  Start New Cycle / Duplicate Pool
+                </Link>
+              </Button>
+            </div>
+          )
+        })()}
 
         {/* Per-pool notification mute (email only) */}
         <div className="mb-4">


### PR DESCRIPTION
closes #91

> Related: #155

## Overview

Users who regularly run savings cycles with the same group had to re-enter every setting from scratch when starting a new round. This PR implements the full duplicate-pool / start-new-cycle flow end-to-end.

## What was built

### Admin-only "Start New Cycle / Duplicate Pool" button (group-details.tsx)

- Visible **only** to the pool admin, verified by comparing the connected wallet address against the on-chain `poolAdmin` address (same check used in `GroupActions`).
- Shown on all non-pending pools regardless of status - an admin may want to plan the next cycle before the current one completes.
- An info banner above the button reads: *"Starting a new cycle deploys a fresh, independent contract - the original pool is unaffected."* This satisfies the requirement to clearly indicate the new pool is separate.
- URL params are built per pool type:
  - **Rotational**: `amount` (per-round contribution) + `frequency`
  - **Target**: `targetAmount` (savings goal)
  - **Flexible**: `minimumDeposit`
  - All types: `name`, `description`, `members` (sourced from `pool_members` relation if available, falling back to `group.members`), `token`

### `DuplicatePrefill` type extended (create/[type]/page.tsx)

Added `targetAmount` and `minimumDeposit` fields so each form type receives the correct pre-filled value. The URL parser now reads all three fields.

### `TargetForm` updated (	arget-form.tsx)

- Now accepts `prefill?: DuplicatePrefill` prop (previously accepted no props).
- Pre-fills: name, description, targetAmount, member list, token symbol.
- Deadline (days) is intentionally left blank - it's always relative to *now* and the original value is no longer meaningful.
- Shows the same "new cycle" info banner when prefill is present.

### `FlexibleForm` updated (lexible-form.tsx)

- Now accepts `prefill?: DuplicatePrefill` prop (previously accepted no props).
- Pre-fills: name, description, minimumDeposit, member list, token symbol.
- withdrawal fee and yield toggle are left at their defaults - the admin can adjust these per-cycle.
- Shows the same "new cycle" info banner when prefill is present.

### `RotationalForm` - no changes needed

Already fully supported prefill from an earlier implementation.

### Parent pages (group/[id]/page.tsx, GroupClient.tsx)

Threaded the `poolAdmin` prop down to `GroupDetails` so it receives the on-chain admin address and can perform the admin check.

## Acceptance criteria

| Criterion | Status |
|---|---|
| "Duplicate Pool" navigates to the correct creation form with fields pre-populated | ? |
| All pre-filled values are editable | ? |
| Only available on pools the user created/administered | ? (on-chain admin check) |
| Creating the duplicated pool results in a new, independent contract deployment | ? (each form always deploys fresh via `useDeployPool`) |