### PR TITLE
feat: implement auto-trigger payouts cron functionality and related logging

### DIFF
--- a/frontend/app/api/cron/health/route.ts
+++ b/frontend/app/api/cron/health/route.ts
@@ -49,11 +49,11 @@ export async function GET(req: NextRequest) {
   }
 
   const lastSuccessfulRun = lastSuccess?.created_at ?? null
-  const isDegraded =
-    !lastSuccessfulRun || now - new Date(lastSuccessfulRun).getTime() > DEGRADED_AFTER_MS
+  const neverRun = !lastSuccessfulRun
+  const isDegraded = !neverRun && now - new Date(lastSuccessfulRun!).getTime() > DEGRADED_AFTER_MS
 
   return NextResponse.json({
-    status: isDegraded ? "degraded" : "healthy",
+    status: neverRun ? "pending" : isDegraded ? "degraded" : "healthy",
     lastSuccessfulRun,
     failuresLast24h: failures?.length ?? 0,
     failures: failures ?? [],

--- a/frontend/app/api/cron/health/route.ts
+++ b/frontend/app/api/cron/health/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getAdminClient } from "@/lib/supabase-admin"
+import { readLimiter } from "@/lib/rate-limit"
+
+const JOB_NAME = "auto-trigger-payouts"
+const DEGRADED_AFTER_MS = 2 * 60 * 60 * 1000 // 2 hours
+const FAILURE_WINDOW_MS = 24 * 60 * 60 * 1000 // 24 hours
+
+/**
+ * GET /api/cron/health
+ *
+ * Reports the health of the auto-trigger-payouts cron: the last successful
+ * run (a pool_id-IS-NULL heartbeat row the Edge Function writes once per
+ * completed invocation) and any per-pool failures logged in the last 24h.
+ * Degraded when no successful run has landed in the last 2 hours — the cron
+ * fires every 15 minutes, so that gap means several runs in a row failed.
+ */
+export async function GET(req: NextRequest) {
+  const limited = readLimiter(req)
+  if (limited) return limited
+
+  const supabase = getAdminClient()
+  const now = Date.now()
+
+  const { data: lastSuccess, error: successError } = await supabase
+    .from("cron_job_logs")
+    .select("created_at")
+    .eq("job_name", JOB_NAME)
+    .eq("status", "success")
+    .is("pool_id", null)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (successError) {
+    return NextResponse.json({ error: "Failed to read cron job logs" }, { status: 500 })
+  }
+
+  const { data: failures, error: failuresError } = await supabase
+    .from("cron_job_logs")
+    .select("id, pool_id, error_message, created_at")
+    .eq("job_name", JOB_NAME)
+    .eq("status", "failed")
+    .gte("created_at", new Date(now - FAILURE_WINDOW_MS).toISOString())
+    .order("created_at", { ascending: false })
+
+  if (failuresError) {
+    return NextResponse.json({ error: "Failed to read cron job logs" }, { status: 500 })
+  }
+
+  const lastSuccessfulRun = lastSuccess?.created_at ?? null
+  const isDegraded =
+    !lastSuccessfulRun || now - new Date(lastSuccessfulRun).getTime() > DEGRADED_AFTER_MS
+
+  return NextResponse.json({
+    status: isDegraded ? "degraded" : "healthy",
+    lastSuccessfulRun,
+    failuresLast24h: failures?.length ?? 0,
+    failures: failures ?? [],
+  })
+}

--- a/frontend/components/group/admin-actions-log.tsx
+++ b/frontend/components/group/admin-actions-log.tsx
@@ -14,6 +14,7 @@ import {
   Loader2,
   RefreshCw,
   ExternalLink,
+  Bot,
 } from "lucide-react"
 import { useStellar } from "@/components/web3-provider"
 import { formatRelativeTime, formatExactDateTime } from "@/lib/utils"
@@ -127,6 +128,14 @@ export function AdminActionsLog({ groupId }: AdminActionsLogProps) {
           iconColor: "text-muted-foreground",
           bgColor: "bg-muted",
         }
+      case "auto_trigger_payout":
+        return {
+          title: "Auto Payout Triggered",
+          description: "The scheduled cron job automatically triggered this round's payout.",
+          icon: Bot,
+          iconColor: "text-blue-600",
+          bgColor: "bg-blue-600/10",
+        }
       default:
         return {
           title: action.action_type.replace("_", " "),
@@ -189,8 +198,17 @@ export function AdminActionsLog({ groupId }: AdminActionsLogProps) {
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 mb-1 flex-wrap">
                     <p className="font-medium text-sm capitalize">{details.title}</p>
-                    <Badge variant="outline" className="text-xs">
-                      Admin: {formatAddress(action.admin_address)}
+                    <Badge
+                      variant="outline"
+                      className={`text-xs ${
+                        action.action_type === "auto_trigger_payout"
+                          ? "border-blue-400 text-blue-600"
+                          : ""
+                      }`}
+                    >
+                      {action.action_type === "auto_trigger_payout"
+                        ? "🤖 Auto (Cron)"
+                        : `Admin: ${formatAddress(action.admin_address)}`}
                     </Badge>
                   </div>
                   <p className="text-xs text-muted-foreground">{details.description}</p>

--- a/frontend/components/group/group-details.tsx
+++ b/frontend/components/group/group-details.tsx
@@ -58,6 +58,7 @@ interface GroupData {
   token_decimals?: number
   members?: string[]
   pool_members?: { member_address: string }[]
+  pool_activity?: { activity_type: string; description: string | null }[]
   creator_address?: string
 }
 
@@ -93,6 +94,13 @@ export function GroupDetails({ groupId, contractAddress, poolAdmin }: GroupDetai
     !!address &&
     !!group?.creator_address &&
     address.toLowerCase() === group.creator_address.toLowerCase()
+
+  // The auto-trigger-payouts cron marks its activity rows with this marker
+  // (see supabase/functions/cron/auto-trigger-payouts) — its presence means
+  // the cron has successfully run for this pool at least once.
+  const hasAutoTrigger =
+    group?.type === "rotational" &&
+    (group?.pool_activity ?? []).some((a) => a.description?.includes("auto_trigger_payout"))
 
   useEffect(() => {
     getRpc()
@@ -457,6 +465,11 @@ export function GroupDetails({ groupId, contractAddress, poolAdmin }: GroupDetai
               {onchainState && (
                 <Badge variant="outline" className="text-xs">
                   Live onchain
+                </Badge>
+              )}
+              {hasAutoTrigger && (
+                <Badge variant="outline" className="text-xs text-blue-600 border-blue-400">
+                  🤖 Auto-trigger enabled
                 </Badge>
               )}
               {ttlDays !== null && (

--- a/frontend/components/group/group-details.tsx
+++ b/frontend/components/group/group-details.tsx
@@ -58,6 +58,9 @@ interface GroupData {
   token_decimals?: number
   members?: string[]
   pool_members?: { member_address: string }[]
+  // Intentionally narrowed to only the fields this component uses.
+  // The /api/pools response includes additional columns (id, user_address,
+  // amount, created_at, tx_hash) that are not needed here.
   pool_activity?: { activity_type: string; description: string | null }[]
   creator_address?: string
 }

--- a/frontend/lib/supabase.ts
+++ b/frontend/lib/supabase.ts
@@ -340,6 +340,40 @@ export type Database = {
           created_at?: string
         }
       }
+      cron_job_logs: {
+        Row: {
+          id: string
+          job_name: string
+          pool_id: string | null
+          status: "success" | "failed" | "retry" | "warning"
+          error_message: string | null
+          tx_hash: string | null
+          retry_count: number
+          next_retry_at: string | null
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          job_name: string
+          pool_id?: string | null
+          status: "success" | "failed" | "retry" | "warning"
+          error_message?: string | null
+          tx_hash?: string | null
+          retry_count?: number
+          next_retry_at?: string | null
+          created_at?: string
+        }
+        Update: {
+          job_name?: string
+          pool_id?: string | null
+          status?: "success" | "failed" | "retry" | "warning"
+          error_message?: string | null
+          tx_hash?: string | null
+          retry_count?: number
+          next_retry_at?: string | null
+          created_at?: string
+        }
+      }
     }
   }
 }

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,89 @@
+# Supabase
+
+This directory holds the project's Postgres migrations (`migrations/`) and
+Deno Edge Functions (`functions/`).
+
+## Edge Functions
+
+| Function | Trigger | Purpose |
+| --- | --- | --- |
+| `notify-pool-event` | DB webhook on `pool_activity` INSERT | Emails members about deposits/payouts/rounds |
+| `send-deposit-reminders` | Scheduled (cron) | Reminds members who haven't deposited before a round deadline |
+| `cron/auto-trigger-payouts` | pg_cron, every 15 minutes | Auto-triggers `trigger_payout` for expired rotational pool rounds |
+
+Deploy a function with:
+
+```bash
+supabase functions deploy <function-name>
+```
+
+Set its secrets (never commit these — use the dashboard or CLI):
+
+```bash
+supabase secrets set SOME_SECRET=value
+```
+
+## `cron/auto-trigger-payouts` — relayer wallet setup
+
+This function eliminates the need for a human relayer: every 15 minutes it
+checks all active rotational pools, and for any whose round deadline has
+passed on-chain, it signs and submits `trigger_payout` itself using a
+dedicated relayer keypair. See `supabase/migrations/20260722120000_cron_job_logs.sql`
+for the audit table and `20260722120100_schedule_auto_trigger_payouts.sql`
+for the pg_cron schedule.
+
+### 1. Generate a relayer keypair
+
+```bash
+stellar keys generate relayer --network testnet
+stellar keys address relayer   # public key (G...)
+stellar keys show relayer      # secret key (S...) — keep this private
+```
+
+Or with the JS SDK: `Keypair.random()`.
+
+### 2. Fund it on testnet
+
+```bash
+curl "https://friendbot.stellar.org/?addr=<RELAYER_PUBLIC_KEY>"
+```
+
+This gives the account 10,000 XLM on testnet, which is enough for a very
+long time at Soroban transaction fee rates. The function itself checks the
+relayer's balance every run and logs a `warning` row to `cron_job_logs` if it
+drops below 10 XLM (configurable via `MIN_RELAYER_BALANCE_XLM`) so it can be
+topped up before it runs out and starts failing.
+
+### 3. Store the secret key as an encrypted Edge Function secret
+
+**Never** put the relayer secret key in a plaintext env var or commit it
+anywhere. Store it as a Supabase secret, which is encrypted at rest and only
+readable by your deployed functions:
+
+```bash
+supabase secrets set RELAYER_SECRET_KEY=S...
+```
+
+### 4. Wire up the pg_cron schedule
+
+The migration that schedules the 15-minute cron (`net.http_post` → the
+deployed function) needs two values in Supabase Vault so the schedule itself
+never contains a secret:
+
+```sql
+select vault.create_secret('https://<project-ref>.supabase.co', 'project_url');
+select vault.create_secret('<service-role-key>', 'service_role_key');
+```
+
+Run these once in the SQL editor (or via the CLI against your project)
+before or after applying `20260722120100_schedule_auto_trigger_payouts.sql` —
+`cron.schedule` just stores the command text, so applying the migration
+first is fine; the job simply won't successfully call out until the vault
+secrets exist.
+
+### 5. Verify
+
+- `GET /api/cron/health` reports the last successful run and any failures in
+  the last 24 hours.
+- `cron_job_logs` (service-role read only) has one row per pool the job
+  looked at, plus a `pool_id IS NULL` heartbeat row per completed run.

--- a/supabase/functions/cron/auto-trigger-payouts/index.ts
+++ b/supabase/functions/cron/auto-trigger-payouts/index.ts
@@ -21,8 +21,8 @@
 //   MAX_TRIGGERS_PER_RUN        - defaults to 10 (relayer fee-saturation guard)
 //   MIN_RELAYER_BALANCE_XLM     - defaults to 10 (low-balance warning threshold)
 
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2"
-import { serve } from "https://deno.land/std@0.177.0/http/server.ts"
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
 import {
   Account,
   Contract,
@@ -31,63 +31,71 @@ import {
   BASE_FEE,
   nativeToScVal,
   rpc,
-} from "https://esm.sh/@stellar/stellar-sdk@15.0.1?target=deno"
+} from "https://esm.sh/@stellar/stellar-sdk@15.0.1?target=deno";
 
-const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? ""
-const SUPABASE_SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
-const RELAYER_SECRET_KEY = Deno.env.get("RELAYER_SECRET_KEY") ?? ""
-const STELLAR_RPC_URL = Deno.env.get("STELLAR_RPC_URL") ?? "https://soroban-testnet.stellar.org"
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
+const SUPABASE_SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+const RELAYER_SECRET_KEY = (Deno.env.get("RELAYER_SECRET_KEY") ?? "").trim();
+const STELLAR_RPC_URL =
+  Deno.env.get("STELLAR_RPC_URL") ?? "https://soroban-testnet.stellar.org";
 const STELLAR_HORIZON_URL =
-  Deno.env.get("STELLAR_HORIZON_URL") ?? "https://horizon-testnet.stellar.org"
+  Deno.env.get("STELLAR_HORIZON_URL") ?? "https://horizon-testnet.stellar.org";
 const STELLAR_NETWORK_PASSPHRASE =
-  Deno.env.get("STELLAR_NETWORK_PASSPHRASE") ?? "Test SDF Network ; September 2015"
-const MAX_TRIGGERS_PER_RUN = Number(Deno.env.get("MAX_TRIGGERS_PER_RUN") ?? "10")
-const MIN_RELAYER_BALANCE_XLM = Number(Deno.env.get("MIN_RELAYER_BALANCE_XLM") ?? "10")
+  Deno.env.get("STELLAR_NETWORK_PASSPHRASE") ??
+  "Test SDF Network ; September 2015";
+const MAX_TRIGGERS_PER_RUN = Number(
+  Deno.env.get("MAX_TRIGGERS_PER_RUN") ?? "10",
+);
+const MIN_RELAYER_BALANCE_XLM = Number(
+  Deno.env.get("MIN_RELAYER_BALANCE_XLM") ?? "10",
+);
 
-const JOB_NAME = "auto-trigger-payouts"
-const TX_TIMEOUT = 300
+const JOB_NAME = "auto-trigger-payouts";
+const TX_TIMEOUT = 300;
 // Cron runs every 15 minutes, so these backoff windows are enforced across
 // runs (a "retry" row's next_retry_at gates re-attempts), not via in-process
 // sleeps — an Edge Function invocation can't block for 15 minutes.
-const RETRY_BACKOFF_MINUTES = [1, 5, 15]
-const MAX_RETRIES = RETRY_BACKOFF_MINUTES.length
+const RETRY_BACKOFF_MINUTES = [1, 5, 15];
+const MAX_RETRIES = RETRY_BACKOFF_MINUTES.length;
 // Placeholder read-only account used only to build simulation transactions —
 // never funded, never signs anything. Same technique the frontend's
 // `viewCall` helper uses for on-chain reads.
-const DUMMY_READ_ACCOUNT = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7"
+const DUMMY_READ_ACCOUNT =
+  "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7";
 
-const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY)
+const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
 
 interface RotationalPool {
-  id: string
-  contract_address: string
+  id: string;
+  contract_address: string;
 }
 
 interface RetryState {
-  status: "success" | "failed" | "retry" | "warning"
-  retry_count: number
-  next_retry_at: string | null
-  created_at: string
+  status: "success" | "failed" | "retry" | "warning";
+  retry_count: number;
+  next_retry_at: string | null;
+  created_at: string;
 }
 
 interface CronLogFields {
-  pool_id?: string | null
-  status: "success" | "failed" | "retry" | "warning"
-  error_message?: string | null
-  tx_hash?: string | null
-  retry_count?: number
-  next_retry_at?: string | null
+  pool_id?: string | null;
+  status: "success" | "failed" | "retry" | "warning";
+  error_message?: string | null;
+  tx_hash?: string | null;
+  retry_count?: number;
+  next_retry_at?: string | null;
 }
 
-const normalizeId = (id: string) => id.toUpperCase()
-const addressVal = (addr: string) => nativeToScVal(addr.toUpperCase(), { type: "address" })
+const normalizeId = (id: string) => id.toUpperCase();
+const addressVal = (addr: string) =>
+  nativeToScVal(addr.toUpperCase(), { type: "address" });
 
 // deno-lint-ignore no-explicit-any
 function scValToBigInt(val: any): bigint {
-  const name = val.switch().name
-  if (name === "scvU64") return BigInt(val.u64().toString())
-  if (name === "scvI64") return BigInt(val.i64().toString())
-  return 0n
+  const name = val.switch().name;
+  if (name === "scvU64") return BigInt(val.u64().toString());
+  if (name === "scvI64") return BigInt(val.i64().toString());
+  return 0n;
 }
 
 async function logCronEvent(fields: CronLogFields): Promise<void> {
@@ -99,8 +107,8 @@ async function logCronEvent(fields: CronLogFields): Promise<void> {
     tx_hash: fields.tx_hash ?? null,
     retry_count: fields.retry_count ?? 0,
     next_retry_at: fields.next_retry_at ?? null,
-  })
-  if (error) console.error("Failed to write cron_job_logs row:", error)
+  });
+  if (error) console.error("Failed to write cron_job_logs row:", error);
 }
 
 async function getRetryState(poolId: string): Promise<RetryState | null> {
@@ -111,57 +119,67 @@ async function getRetryState(poolId: string): Promise<RetryState | null> {
     .eq("pool_id", poolId)
     .order("created_at", { ascending: false })
     .limit(1)
-    .maybeSingle()
-  if (error) throw error
-  return data as RetryState | null
+    .maybeSingle();
+  if (error) throw error;
+  return data as RetryState | null;
 }
 
 async function getRelayerXlmBalance(publicKey: string): Promise<number> {
-  const res = await fetch(`${STELLAR_HORIZON_URL}/accounts/${publicKey}`)
-  if (!res.ok) throw new Error(`Horizon account lookup failed: ${res.status}`)
-  const data = await res.json()
-  const balances = (data.balances ?? []) as { asset_type: string; balance: string }[]
-  const native = balances.find((b) => b.asset_type === "native")
-  return native ? parseFloat(native.balance) : 0
+  const res = await fetch(`${STELLAR_HORIZON_URL}/accounts/${publicKey}`);
+  if (!res.ok) throw new Error(`Horizon account lookup failed: ${res.status}`);
+  const data = await res.json();
+  const balances = (data.balances ?? []) as {
+    asset_type: string;
+    balance: string;
+  }[];
+  const native = balances.find((b) => b.asset_type === "native");
+  return native ? parseFloat(native.balance) : 0;
 }
 
 /** Fire-and-forget read call — no signing, no fee. Mirrors the frontend's viewCall. */
 // deno-lint-ignore no-explicit-any
-async function viewCall(server: any, contractId: string, method: string): Promise<any> {
-  const dummyAccount = new Account(DUMMY_READ_ACCOUNT, "0")
+async function viewCall(
+  server: any,
+  contractId: string,
+  method: string,
+): Promise<any> {
+  const dummyAccount = new Account(DUMMY_READ_ACCOUNT, "0");
   const tx = new TransactionBuilder(dummyAccount, {
     fee: BASE_FEE,
     networkPassphrase: STELLAR_NETWORK_PASSPHRASE,
   })
     .addOperation(new Contract(normalizeId(contractId)).call(method))
     .setTimeout(TX_TIMEOUT)
-    .build()
+    .build();
 
-  const sim = await server.simulateTransaction(tx)
+  const sim = await server.simulateTransaction(tx);
   if (rpc.Api.isSimulationError(sim)) {
-    throw new Error(`View call failed (${method}): ${sim.error}`)
+    throw new Error(`View call failed (${method}): ${sim.error}`);
   }
-  return sim.result.retval
+  return sim.result.retval;
 }
 
 interface DueState {
-  isActive: boolean
-  isPaused: boolean
-  nextPayoutTime: number
+  isActive: boolean;
+  isPaused: boolean;
+  nextPayoutTime: number;
 }
 
 // deno-lint-ignore no-explicit-any
-async function fetchDueState(server: any, contractId: string): Promise<DueState> {
+async function fetchDueState(
+  server: any,
+  contractId: string,
+): Promise<DueState> {
   const [activeVal, pausedVal, payoutVal] = await Promise.all([
     viewCall(server, contractId, "is_active"),
     viewCall(server, contractId, "is_paused"),
     viewCall(server, contractId, "next_payout_time"),
-  ])
+  ]);
   return {
     isActive: activeVal.switch().name === "scvBool" ? activeVal.b() : false,
     isPaused: pausedVal.switch().name === "scvBool" ? pausedVal.b() : false,
     nextPayoutTime: Number(scValToBigInt(payoutVal)),
-  }
+  };
 }
 
 /** Simulate → assemble → sign with the relayer keypair → send → poll. Returns tx hash. */
@@ -170,52 +188,61 @@ async function submitTriggerPayout(
   server: any,
   // deno-lint-ignore no-explicit-any
   relayerKeypair: any,
-  contractId: string
+  contractId: string,
 ): Promise<string> {
-  const relayerPublicKey = relayerKeypair.publicKey()
-  const account = await server.getAccount(relayerPublicKey)
+  const relayerPublicKey = relayerKeypair.publicKey();
+  const account = await server.getAccount(relayerPublicKey);
 
   const tx = new TransactionBuilder(account, {
     fee: BASE_FEE,
     networkPassphrase: STELLAR_NETWORK_PASSPHRASE,
   })
     .addOperation(
-      new Contract(normalizeId(contractId)).call("trigger_payout", addressVal(relayerPublicKey))
+      new Contract(normalizeId(contractId)).call(
+        "trigger_payout",
+        addressVal(relayerPublicKey),
+      ),
     )
     .setTimeout(TX_TIMEOUT)
-    .build()
+    .build();
 
-  const simResult = await server.simulateTransaction(tx)
+  const simResult = await server.simulateTransaction(tx);
   if (rpc.Api.isSimulationError(simResult)) {
-    throw new Error(`Simulation failed: ${simResult.error}`)
+    throw new Error(`Simulation failed: ${simResult.error}`);
   }
 
-  const prepared = rpc.assembleTransaction(tx, simResult).build()
-  prepared.sign(relayerKeypair)
+  const prepared = rpc.assembleTransaction(tx, simResult).build();
+  prepared.sign(relayerKeypair);
 
-  const sendResult = await server.sendTransaction(prepared)
+  const sendResult = await server.sendTransaction(prepared);
   if (sendResult.status === "ERROR") {
-    throw new Error(`Send failed: ${JSON.stringify(sendResult.errorResult)}`)
+    throw new Error(`Send failed: ${JSON.stringify(sendResult.errorResult)}`);
   }
 
-  let getResult = await server.getTransaction(sendResult.hash)
-  let attempts = 0
-  while (getResult.status === rpc.Api.GetTransactionStatus.NOT_FOUND && attempts < 20) {
-    await new Promise((r) => setTimeout(r, 1500))
-    getResult = await server.getTransaction(sendResult.hash)
-    attempts++
+  let getResult = await server.getTransaction(sendResult.hash);
+  let attempts = 0;
+  while (
+    getResult.status === rpc.Api.GetTransactionStatus.NOT_FOUND &&
+    attempts < 20
+  ) {
+    await new Promise((r) => setTimeout(r, 1500));
+    getResult = await server.getTransaction(sendResult.hash);
+    attempts++;
   }
 
   if (getResult.status !== rpc.Api.GetTransactionStatus.SUCCESS) {
-    throw new Error(`Transaction did not succeed on-chain (status: ${getResult.status})`)
+    throw new Error(
+      `Transaction did not succeed on-chain (status: ${getResult.status})`,
+    );
   }
 
-  return sendResult.hash
+  return sendResult.hash;
 }
 
 interface ProcessOutcome {
-  attempted: boolean
-  skipped?: string
+  attempted: boolean;
+  succeeded?: boolean;
+  skipped?: string;
 }
 
 async function processPool(
@@ -223,41 +250,48 @@ async function processPool(
   server: any,
   // deno-lint-ignore no-explicit-any
   relayerKeypair: any,
-  pool: RotationalPool
+  pool: RotationalPool,
 ): Promise<ProcessOutcome> {
-  const retryState = await getRetryState(pool.id)
-  let attemptNumber = 0
+  const retryState = await getRetryState(pool.id);
+  let attemptNumber = 0;
   if (retryState?.status === "retry") {
-    if (retryState.next_retry_at && new Date(retryState.next_retry_at) > new Date()) {
-      return { attempted: false, skipped: "backoff" }
+    if (
+      retryState.next_retry_at &&
+      new Date(retryState.next_retry_at) > new Date()
+    ) {
+      return { attempted: false, skipped: "backoff" };
     }
-    attemptNumber = retryState.retry_count
+    attemptNumber = retryState.retry_count;
   }
 
-  let state: DueState
+  let state: DueState;
   try {
-    state = await fetchDueState(server, pool.contract_address)
+    state = await fetchDueState(server, pool.contract_address);
   } catch (err) {
     await logCronEvent({
       pool_id: pool.id,
       status: "failed",
       error_message: `Failed to read on-chain state: ${err instanceof Error ? err.message : String(err)}`,
-    })
-    return { attempted: false, skipped: "state_read_error" }
+    });
+    return { attempted: false, skipped: "state_read_error" };
   }
 
   if (!state.isActive || state.isPaused) {
-    return { attempted: false, skipped: "inactive_or_paused" }
+    return { attempted: false, skipped: "inactive_or_paused" };
   }
 
-  const nowSec = Math.floor(Date.now() / 1000)
+  const nowSec = Math.floor(Date.now() / 1000);
   if (state.nextPayoutTime === 0 || nowSec < state.nextPayoutTime) {
-    return { attempted: false, skipped: "not_due" }
+    return { attempted: false, skipped: "not_due" };
   }
 
   try {
-    const txHash = await submitTriggerPayout(server, relayerKeypair, pool.contract_address)
-    const relayerPublicKey = relayerKeypair.publicKey()
+    const txHash = await submitTriggerPayout(
+      server,
+      relayerKeypair,
+      pool.contract_address,
+    );
+    const relayerPublicKey = relayerKeypair.publicKey();
 
     await Promise.all([
       sb.from("pool_activity").insert({
@@ -265,7 +299,8 @@ async function processPool(
         activity_type: "payout",
         user_address: relayerPublicKey,
         tx_hash: txHash,
-        description: "Auto-triggered payout by scheduled relayer (auto_trigger_payout)",
+        description:
+          "Auto-triggered payout by scheduled relayer (auto_trigger_payout)",
       }),
       sb.from("admin_actions").insert({
         pool_id: pool.id,
@@ -274,13 +309,18 @@ async function processPool(
         tx_hash: txHash,
         metadata: { job_name: JOB_NAME, source: "cron" },
       }),
-      logCronEvent({ pool_id: pool.id, status: "success", tx_hash: txHash, retry_count: 0 }),
-    ])
+      logCronEvent({
+        pool_id: pool.id,
+        status: "success",
+        tx_hash: txHash,
+        retry_count: 0,
+      }),
+    ]);
 
-    return { attempted: true }
+    return { attempted: true, succeeded: true };
   } catch (err) {
-    const nextAttempt = attemptNumber + 1
-    const message = err instanceof Error ? err.message : String(err)
+    const nextAttempt = attemptNumber + 1;
+    const message = err instanceof Error ? err.message : String(err);
 
     if (nextAttempt > MAX_RETRIES) {
       await logCronEvent({
@@ -288,42 +328,45 @@ async function processPool(
         status: "failed",
         error_message: message,
         retry_count: nextAttempt,
-      })
+      });
     } else {
-      const backoffMin = RETRY_BACKOFF_MINUTES[nextAttempt - 1]
-      const nextRetryAt = new Date(Date.now() + backoffMin * 60_000)
+      const backoffMin = RETRY_BACKOFF_MINUTES[nextAttempt - 1];
+      const nextRetryAt = new Date(Date.now() + backoffMin * 60_000);
       await logCronEvent({
         pool_id: pool.id,
         status: "retry",
         error_message: message,
         retry_count: nextAttempt,
         next_retry_at: nextRetryAt.toISOString(),
-      })
+      });
     }
-    return { attempted: true }
+    return { attempted: true, succeeded: false };
   }
 }
 
 serve(async () => {
   if (!RELAYER_SECRET_KEY) {
-    console.error("RELAYER_SECRET_KEY is not configured")
-    await logCronEvent({ status: "failed", error_message: "RELAYER_SECRET_KEY not configured" })
-    return new Response("relayer not configured", { status: 500 })
+    console.error("RELAYER_SECRET_KEY is not configured");
+    await logCronEvent({
+      status: "failed",
+      error_message: "RELAYER_SECRET_KEY not configured",
+    });
+    return new Response("relayer not configured", { status: 500 });
   }
 
-  const relayerKeypair = Keypair.fromSecret(RELAYER_SECRET_KEY)
-  const server = new rpc.Server(STELLAR_RPC_URL)
+  const relayerKeypair = Keypair.fromSecret(RELAYER_SECRET_KEY);
+  const server = new rpc.Server(STELLAR_RPC_URL);
 
   try {
-    const balance = await getRelayerXlmBalance(relayerKeypair.publicKey())
+    const balance = await getRelayerXlmBalance(relayerKeypair.publicKey());
     if (balance < MIN_RELAYER_BALANCE_XLM) {
       await logCronEvent({
         status: "warning",
         error_message: `Relayer balance low: ${balance} XLM (threshold ${MIN_RELAYER_BALANCE_XLM} XLM)`,
-      })
+      });
     }
   } catch (err) {
-    console.error("Relayer balance check failed:", err)
+    console.error("Relayer balance check failed:", err);
   }
 
   try {
@@ -333,49 +376,62 @@ serve(async () => {
       .eq("type", "rotational")
       .eq("status", "active")
       .not("contract_address", "is", null)
-      .neq("contract_address", "pending_deployment")
+      .neq("contract_address", "pending_deployment");
 
-    if (error) throw error
+    if (error) throw error;
 
-    let triggered = 0
-    let rateLimited = 0
-    const errors: string[] = []
+    // `processed` counts pools that were actively attempted (success OR failure).
+    // `triggered` counts successful on-chain payout submissions only.
+    let processed = 0;
+    let triggered = 0;
+    let rateLimited = 0;
+    const errors: string[] = [];
 
     for (const pool of (pools ?? []) as RotationalPool[]) {
-      if (triggered >= MAX_TRIGGERS_PER_RUN) {
-        rateLimited++
-        continue
+      if (processed >= MAX_TRIGGERS_PER_RUN) {
+        rateLimited++;
+        continue;
       }
       try {
-        const outcome = await processPool(server, relayerKeypair, pool)
-        if (outcome.attempted) triggered++
+        const outcome = await processPool(server, relayerKeypair, pool);
+        if (outcome.attempted) {
+          processed++;
+          if (outcome.succeeded) triggered++;
+        }
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err)
-        errors.push(`${pool.id}: ${message}`)
-        await logCronEvent({ pool_id: pool.id, status: "failed", error_message: message })
+        const message = err instanceof Error ? err.message : String(err);
+        errors.push(`${pool.id}: ${message}`);
+        await logCronEvent({
+          pool_id: pool.id,
+          status: "failed",
+          error_message: message,
+        });
       }
     }
 
     if (rateLimited > 0) {
-      console.warn(`Rate limit hit: ${rateLimited} due pool(s) deferred to the next run`)
+      console.warn(
+        `Rate limit hit: ${rateLimited} due pool(s) deferred to the next run`,
+      );
     }
 
-    await logCronEvent({ status: "success" })
+    await logCronEvent({ status: "success" });
 
     return new Response(
       JSON.stringify({
         ok: true,
         checked_pools: (pools ?? []).length,
+        processed,
         triggered,
         deferred_rate_limit: rateLimited,
         errors,
       }),
-      { status: 200, headers: { "Content-Type": "application/json" } }
-    )
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
-    console.error("auto-trigger-payouts error:", err)
-    await logCronEvent({ status: "failed", error_message: message })
-    return new Response("internal error", { status: 500 })
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("auto-trigger-payouts error:", err);
+    await logCronEvent({ status: "failed", error_message: message });
+    return new Response("internal error", { status: 500 });
   }
-})
+});

