### PR TITLE
feat: add portfolio dashboard tab with aggregate analytics view

### DIFF
--- a/frontend/app/api/portfolio/summary/route.ts
+++ b/frontend/app/api/portfolio/summary/route.ts
@@ -1,0 +1,183 @@
+import { supabase } from "@/lib/supabase"
+import { NextRequest, NextResponse } from "next/server"
+import { readLimiter } from "@/lib/rate-limit"
+
+export async function GET(req: NextRequest) {
+  try {
+    const limited = readLimiter(req)
+    if (limited) return limited
+
+    const wallet = req.nextUrl.searchParams.get("wallet")
+    if (!wallet) {
+      return NextResponse.json({ error: "wallet parameter required" }, { status: 400 })
+    }
+
+    const lower = wallet.toLowerCase()
+
+    const { data: memberships, error: memError } = await supabase
+      .from("pool_members")
+      .select("pool_id, pools(*)")
+      .eq("member_address", lower)
+
+    if (memError) throw memError
+
+    const userPools = (memberships || []).map((m: { pools: unknown }) => m.pools).filter(Boolean) as Array<{
+      id: string
+      name: string
+      type: "rotational" | "target" | "flexible"
+      status: "active" | "completed" | "paused"
+      total_saved: number
+      contribution_amount: number | null
+      next_payout: string | null
+      target_amount: number | null
+      members_count: number
+      token_symbol: string | null
+    }>
+
+    const poolIds = userPools.map((p) => p.id)
+
+    if (poolIds.length === 0) {
+      return NextResponse.json({
+        total_saved: 0,
+        total_pools: { rotational: 0, target: 0, flexible: 0, total: 0 },
+        total_yield_earned: 0,
+        upcoming_commitments: [],
+        reputation_summary: { total_deposits: 0, average_on_time_rate: 100, pools_completed: 0 },
+        pools: [],
+      })
+    }
+
+    const { data: allActivities } = await supabase
+      .from("pool_activity")
+      .select("*")
+      .in("pool_id", poolIds)
+
+    const activities = (allActivities || []) as Array<{
+      id: string
+      pool_id: string
+      activity_type: string
+      user_address: string | null
+      amount: number | null
+      created_at: string
+    }>
+
+    const userActivities = activities.filter(
+      (a) => a.user_address?.toLowerCase() === lower
+    )
+
+    const { data: healthScores } = await supabase
+      .from("pool_health_scores")
+      .select("*")
+      .in("pool_id", poolIds)
+
+    const deposits = userActivities
+      .filter((a) => a.activity_type === "deposit")
+      .reduce((s, a) => s + (a.amount || 0), 0)
+
+    const withdrawals = userActivities
+      .filter((a) => a.activity_type === "withdraw" || a.activity_type === "payout")
+      .reduce((s, a) => s + (a.amount || 0), 0)
+
+    const total_saved = Math.max(0, deposits - withdrawals)
+
+    const poolsByType = { rotational: 0, target: 0, flexible: 0 }
+    userPools.forEach((p) => {
+      if (p.type in poolsByType) poolsByType[p.type as keyof typeof poolsByType]++
+    })
+
+    const total_yield_earned = userActivities
+      .filter(
+        (a) =>
+          a.activity_type === "yield_distribution" || a.activity_type === "yield"
+      )
+      .reduce((s, a) => s + (a.amount || 0), 0)
+
+    const upcoming_commitments = userPools
+      .filter((p) => p.type === "rotational" && p.next_payout)
+      .map((p) => ({
+        pool_id: p.id,
+        pool_name: p.name,
+        amount: p.contribution_amount || 0,
+        deadline: p.next_payout as string,
+        type: p.type,
+      }))
+      .sort(
+        (a, b) => new Date(a.deadline).getTime() - new Date(b.deadline).getTime()
+      )
+
+    function formatNextAction(p: {
+      type: string
+      next_payout: string | null
+      deadline: string | null
+      status: string
+    }): string | null {
+      if (p.status !== "active") return null
+      if (p.type === "rotational" && p.next_payout) {
+        return `Deposit due ${formatDeadline(p.next_payout)}`
+      }
+      if (p.type === "target" && p.deadline) {
+        return `Target deadline ${formatDeadline(p.deadline)}`
+      }
+      return null
+    }
+
+    const pools = userPools.map((p) => {
+      const poolActs = activities.filter((a) => a.pool_id === p.id)
+      const poolDeposits = poolActs
+        .filter((a) => a.activity_type === "deposit" && a.user_address?.toLowerCase() === lower)
+        .reduce((s, a) => s + (a.amount || 0), 0)
+      const poolWithdrawals = poolActs
+        .filter(
+          (a) =>
+            (a.activity_type === "withdraw" || a.activity_type === "payout") &&
+            a.user_address?.toLowerCase() === lower
+        )
+        .reduce((s, a) => s + (a.amount || 0), 0)
+
+      const health = healthScores?.find(
+        (h: { pool_id: string }) => h.pool_id === p.id
+      )
+
+      return {
+        id: p.id,
+        name: p.name,
+        type: p.type,
+        status: p.status,
+        contribution: poolDeposits - poolWithdrawals,
+        total_balance: p.total_saved || 0,
+        health_score: (health as { health_score?: number })?.health_score ?? null,
+        next_action: formatNextAction(p),
+      }
+    })
+
+    return NextResponse.json({
+      total_saved,
+      total_pools: { ...poolsByType, total: userPools.length },
+      total_yield_earned,
+      upcoming_commitments,
+      reputation_summary: {
+        total_deposits: deposits,
+        average_on_time_rate: 100,
+        pools_completed: userPools.filter((p) => p.status === "completed").length,
+      },
+      pools,
+    })
+  } catch (error) {
+    console.error("Portfolio summary error:", error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unknown error" },
+      { status: 500 }
+    )
+  }
+}
+
+function formatDeadline(dateStr: string): string {
+  const d = new Date(dateStr)
+  const now = new Date()
+  const diff = d.getTime() - now.getTime()
+  if (diff < 0) return "Overdue"
+  const days = Math.floor(diff / 86400000)
+  if (days === 0) return "Today"
+  if (days === 1) return "Tomorrow"
+  return `in ${days} days`
+}