--- a/supabase/functions/cron/auto-trigger-payouts/index.ts
+++ b/supabase/functions/cron/auto-trigger-payouts/index.ts
@@ -1,0 +1,381 @@
+// Supabase Edge Function: cron/auto-trigger-payouts
+//
+// Scheduled via pg_cron every 15 minutes (see
+// supabase/migrations/20260722120100_schedule_auto_trigger_payouts.sql).
+// Finds active rotational pools whose on-chain round deadline has passed and
+// submits `trigger_payout` on their behalf, signed by a dedicated relayer
+// keypair, so rounds don't stall waiting for a human to notice and click the
+// button.
+//
+// Required env vars (Edge Function secrets — never plaintext env vars):
+//   SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY - auto-injected by Supabase
+//   RELAYER_SECRET_KEY                      - Stellar secret key (S...) for the
+//                                              relayer account. Set via:
+//                                                supabase secrets set RELAYER_SECRET_KEY=...
+//                                              See supabase/README.md for how
+//                                              to generate and fund it.
+// Optional env vars:
+//   STELLAR_RPC_URL             - defaults to the public testnet RPC
+//   STELLAR_HORIZON_URL         - defaults to the public testnet Horizon
+//   STELLAR_NETWORK_PASSPHRASE  - defaults to the testnet passphrase
+//   MAX_TRIGGERS_PER_RUN        - defaults to 10 (relayer fee-saturation guard)
+//   MIN_RELAYER_BALANCE_XLM     - defaults to 10 (low-balance warning threshold)
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2"
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts"
+import {
+  Account,
+  Contract,
+  Keypair,
+  TransactionBuilder,
+  BASE_FEE,
+  nativeToScVal,
+  rpc,
+} from "https://esm.sh/@stellar/stellar-sdk@15.0.1?target=deno"
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? ""
+const SUPABASE_SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+const RELAYER_SECRET_KEY = Deno.env.get("RELAYER_SECRET_KEY") ?? ""
+const STELLAR_RPC_URL = Deno.env.get("STELLAR_RPC_URL") ?? "https://soroban-testnet.stellar.org"
+const STELLAR_HORIZON_URL =
+  Deno.env.get("STELLAR_HORIZON_URL") ?? "https://horizon-testnet.stellar.org"
+const STELLAR_NETWORK_PASSPHRASE =
+  Deno.env.get("STELLAR_NETWORK_PASSPHRASE") ?? "Test SDF Network ; September 2015"
+const MAX_TRIGGERS_PER_RUN = Number(Deno.env.get("MAX_TRIGGERS_PER_RUN") ?? "10")
+const MIN_RELAYER_BALANCE_XLM = Number(Deno.env.get("MIN_RELAYER_BALANCE_XLM") ?? "10")
+
+const JOB_NAME = "auto-trigger-payouts"
+const TX_TIMEOUT = 300
+// Cron runs every 15 minutes, so these backoff windows are enforced across
+// runs (a "retry" row's next_retry_at gates re-attempts), not via in-process
+// sleeps — an Edge Function invocation can't block for 15 minutes.
+const RETRY_BACKOFF_MINUTES = [1, 5, 15]
+const MAX_RETRIES = RETRY_BACKOFF_MINUTES.length
+// Placeholder read-only account used only to build simulation transactions —
+// never funded, never signs anything. Same technique the frontend's
+// `viewCall` helper uses for on-chain reads.
+const DUMMY_READ_ACCOUNT = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7"
+
+const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY)
+
+interface RotationalPool {
+  id: string
+  contract_address: string
+}
+
+interface RetryState {
+  status: "success" | "failed" | "retry" | "warning"
+  retry_count: number
+  next_retry_at: string | null
+  created_at: string
+}
+
+interface CronLogFields {
+  pool_id?: string | null
+  status: "success" | "failed" | "retry" | "warning"
+  error_message?: string | null
+  tx_hash?: string | null
+  retry_count?: number
+  next_retry_at?: string | null
+}
+
+const normalizeId = (id: string) => id.toUpperCase()
+const addressVal = (addr: string) => nativeToScVal(addr.toUpperCase(), { type: "address" })
+
+// deno-lint-ignore no-explicit-any
+function scValToBigInt(val: any): bigint {
+  const name = val.switch().name
+  if (name === "scvU64") return BigInt(val.u64().toString())
+  if (name === "scvI64") return BigInt(val.i64().toString())
+  return 0n
+}
+
+async function logCronEvent(fields: CronLogFields): Promise<void> {
+  const { error } = await sb.from("cron_job_logs").insert({
+    job_name: JOB_NAME,
+    pool_id: fields.pool_id ?? null,
+    status: fields.status,
+    error_message: fields.error_message ?? null,
+    tx_hash: fields.tx_hash ?? null,
+    retry_count: fields.retry_count ?? 0,
+    next_retry_at: fields.next_retry_at ?? null,
+  })
+  if (error) console.error("Failed to write cron_job_logs row:", error)
+}
+
+async function getRetryState(poolId: string): Promise<RetryState | null> {
+  const { data, error } = await sb
+    .from("cron_job_logs")
+    .select("status, retry_count, next_retry_at, created_at")
+    .eq("job_name", JOB_NAME)
+    .eq("pool_id", poolId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle()
+  if (error) throw error
+  return data as RetryState | null
+}
+
+async function getRelayerXlmBalance(publicKey: string): Promise<number> {
+  const res = await fetch(`${STELLAR_HORIZON_URL}/accounts/${publicKey}`)
+  if (!res.ok) throw new Error(`Horizon account lookup failed: ${res.status}`)
+  const data = await res.json()
+  const balances = (data.balances ?? []) as { asset_type: string; balance: string }[]
+  const native = balances.find((b) => b.asset_type === "native")
+  return native ? parseFloat(native.balance) : 0
+}
+
+/** Fire-and-forget read call — no signing, no fee. Mirrors the frontend's viewCall. */
+// deno-lint-ignore no-explicit-any
+async function viewCall(server: any, contractId: string, method: string): Promise<any> {
+  const dummyAccount = new Account(DUMMY_READ_ACCOUNT, "0")
+  const tx = new TransactionBuilder(dummyAccount, {
+    fee: BASE_FEE,
+    networkPassphrase: STELLAR_NETWORK_PASSPHRASE,
+  })
+    .addOperation(new Contract(normalizeId(contractId)).call(method))
+    .setTimeout(TX_TIMEOUT)
+    .build()
+
+  const sim = await server.simulateTransaction(tx)
+  if (rpc.Api.isSimulationError(sim)) {
+    throw new Error(`View call failed (${method}): ${sim.error}`)
+  }
+  return sim.result.retval
+}
+
+interface DueState {
+  isActive: boolean
+  isPaused: boolean
+  nextPayoutTime: number
+}
+
+// deno-lint-ignore no-explicit-any
+async function fetchDueState(server: any, contractId: string): Promise<DueState> {
+  const [activeVal, pausedVal, payoutVal] = await Promise.all([
+    viewCall(server, contractId, "is_active"),
+    viewCall(server, contractId, "is_paused"),
+    viewCall(server, contractId, "next_payout_time"),
+  ])
+  return {
+    isActive: activeVal.switch().name === "scvBool" ? activeVal.b() : false,
+    isPaused: pausedVal.switch().name === "scvBool" ? pausedVal.b() : false,
+    nextPayoutTime: Number(scValToBigInt(payoutVal)),
+  }
+}
+
+/** Simulate → assemble → sign with the relayer keypair → send → poll. Returns tx hash. */
+async function submitTriggerPayout(
+  // deno-lint-ignore no-explicit-any
+  server: any,
+  // deno-lint-ignore no-explicit-any
+  relayerKeypair: any,
+  contractId: string
+): Promise<string> {
+  const relayerPublicKey = relayerKeypair.publicKey()
+  const account = await server.getAccount(relayerPublicKey)
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: STELLAR_NETWORK_PASSPHRASE,
+  })
+    .addOperation(
+      new Contract(normalizeId(contractId)).call("trigger_payout", addressVal(relayerPublicKey))
+    )
+    .setTimeout(TX_TIMEOUT)
+    .build()
+
+  const simResult = await server.simulateTransaction(tx)
+  if (rpc.Api.isSimulationError(simResult)) {
+    throw new Error(`Simulation failed: ${simResult.error}`)
+  }
+
+  const prepared = rpc.assembleTransaction(tx, simResult).build()
+  prepared.sign(relayerKeypair)
+
+  const sendResult = await server.sendTransaction(prepared)
+  if (sendResult.status === "ERROR") {
+    throw new Error(`Send failed: ${JSON.stringify(sendResult.errorResult)}`)
+  }
+
+  let getResult = await server.getTransaction(sendResult.hash)
+  let attempts = 0
+  while (getResult.status === rpc.Api.GetTransactionStatus.NOT_FOUND && attempts < 20) {
+    await new Promise((r) => setTimeout(r, 1500))
+    getResult = await server.getTransaction(sendResult.hash)
+    attempts++
+  }
+
+  if (getResult.status !== rpc.Api.GetTransactionStatus.SUCCESS) {
+    throw new Error(`Transaction did not succeed on-chain (status: ${getResult.status})`)
+  }
+
+  return sendResult.hash
+}
+
+interface ProcessOutcome {
+  attempted: boolean
+  skipped?: string
+}
+
+async function processPool(
+  // deno-lint-ignore no-explicit-any
+  server: any,
+  // deno-lint-ignore no-explicit-any
+  relayerKeypair: any,
+  pool: RotationalPool
+): Promise<ProcessOutcome> {
+  const retryState = await getRetryState(pool.id)
+  let attemptNumber = 0
+  if (retryState?.status === "retry") {
+    if (retryState.next_retry_at && new Date(retryState.next_retry_at) > new Date()) {
+      return { attempted: false, skipped: "backoff" }
+    }
+    attemptNumber = retryState.retry_count
+  }
+
+  let state: DueState
+  try {
+    state = await fetchDueState(server, pool.contract_address)
+  } catch (err) {
+    await logCronEvent({
+      pool_id: pool.id,
+      status: "failed",
+      error_message: `Failed to read on-chain state: ${err instanceof Error ? err.message : String(err)}`,
+    })
+    return { attempted: false, skipped: "state_read_error" }
+  }
+
+  if (!state.isActive || state.isPaused) {
+    return { attempted: false, skipped: "inactive_or_paused" }
+  }
+
+  const nowSec = Math.floor(Date.now() / 1000)
+  if (state.nextPayoutTime === 0 || nowSec < state.nextPayoutTime) {
+    return { attempted: false, skipped: "not_due" }
+  }
+
+  try {
+    const txHash = await submitTriggerPayout(server, relayerKeypair, pool.contract_address)
+    const relayerPublicKey = relayerKeypair.publicKey()
+
+    await Promise.all([
+      sb.from("pool_activity").insert({
+        pool_id: pool.id,
+        activity_type: "payout",
+        user_address: relayerPublicKey,
+        tx_hash: txHash,
+        description: "Auto-triggered payout by scheduled relayer (auto_trigger_payout)",
+      }),
+      sb.from("admin_actions").insert({
+        pool_id: pool.id,
+        admin_address: relayerPublicKey,
+        action_type: "auto_trigger_payout",
+        tx_hash: txHash,
+        metadata: { job_name: JOB_NAME, source: "cron" },
+      }),
+      logCronEvent({ pool_id: pool.id, status: "success", tx_hash: txHash, retry_count: 0 }),
+    ])
+
+    return { attempted: true }
+  } catch (err) {
+    const nextAttempt = attemptNumber + 1
+    const message = err instanceof Error ? err.message : String(err)
+
+    if (nextAttempt > MAX_RETRIES) {
+      await logCronEvent({
+        pool_id: pool.id,
+        status: "failed",
+        error_message: message,
+        retry_count: nextAttempt,
+      })
+    } else {
+      const backoffMin = RETRY_BACKOFF_MINUTES[nextAttempt - 1]
+      const nextRetryAt = new Date(Date.now() + backoffMin * 60_000)
+      await logCronEvent({
+        pool_id: pool.id,
+        status: "retry",
+        error_message: message,
+        retry_count: nextAttempt,
+        next_retry_at: nextRetryAt.toISOString(),
+      })
+    }
+    return { attempted: true }
+  }
+}
+
+serve(async () => {
+  if (!RELAYER_SECRET_KEY) {
+    console.error("RELAYER_SECRET_KEY is not configured")
+    await logCronEvent({ status: "failed", error_message: "RELAYER_SECRET_KEY not configured" })
+    return new Response("relayer not configured", { status: 500 })
+  }
+
+  const relayerKeypair = Keypair.fromSecret(RELAYER_SECRET_KEY)
+  const server = new rpc.Server(STELLAR_RPC_URL)
+
+  try {
+    const balance = await getRelayerXlmBalance(relayerKeypair.publicKey())
+    if (balance < MIN_RELAYER_BALANCE_XLM) {
+      await logCronEvent({
+        status: "warning",
+        error_message: `Relayer balance low: ${balance} XLM (threshold ${MIN_RELAYER_BALANCE_XLM} XLM)`,
+      })
+    }
+  } catch (err) {
+    console.error("Relayer balance check failed:", err)
+  }
+
+  try {
+    const { data: pools, error } = await sb
+      .from("pools")
+      .select("id, contract_address")
+      .eq("type", "rotational")
+      .eq("status", "active")
+      .not("contract_address", "is", null)
+      .neq("contract_address", "pending_deployment")
+
+    if (error) throw error
+
+    let triggered = 0
+    let rateLimited = 0
+    const errors: string[] = []
+
+    for (const pool of (pools ?? []) as RotationalPool[]) {
+      if (triggered >= MAX_TRIGGERS_PER_RUN) {
+        rateLimited++
+        continue
+      }
+      try {
+        const outcome = await processPool(server, relayerKeypair, pool)
+        if (outcome.attempted) triggered++
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        errors.push(`${pool.id}: ${message}`)
+        await logCronEvent({ pool_id: pool.id, status: "failed", error_message: message })
+      }
+    }
+
+    if (rateLimited > 0) {
+      console.warn(`Rate limit hit: ${rateLimited} due pool(s) deferred to the next run`)
+    }
+
+    await logCronEvent({ status: "success" })
+
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        checked_pools: (pools ?? []).length,
+        triggered,
+        deferred_rate_limit: rateLimited,
+        errors,
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    )
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.error("auto-trigger-payouts error:", err)
+    await logCronEvent({ status: "failed", error_message: message })
+    return new Response("internal error", { status: 500 })
+  }
+})

--- a/supabase/migrations/20260722120000_cron_job_logs.sql
+++ b/supabase/migrations/20260722120000_cron_job_logs.sql
@@ -7,7 +7,7 @@
 CREATE TABLE IF NOT EXISTS public.cron_job_logs (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   job_name TEXT NOT NULL,
-  pool_id UUID REFERENCES public.pools(id) ON DELETE CASCADE,
+  pool_id UUID REFERENCES public.pools(id) ON DELETE SET NULL,
   status TEXT NOT NULL CHECK (status IN ('success', 'failed', 'retry', 'warning')),
   error_message TEXT,
   tx_hash TEXT,

--- a/supabase/migrations/20260722120000_cron_job_logs.sql
+++ b/supabase/migrations/20260722120000_cron_job_logs.sql
@@ -1,0 +1,28 @@
+-- Migration: Create cron_job_logs table for tracking scheduled job executions
+-- (initially: the auto-trigger-payouts cron). Records one row per pool
+-- processed, plus a pool_id-less heartbeat row per completed run, so cron
+-- health can be monitored (see /api/cron/health) without inspecting Edge
+-- Function logs directly.
+
+CREATE TABLE IF NOT EXISTS public.cron_job_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_name TEXT NOT NULL,
+  pool_id UUID REFERENCES public.pools(id) ON DELETE CASCADE,
+  status TEXT NOT NULL CHECK (status IN ('success', 'failed', 'retry', 'warning')),
+  error_message TEXT,
+  tx_hash TEXT,
+  retry_count INT NOT NULL DEFAULT 0,
+  next_retry_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_cron_job_logs_job_created ON public.cron_job_logs(job_name, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_cron_job_logs_pool_id ON public.cron_job_logs(pool_id);
+
+ALTER TABLE public.cron_job_logs ENABLE ROW LEVEL SECURITY;
+-- No SELECT/INSERT policies. This app has no Supabase Auth / admin role
+-- (identity is wallet-address based — see 20260624000000_rls_lockdown.sql), so
+-- "admin-only read access" is enforced by only ever reading this table through
+-- the service-role key (the auto-trigger-payouts Edge Function and the
+-- /api/cron/health route). Anon-key callers get nothing back, matching the
+-- service-role-only pattern already used for deposit_reminders.

--- a/supabase/migrations/20260722120100_schedule_auto_trigger_payouts.sql
+++ b/supabase/migrations/20260722120100_schedule_auto_trigger_payouts.sql
@@ -1,0 +1,37 @@
+-- Schedules the auto-trigger-payouts Edge Function to run every 15 minutes via
+-- pg_cron + pg_net, following Supabase's documented pattern for invoking Edge
+-- Functions from a cron job. Applying this migration is safe on its own, but
+-- the scheduled call will fail until two one-time manual steps are done (see
+-- supabase/README.md for the full walkthrough):
+--
+--   1. Store the project URL and service-role key in Supabase Vault so the
+--      cron command below never needs a secret committed to a migration file:
+--        select vault.create_secret('https://<project-ref>.supabase.co', 'project_url');
+--        select vault.create_secret('<service-role-key>', 'service_role_key');
+--
+--   2. Deploy the function: `supabase functions deploy auto-trigger-payouts`
+--      and set its secrets: `supabase secrets set RELAYER_SECRET_KEY=...`
+--
+-- cron.schedule() upserts by job name, so re-running this migration (e.g. to
+-- change the schedule) is idempotent.
+
+create extension if not exists pg_cron with schema extensions;
+create extension if not exists pg_net with schema extensions;
+
+select
+  cron.schedule(
+    'auto-trigger-payouts-every-15-min',
+    '*/15 * * * *',
+    $$
+    select
+      net.http_post(
+        url := (select decrypted_secret from vault.decrypted_secrets where name = 'project_url') || '/functions/v1/auto-trigger-payouts',
+        headers := jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || (select decrypted_secret from vault.decrypted_secrets where name = 'service_role_key')
+        ),
+        body := '{}'::jsonb,
+        timeout_milliseconds := 60000
+      ) as request_id;
+    $$
+  );

--- a/supabase/migrations/20260722120100_schedule_auto_trigger_payouts.sql
+++ b/supabase/migrations/20260722120100_schedule_auto_trigger_payouts.sql
@@ -31,7 +31,7 @@ select
           'Authorization', 'Bearer ' || (select decrypted_secret from vault.decrypted_secrets where name = 'service_role_key')
         ),
         body := '{}'::jsonb,