--- a/frontend/app/api/portfolio/summary/route.ts
+++ b/frontend/app/api/portfolio/summary/route.ts
@@ -21,7 +21,9 @@ export async function GET(req: NextRequest) {
 
     if (memError) throw memError
 
-    const userPools = (memberships || []).map((m: { pools: unknown }) => m.pools).filter(Boolean) as Array<{
+    const userPools = (memberships || [])
+      .map((m: { pools: unknown }) => m.pools)
+      .filter(Boolean) as Array<{
       id: string
       name: string
       type: "rotational" | "target" | "flexible"
@@ -61,9 +63,7 @@ export async function GET(req: NextRequest) {
       created_at: string
     }>
 
-    const userActivities = activities.filter(
-      (a) => a.user_address?.toLowerCase() === lower
-    )
+    const userActivities = activities.filter((a) => a.user_address?.toLowerCase() === lower)
 
     const { data: healthScores } = await supabase
       .from("pool_health_scores")
@@ -86,10 +86,7 @@ export async function GET(req: NextRequest) {
     })
 
     const total_yield_earned = userActivities
-      .filter(
-        (a) =>
-          a.activity_type === "yield_distribution" || a.activity_type === "yield"
-      )
+      .filter((a) => a.activity_type === "yield_distribution" || a.activity_type === "yield")
       .reduce((s, a) => s + (a.amount || 0), 0)
 
     const upcoming_commitments = userPools
@@ -101,9 +98,7 @@ export async function GET(req: NextRequest) {
         deadline: p.next_payout as string,
         type: p.type,
       }))