-        timeout_milliseconds := 60000
+        timeout_milliseconds := 300000
       ) as request_id;
     $$
   );


### PR DESCRIPTION
## Description

Adds a Supabase cron job that monitors all active rotational pools and automatically triggers `trigger_payout` once a round's on-chain deadline has passed, removing the dependency on a human relayer noticing and clicking the button.

- **`supabase/functions/cron/auto-trigger-payouts`** — runs every 15 minutes (pg_cron). For each active rotational pool it reads on-chain state (`is_active`, `is_paused`, `next_payout_time`) via Soroban RPC and, if the round is due, signs and submits `trigger_payout` with a dedicated relayer keypair. Successes are logged to `pool_activity` and `admin_actions` (`action_type: auto_trigger_payout`); failures retry up to 3 times with 1/5/15-minute backoff (tracked across cron ticks, since a single invocation can't block that long) before being logged as failed. Capped at 10 triggers per run to protect the relayer from fee saturation, and warns when its XLM balance drops below 10.
- **`cron_job_logs` table** (new migration) — one row per pool processed per run, plus a `pool_id IS NULL` heartbeat row per completed run. RLS enabled with no policies (service-role-only reads), consistent with this repo's wallet-address identity model — there's no Supabase Auth/admin role to scope an "admin-only" policy to.
- **pg_cron scheduling migration** — wires the function up via `pg_cron` + `pg_net`, reading the project URL / service-role key from Supabase Vault at call time so no secret is ever committed.
- **`supabase/README.md`** (new) — documents generating/funding the relayer keypair on testnet, storing `RELAYER_SECRET_KEY` as an encrypted Edge Function secret, and the one-time Vault setup the scheduling migration depends on.
- **`/api/cron/health`** — returns the last successful run and failures in the last 24h; reports `degraded` if no successful run in 2 hours.
- **Frontend** — `GroupDetails` shows an "🤖 Auto-trigger enabled" badge on rotational pools with auto-trigger activity; `AdminActionsLog` gives `auto_trigger_payout` actions a distinct icon/badge instead of `Admin: {address}`.

**Note on the issue spec:** `next_payout_time` in the rotational contract is a Unix timestamp (`env.ledger().timestamp()`), not a ledger sequence number — the cron reads it accordingly. No extra double-payout guard was needed: the contract itself reverts a second `trigger_payout` with "too early" until the next round's deadline, so manual triggering remains safe after a cron success.

Closes #<!-- fill in issue number -->

## Type of Change

- [x] feat: new feature

## How Has This Been Tested?

- [x] `pnpm build` succeeds (frontend)
- [x] `pnpm lint` passes (frontend)
- [ ] `cargo test` passes (smart contracts) — no contract changes in this PR
- [ ] Manual testing (describe below)

Typechecked the full frontend and diffed against the pre-change baseline — no new TypeScript errors introduced (all remaining errors are pre-existing, unrelated to this change). ESLint and Prettier clean on all touched files.

Not yet manually tested against a live Supabase project: needs a deployed relayer keypair funded on testnet (see `supabase/README.md`) and the pg_cron/Vault setup applied before an end-to-end run can be verified.

## Checklist

- [x] My code follows the coding conventions of this project
- [ ] I have added/updated tests if needed
- [x] I have updated documentation if needed
- [x] My changes generate no new warnings or errors

N/A — this PR is backend/cron infrastructure plus two small badge additions; no new screens.
fixes #183