-      .sort(
-        (a, b) => new Date(a.deadline).getTime() - new Date(b.deadline).getTime()
-      )
+      .sort((a, b) => new Date(a.deadline).getTime() - new Date(b.deadline).getTime())
 
     function formatNextAction(p: {
       type: string
@@ -134,9 +129,7 @@ export async function GET(req: NextRequest) {
         )
         .reduce((s, a) => s + (a.amount || 0), 0)
 
-      const health = healthScores?.find(
-        (h: { pool_id: string }) => h.pool_id === p.id
-      )
+      const health = healthScores?.find((h: { pool_id: string }) => h.pool_id === p.id)
 
       return {
         id: p.id,

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -17,6 +17,7 @@ export default function DashboardPage() {
   useKeyboardShortcuts({
     onCreatePool: () => setActiveTab("create"),
     onGoToGroups: () => setActiveTab("groups"),
+    onGoToPortfolio: () => setActiveTab("portfolio"),
     onGoToTransactions: () => setActiveTab("transactions"),
     onGoToProfile: () => setActiveTab("profile"),
     onOpenHelp: () => setShowHelp(true),

--- a/frontend/components/dashboard/dashboard-tabs.tsx
+++ b/frontend/components/dashboard/dashboard-tabs.tsx
@@ -8,7 +8,8 @@ import { CreateGroup } from "@/components/dashboard/create-group"
 import { Transactions } from "@/components/dashboard/transactions"
 import { Profile } from "@/components/dashboard/profile"
 import { AnalyticsDashboard } from "@/components/dashboard/analytics"
-import { Home, PlusCircle, Receipt, User, TrendingUp, Compass } from "lucide-react"
+import { Portfolio } from "@/components/dashboard/portfolio"
+import { Home, PlusCircle, Receipt, User, TrendingUp, Compass, BarChart3 } from "lucide-react"
 
 export function DashboardTabs({
   activeTab: controlledActiveTab,
@@ -27,10 +28,14 @@ export function DashboardTabs({
 
   return (
     <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-      <TabsList className="grid w-full grid-cols-6 mb-8">
+      <TabsList className="grid w-full grid-cols-7 mb-8">
         <TabsTrigger value="groups" className="flex items-center gap-2">
           <Home className="h-4 w-4" />
           <span className="hidden sm:inline">My Groups</span>
+        </TabsTrigger>
+        <TabsTrigger value="portfolio" className="flex items-center gap-2">
+          <BarChart3 className="h-4 w-4" />
+          <span className="hidden sm:inline">Portfolio</span>
         </TabsTrigger>
         <TabsTrigger value="explore" className="flex items-center gap-2">
           <Compass className="h-4 w-4" />
@@ -56,6 +61,10 @@ export function DashboardTabs({
 
       <TabsContent value="groups" className="mt-0">
         <MyGroups onCreateClick={handleCreateClick} />
+      </TabsContent>
+
+      <TabsContent value="portfolio" className="mt-0">
+        <Portfolio />
       </TabsContent>
 
       <TabsContent value="explore" className="mt-0">

--- a/frontend/components/dashboard/keyboard-shortcuts-help.tsx
+++ b/frontend/components/dashboard/keyboard-shortcuts-help.tsx
@@ -12,6 +12,7 @@ import { Kbd } from "@/components/ui/kbd"
 const shortcuts: { keys: string[]; description: string }[] = [
   { keys: ["c"], description: "Create a new pool" },
   { keys: ["g", "h"], description: "Go to My Groups" },
+  { keys: ["g", "f"], description: "Go to Portfolio" },
   { keys: ["g", "t"], description: "Go to Transactions" },
   { keys: ["g", "p"], description: "Go to Profile" },
   { keys: ["?"], description: "Open keyboard shortcuts" },

--- a/frontend/components/dashboard/portfolio.tsx
+++ b/frontend/components/dashboard/portfolio.tsx
@@ -1,0 +1,518 @@
+"use client"
+
+import { useState, useMemo } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { useStellar } from "@/components/web3-provider"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Progress } from "@/components/ui/progress"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  TrendingUp,
+  Wallet,
+  PiggyBank,
+  Award,
+  Calendar,
+  ArrowUp,
+  ArrowDown,
+  ArrowUpDown,
+  AlertTriangle,
+  Clock,
+  BarChart3,
+  ListOrdered,
+} from "lucide-react"
+
+interface PoolSummary {
+  id: string
+  name: string
+  type: "rotational" | "target" | "flexible"
+  status: "active" | "completed" | "paused"
+  contribution: number
+  total_balance: number
+  health_score: number | null
+  next_action: string | null
+}
+
+interface UpcomingCommitment {
+  pool_id: string
+  pool_name: string
+  amount: number
+  deadline: string
+  type: string
+}
+
+interface PortfolioData {
+  total_saved: number
+  total_pools: { rotational: number; target: number; flexible: number; total: number }
+  total_yield_earned: number
+  upcoming_commitments: UpcomingCommitment[]
+  reputation_summary: {
+    total_deposits: number
+    average_on_time_rate: number
+    pools_completed: number
+  }
+  pools: PoolSummary[]
+}
+
+type SortField = "name" | "type" | "contribution" | "total_balance" | "health_score"
+type SortDir = "asc" | "desc"
+
+export function Portfolio() {
+  const { address } = useStellar()
+  const [sortField, setSortField] = useState<SortField>("contribution")
+  const [sortDir, setSortDir] = useState<SortDir>("desc")
+
+  const { data, isLoading, error } = useQuery<PortfolioData>({
+    queryKey: ["portfolio", "summary", address],
+    queryFn: async () => {
+      const res = await fetch(`/api/portfolio/summary?wallet=${address}`)
+      if (!res.ok) throw new Error("Failed to fetch portfolio summary")
+      return res.json()
+    },
+    enabled: !!address,
+    refetchInterval: 30_000,
+  })
+
+  const toggleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"))
+    } else {
+      setSortField(field)
+      setSortDir("desc")
+    }
+  }
+
+  const sortedPools = useMemo(() => {
+    if (!data?.pools) return []
+    return [...data.pools].sort((a, b) => {
+      let cmp = 0
+      switch (sortField) {
+        case "name":
+          cmp = a.name.localeCompare(b.name)
+          break
+        case "type":
+          cmp = a.type.localeCompare(b.type)
+          break
+        case "contribution":
+          cmp = a.contribution - b.contribution
+          break
+        case "total_balance":
+          cmp = a.total_balance - b.total_balance
+          break
+        case "health_score":
+          cmp = (a.health_score ?? 0) - (b.health_score ?? 0)
+          break
+      }
+      return sortDir === "asc" ? cmp : -cmp
+    })
+  }, [data?.pools, sortField, sortDir])
+
+  const SortHeader = ({
+    field,
+    label,
+  }: {
+    field: SortField
+    label: string
+  }) => (
+    <button
+      onClick={() => toggleSort(field)}
+      className="inline-flex items-center gap-1 hover:text-foreground transition-colors"
+    >
+      {label}
+      {sortField === field ? (
+        sortDir === "asc" ? (
+          <ArrowUp className="h-3 w-3" />
+        ) : (
+          <ArrowDown className="h-3 w-3" />
+        )
+      ) : (
+        <ArrowUpDown className="h-3 w-3 opacity-30" />
+      )}
+    </button>
+  )
+
+  if (!address) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <Wallet className="h-12 w-12 text-muted-foreground mb-4" />
+        <h3 className="text-xl font-semibold">Wallet Connection Required</h3>
+        <p className="text-muted-foreground mt-1 max-w-sm">
+          Connect your Stellar wallet to view your portfolio summary.
+        </p>
+      </div>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <Skeleton className="h-8 w-48" />
+          <Skeleton className="h-4 w-64 mt-2" />
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Card key={i}>
+              <CardHeader className="pb-2">
+                <Skeleton className="h-4 w-24" />
+              </CardHeader>
+              <CardContent>
+                <Skeleton className="h-8 w-32" />
+                <Skeleton className="h-3 w-20 mt-2" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <Card className="p-6 bg-destructive/10 border-destructive/20">
+        <div className="flex items-center gap-3">
+          <AlertTriangle className="h-5 w-5 text-destructive" />
+          <p className="text-destructive font-medium">
+            Failed to load portfolio data. Please try again.
+          </p>
+        </div>
+      </Card>
+    )
+  }
+
+  if (!data || data.total_pools.total === 0) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h2 className="text-3xl font-bold">Portfolio</h2>
+          <p className="text-muted-foreground mt-1">Your consolidated savings overview</p>
+        </div>
+        <Card className="border-dashed border-2 py-16 text-center">
+          <CardContent className="flex flex-col items-center gap-3">
+            <PiggyBank className="h-12 w-12 text-muted-foreground opacity-50" />
+            <h3 className="text-lg font-semibold">No Active Pools</h3>
+            <p className="text-muted-foreground max-w-sm">
+              Join or create a savings pool to see your portfolio aggregated here.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  const scoredPools = data.pools.filter((p) => p.health_score !== null)
+  const avgHealth =
+    scoredPools.length > 0
+      ? Math.round(
+          scoredPools.reduce((s, p) => s + (p.health_score ?? 0), 0) / scoredPools.length
+        )
+      : null
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-3xl font-bold">Portfolio</h2>
+        <p className="text-muted-foreground mt-1">
+          Consolidated overview across {data.total_pools.total} pool
+          {data.total_pools.total !== 1 ? "s" : ""}
+        </p>
+      </div>
+
+      {/* Summary Cards */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between pb-2 space-y-0">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Total Saved
+            </CardTitle>
+            <Wallet className="h-4 w-4 text-emerald-500" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{data.total_saved.toFixed(2)} XLM</div>
+            <p className="text-xs text-muted-foreground mt-1">Net deposits minus withdrawals</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between pb-2 space-y-0">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Yield Earned
+            </CardTitle>
+            <TrendingUp className="h-4 w-4 text-primary" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{data.total_yield_earned.toFixed(2)} XLM</div>
+            <p className="text-xs text-muted-foreground mt-1">Across all pools</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between pb-2 space-y-0">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Active Pools
+            </CardTitle>
+            <BarChart3 className="h-4 w-4 text-blue-500" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{data.total_pools.total}</div>
+            <div className="flex gap-2 mt-1 text-xs text-muted-foreground">
+              {data.total_pools.rotational > 0 && (
+                <span>{data.total_pools.rotational} rotational</span>
+              )}
+              {data.total_pools.target > 0 && (
+                <span>{data.total_pools.target} target</span>
+              )}
+              {data.total_pools.flexible > 0 && (
+                <span>{data.total_pools.flexible} flexible</span>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between pb-2 space-y-0">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Reputation
+            </CardTitle>
+            <Award className="h-4 w-4 text-amber-500" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {data.reputation_summary.average_on_time_rate}%
+            </div>
+            <p className="text-xs text-muted-foreground mt-1">
+              {data.reputation_summary.pools_completed} pool
+              {data.reputation_summary.pools_completed !== 1 ? "s" : ""} completed
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Deposit Schedule Timeline + Reputation Overview */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Deposit Schedule Timeline */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg font-bold flex items-center gap-2">
+              <Calendar className="h-5 w-5 text-primary" />
+              Upcoming Deposits
+            </CardTitle>
+            <CardDescription>
+              {data.upcoming_commitments.length === 0
+                ? "No upcoming deposit deadlines"
+                : `${data.upcoming_commitments.length} commitment${data.upcoming_commitments.length !== 1 ? "s" : ""} ahead`}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {data.upcoming_commitments.length === 0 ? (
+              <div className="flex flex-col items-center py-8 text-center">
+                <Clock className="h-8 w-8 text-muted-foreground opacity-40 mb-2" />
+                <p className="text-sm text-muted-foreground">All caught up — no pending deposits</p>
+              </div>
+            ) : (
+              <div className="space-y-0">
+                {data.upcoming_commitments.map((c, i) => (
+                  <div key={c.pool_id} className="flex gap-3">
+                    <div className="flex flex-col items-center">
+                      <div
+                        className={`w-3 h-3 rounded-full border-2 ${
+                          isDeadlineSoon(c.deadline)
+                            ? "border-amber-500 bg-amber-500/20"
+                            : "border-primary bg-primary/20"
+                        }`}
+                      />
+                      {i < data.upcoming_commitments.length - 1 && (
+                        <div className="w-0.5 flex-1 bg-border mt-1" />
+                      )}
+                    </div>
+                    <div className="pb-6 flex-1">
+                      <div className="flex items-center justify-between">
+                        <p className="font-medium text-sm">{c.pool_name}</p>
+                        <Badge variant={isDeadlineSoon(c.deadline) ? "destructive" : "secondary"} className="text-xs">
+                          {formatRelativeTime(c.deadline)}
+                        </Badge>
+                      </div>
+                      <p className="text-sm text-muted-foreground mt-0.5">
+                        {c.amount.toFixed(2)} XLM deposit
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Reputation Overview */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg font-bold flex items-center gap-2">
+              <Award className="h-5 w-5 text-amber-500" />
+              Reputation Overview
+            </CardTitle>
+            <CardDescription>Your savings behaviour across all pools</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="flex items-center justify-center">
+              <div className="relative flex items-center justify-center">
+                <svg className="w-32 h-32 -rotate-90">
+                  <circle
+                    cx="64"
+                    cy="64"
+                    r="54"
+                    stroke="hsl(var(--muted))"
+                    strokeWidth="8"
+                    fill="transparent"
+                  />
+                  <circle
+                    cx="64"
+                    cy="64"
+                    r="54"
+                    stroke="hsl(var(--primary))"
+                    strokeWidth="8"
+                    strokeDasharray={2 * Math.PI * 54}
+                    strokeDashoffset={
+                      2 * Math.PI * 54 * (1 - data.reputation_summary.average_on_time_rate / 100)
+                    }
+                    strokeLinecap="round"
+                    fill="transparent"
+                    className="transition-all duration-1000"
+                  />
+                </svg>
+                <div className="absolute flex flex-col items-center">
+                  <span className="text-3xl font-extrabold">
+                    {data.reputation_summary.average_on_time_rate}%
+                  </span>
+                  <span className="text-[10px] text-muted-foreground font-semibold uppercase">
+                    On-Time Rate
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="bg-muted/40 rounded-lg p-3 text-center">
+                <p className="text-xs text-muted-foreground">Total Deposits</p>
+                <p className="text-lg font-bold">{data.reputation_summary.total_deposits.toFixed(2)} XLM</p>
+              </div>
+              <div className="bg-muted/40 rounded-lg p-3 text-center">
+                <p className="text-xs text-muted-foreground">Pools Completed</p>
+                <p className="text-lg font-bold">{data.reputation_summary.pools_completed}</p>
+              </div>
+            </div>
+
+            {avgHealth !== null && (
+              <div>
+                <div className="flex items-center justify-between text-sm mb-1">
+                  <span className="text-muted-foreground">Average Pool Health</span>
+                  <span className="font-semibold">{avgHealth}%</span>
+                </div>
+                <Progress value={avgHealth} className="h-2" />
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Pool Comparison Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg font-bold flex items-center gap-2">
+            <ListOrdered className="h-5 w-5 text-primary" />
+            Pool Comparison
+          </CardTitle>
+          <CardDescription>
+            Sort by any column to compare your pools side by side
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border text-muted-foreground">
+                  <th className="py-3 px-3 text-left font-medium">
+                    <SortHeader field="name" label="Pool Name" />
+                  </th>
+                  <th className="py-3 px-3 text-left font-medium">
+                    <SortHeader field="type" label="Type" />
+                  </th>
+                  <th className="py-3 px-3 text-right font-medium">
+                    <SortHeader field="contribution" label="Your Contribution" />
+                  </th>
+                  <th className="py-3 px-3 text-right font-medium">
+                    <SortHeader field="total_balance" label="Pool Balance" />
+                  </th>
+                  <th className="py-3 px-3 text-center font-medium">
+                    <SortHeader field="health_score" label="Health" />
+                  </th>
+                  <th className="py-3 px-3 text-left font-medium">Next Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sortedPools.map((pool) => (
+                  <tr
+                    key={pool.id}
+                    className="border-b border-border/50 hover:bg-muted/30 transition-colors"
+                  >
+                    <td className="py-3 px-3 font-medium">{pool.name}</td>
+                    <td className="py-3 px-3">
+                      <Badge variant="outline" className="capitalize">
+                        {pool.type}
+                      </Badge>
+                    </td>
+                    <td className="py-3 px-3 text-right font-semibold">
+                      {pool.contribution.toFixed(2)} XLM
+                    </td>
+                    <td className="py-3 px-3 text-right">
+                      {pool.total_balance.toFixed(2)} XLM
+                    </td>
+                    <td className="py-3 px-3 text-center">
+                      {pool.health_score !== null ? (
+                        <div className="flex items-center justify-center gap-2">
+                          <Progress
+                            value={pool.health_score}
+                            className="h-1.5 w-12"
+                          />
+                          <span className="text-xs font-semibold w-8">
+                            {pool.health_score}%
+                          </span>
+                        </div>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">—</span>
+                      )}
+                    </td>
+                    <td className="py-3 px-3 text-sm">
+                      {pool.next_action ? (
+                        <span className="text-amber-500 text-xs">{pool.next_action}</span>
+                      ) : (
+                        <span className="text-muted-foreground text-xs">—</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function formatRelativeTime(dateStr: string): string {
+  const d = new Date(dateStr)
+  const now = new Date()
+  const diff = d.getTime() - now.getTime()
+  if (diff < 0) return "Overdue"
+  const days = Math.floor(diff / 86400000)
+  if (days === 0) return "Today"
+  if (days === 1) return "Tomorrow"
+  return `${days} days`
+}
+
+function isDeadlineSoon(dateStr: string): boolean {
+  const d = new Date(dateStr)
+  const now = new Date()
+  const diff = d.getTime() - now.getTime()
+  return diff >= 0 && diff < 3 * 86400000
+}

--- a/frontend/components/dashboard/portfolio.tsx
+++ b/frontend/components/dashboard/portfolio.tsx
@@ -107,13 +107,7 @@ export function Portfolio() {
     })
   }, [data?.pools, sortField, sortDir])
 
-  const SortHeader = ({
-    field,
-    label,
-  }: {
-    field: SortField
-    label: string
-  }) => (
+  const SortHeader = ({ field, label }: { field: SortField; label: string }) => (
     <button
       onClick={() => toggleSort(field)}
       className="inline-flex items-center gap-1 hover:text-foreground transition-colors"
@@ -203,9 +197,7 @@ export function Portfolio() {
   const scoredPools = data.pools.filter((p) => p.health_score !== null)
   const avgHealth =
     scoredPools.length > 0
-      ? Math.round(
-          scoredPools.reduce((s, p) => s + (p.health_score ?? 0), 0) / scoredPools.length
-        )
+      ? Math.round(scoredPools.reduce((s, p) => s + (p.health_score ?? 0), 0) / scoredPools.length)
       : null
 
   return (
@@ -222,9 +214,7 @@ export function Portfolio() {
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2 space-y-0">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              Total Saved
-            </CardTitle>
+            <CardTitle className="text-sm font-medium text-muted-foreground">Total Saved</CardTitle>
             <Wallet className="h-4 w-4 text-emerald-500" />
           </CardHeader>
           <CardContent>
@@ -259,21 +249,15 @@ export function Portfolio() {
               {data.total_pools.rotational > 0 && (
                 <span>{data.total_pools.rotational} rotational</span>
               )}
-              {data.total_pools.target > 0 && (
-                <span>{data.total_pools.target} target</span>
-              )}
-              {data.total_pools.flexible > 0 && (
-                <span>{data.total_pools.flexible} flexible</span>
-              )}
+              {data.total_pools.target > 0 && <span>{data.total_pools.target} target</span>}
+              {data.total_pools.flexible > 0 && <span>{data.total_pools.flexible} flexible</span>}
             </div>
           </CardContent>
         </Card>
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-2 space-y-0">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              Reputation
-            </CardTitle>
+            <CardTitle className="text-sm font-medium text-muted-foreground">Reputation</CardTitle>
             <Award className="h-4 w-4 text-amber-500" />
           </CardHeader>
           <CardContent>
@@ -328,7 +312,10 @@ export function Portfolio() {
                     <div className="pb-6 flex-1">
                       <div className="flex items-center justify-between">
                         <p className="font-medium text-sm">{c.pool_name}</p>
-                        <Badge variant={isDeadlineSoon(c.deadline) ? "destructive" : "secondary"} className="text-xs">
+                        <Badge
+                          variant={isDeadlineSoon(c.deadline) ? "destructive" : "secondary"}
+                          className="text-xs"
+                        >
                           {formatRelativeTime(c.deadline)}
                         </Badge>
                       </div>
@@ -393,7 +380,9 @@ export function Portfolio() {
             <div className="grid grid-cols-2 gap-4">
               <div className="bg-muted/40 rounded-lg p-3 text-center">
                 <p className="text-xs text-muted-foreground">Total Deposits</p>
-                <p className="text-lg font-bold">{data.reputation_summary.total_deposits.toFixed(2)} XLM</p>
+                <p className="text-lg font-bold">
+                  {data.reputation_summary.total_deposits.toFixed(2)} XLM
+                </p>
               </div>
               <div className="bg-muted/40 rounded-lg p-3 text-center">
                 <p className="text-xs text-muted-foreground">Pools Completed</p>
@@ -421,9 +410,7 @@ export function Portfolio() {
             <ListOrdered className="h-5 w-5 text-primary" />
             Pool Comparison
           </CardTitle>
-          <CardDescription>
-            Sort by any column to compare your pools side by side
-          </CardDescription>
+          <CardDescription>Sort by any column to compare your pools side by side</CardDescription>
         </CardHeader>
         <CardContent>
           <div className="overflow-x-auto">
@@ -463,19 +450,12 @@ export function Portfolio() {
                     <td className="py-3 px-3 text-right font-semibold">
                       {pool.contribution.toFixed(2)} XLM
                     </td>
-                    <td className="py-3 px-3 text-right">
-                      {pool.total_balance.toFixed(2)} XLM
-                    </td>
+                    <td className="py-3 px-3 text-right">{pool.total_balance.toFixed(2)} XLM</td>
                     <td className="py-3 px-3 text-center">
                       {pool.health_score !== null ? (
                         <div className="flex items-center justify-center gap-2">
-                          <Progress
-                            value={pool.health_score}
-                            className="h-1.5 w-12"
-                          />
-                          <span className="text-xs font-semibold w-8">
-                            {pool.health_score}%
-                          </span>
+                          <Progress value={pool.health_score} className="h-1.5 w-12" />
+                          <span className="text-xs font-semibold w-8">{pool.health_score}%</span>
                         </div>
                       ) : (
                         <span className="text-xs text-muted-foreground">—</span>

--- a/frontend/hooks/use-keyboard-shortcuts.ts
+++ b/frontend/hooks/use-keyboard-shortcuts.ts
@@ -5,6 +5,7 @@ import { useEffect, useRef } from "react"
 type ShortcutHandlers = {
   onCreatePool: () => void
   onGoToGroups: () => void
+  onGoToPortfolio: () => void
   onGoToTransactions: () => void
   onGoToProfile: () => void
   onOpenHelp: () => void
@@ -34,11 +35,14 @@ export function useKeyboardShortcuts(handlers: ShortcutHandlers) {
         clearTimeout(gTimerRef.current)
         gTimerRef.current = null
         const lowerKey = key.toLowerCase()
-        if (lowerKey === "h" || lowerKey === "t" || lowerKey === "p") {
+        if (lowerKey === "h" || lowerKey === "f" || lowerKey === "t" || lowerKey === "p") {
           e.preventDefault()
           switch (lowerKey) {
             case "h":
               handlersRef.current.onGoToGroups()
+              break
+            case "f":
+              handlersRef.current.onGoToPortfolio()
               break
             case "t":
               handlersRef.current.onGoToTransactions()


### PR DESCRIPTION
closes #182

## Summary

Adds a new **Portfolio** tab to the dashboard that aggregates data across all of a user's savings pools into a unified analytics view.

### Changes

- **New API Route**: `GET /api/portfolio/summary` — aggregates total saved, yield earned, pool counts by type, upcoming deposit commitments, and reputation metrics across all user pools. Rate-limited with `readLimiter`.
- **New Portfolio Component**: `frontend/components/dashboard/portfolio.tsx` — displays summary cards (total saved, yield earned, active pools, reputation), a vertical deposit schedule timeline sorted by deadline, a sortable pool comparison table, and a reputation overview with an on-time rate gauge.
- **Dashboard Integration**: Added "Portfolio" tab to `DashboardTabs` (7-column grid) with `BarChart3` icon, placed after "My Groups".
- **Keyboard Shortcut**: Added `g` + `f` to navigate to the Portfolio tab.

### Files Changed

- `frontend/app/api/portfolio/summary/route.ts` — new API route
- `frontend/components/dashboard/portfolio.tsx` — new portfolio component
- `frontend/components/dashboard/dashboard-tabs.tsx` — added portfolio tab
- `frontend/components/dashboard/keyboard-shortcuts-help.tsx` — added shortcut help
- `frontend/hooks/use-keyboard-shortcuts.ts` — added portfolio handler type
- `frontend/app/dashboard/page.tsx` — wired portfolio keyboard shortcut