### PR TITLE
feat: USDC deposit support via CCTP bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to **JointSave** will be documented in this file.
 - **React Error Boundaries** with fallback UIs and error reporting across all dashboard routes to prevent full page crashes.
 - **Smart contract pause & recovery** capabilities to improve safety and operational resilience of deployed pool contracts.
 - **Multi-token support** (including support for the native token) for pool participation.
+- **USDC deposits** for all three pool types, with an on-chain supported-token allowlist, a token-aware deposit flow (live balance + approximate USD value), token-separated dashboard totals, and a bridge tutorial page (`/bridge`) covering Circle's CCTP and Stellar's native USDC.
 - **Reputation tracking** to represent participant trust based on pool participation.
 - **Pool notifications** for user-facing updates related to pool activity.
 - **Explore page** so users can discover available pools.

--- a/docs/contract-api.md
+++ b/docs/contract-api.md
@@ -178,6 +178,8 @@ stellar contract invoke \
 | `members` | — | `Vec<Address>` | None | Returns the ordered member list. |
 | `has_deposited` | `member: Address` | `bool` | None | Returns whether `member` has deposited for the current round. |
 | `next_payout_time` | — | `u64` | None | Returns the Unix timestamp after which `trigger_payout` may be called. |
+| `set_supported_tokens` | `admin: Address`, `tokens: Vec<Address>` | `()` | `admin` | Sets the allowed token allowlist. Once non-empty, `deposit` requires the pool's `Token` to be on this list (e.g. native XLM's SAC or USDC's SAC on Stellar). |
+| `get_supported_tokens` | — | `Vec<Address>` | None | Returns the configured token allowlist. Empty by default (unrestricted). |
 
 ### Events
 
@@ -202,6 +204,7 @@ stellar contract invoke \
 | `NextPayoutTime` | `u64` | Persistent | Unix timestamp when next payout becomes eligible. |
 | `Active` | `bool` | Persistent | Whether the pool is accepting deposits and payouts. |
 | `HasDeposited(Address)` | `bool` | Persistent (cleared each round) | Per-member deposit flag. Removed from storage after each `trigger_payout`. |
+| `SupportedTokens` | `Vec<Address>` | Persistent | Allowlist of token contract addresses `deposit` will accept once set via `set_supported_tokens`. |
 
 ### Error Conditions
 
@@ -215,6 +218,7 @@ stellar contract invoke \
 | `"already deposited this round"` | `deposit` called by a member who already deposited this round. |
 | `"too early"` | `trigger_payout` called before `NextPayoutTime` has elapsed. |
 | `"no deposits this round"` | `trigger_payout` called when no member deposited this round. |
+| `"token not supported"` | `deposit` called while `SupportedTokens` is non-empty and the pool's `Token` is not on the list. |
 
 ### Example CLI Invocations
 
@@ -290,6 +294,8 @@ stellar contract invoke \
 | `total_deposited` | — | `i128` | None | Returns total tokens deposited across all members. |
 | `is_unlocked` | — | `bool` | None | Returns whether the target has been reached and withdrawals are open. |
 | `target_amount` | — | `i128` | None | Returns the savings target in stroops. |
+| `set_supported_tokens` | `admin: Address`, `tokens: Vec<Address>` | `()` | `admin` | Sets the allowed token allowlist. Once non-empty, `deposit` requires the pool's `Token` to be on this list (e.g. native XLM's SAC or USDC's SAC on Stellar). |
+| `get_supported_tokens` | — | `Vec<Address>` | None | Returns the configured token allowlist. Empty by default (unrestricted). |
 
 ### Events
 
@@ -313,6 +319,7 @@ stellar contract invoke \
 | `Active` | `bool` | Persistent | Whether the pool accepts deposits (set to `false` on `refund`). |
 | `Unlocked` | `bool` | Persistent | Whether the target has been reached; gates `withdraw`. |
 | `Balance(Address)` | `i128` | Persistent | Individual member deposit balance. |
+| `SupportedTokens` | `Vec<Address>` | Persistent | Allowlist of token contract addresses `deposit` will accept once set via `set_supported_tokens`. |
 
 ### Error Conditions
 
@@ -324,6 +331,7 @@ stellar contract invoke \
 | `"not a member"` | `deposit` called by an address not in the members list. |
 | `"amount must be > 0"` | `deposit` called with `amount <= 0`. |
 | `"deadline passed"` | `deposit` called after `ledger.sequence() > deadline`. |
+| `"token not supported"` | `deposit` called while `SupportedTokens` is non-empty and the pool's `Token` is not on the list. |
 | `"target not reached yet"` | `withdraw` called before `Unlocked == true`. |
 | `"nothing to withdraw"` | `withdraw` called by a member with zero balance. |
 | `"not admin"` | `refund` called by an address other than the stored admin. |
@@ -411,6 +419,8 @@ stellar contract invoke \
 | `total_balance` | — | `i128` | None | Returns the total tokens held by the pool. |
 | `members` | — | `Vec<Address>` | None | Returns the list of authorized members. |
 | `is_active` | — | `bool` | None | Returns whether the pool is active. |
+| `set_supported_tokens` | `admin: Address`, `tokens: Vec<Address>` | `()` | `admin` | Sets the allowed token allowlist. Once non-empty, `deposit` requires the pool's `Token` to be on this list (e.g. native XLM's SAC or USDC's SAC on Stellar). |
+| `get_supported_tokens` | — | `Vec<Address>` | None | Returns the configured token allowlist. Empty by default (unrestricted). |
 
 ### Events
 
@@ -434,6 +444,7 @@ stellar contract invoke \
 | `TotalBalance` | `i128` | Persistent | Sum of all member balances. |
 | `Active` | `bool` | Persistent | Whether the pool is active. |
 | `Balance(Address)` | `i128` | Persistent | Individual member balance including yield. |
+| `SupportedTokens` | `Vec<Address>` | Persistent | Allowlist of token contract addresses `deposit` will accept once set via `set_supported_tokens`. |
 
 ### Error Conditions
 
@@ -446,6 +457,7 @@ stellar contract invoke \
 | `"below minimum deposit"` | `deposit` called with `amount < MinimumDeposit`. |
 | `"amount must be > 0"` | `withdraw` called with `amount <= 0`. |
 | `"insufficient balance"` | `withdraw` called with `amount > member's balance`. |
+| `"token not supported"` | `deposit` called while `SupportedTokens` is non-empty and the pool's `Token` is not on the list. |
 | `"yield disabled"` | `distribute_yield` called when `YieldEnabled == false`. |
 | `"yield must be > 0"` | `distribute_yield` called with `yield_amount <= 0`. |
 | `"no balance"` | `distribute_yield` called when `TotalBalance == 0`. |

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -16,6 +16,11 @@ NEXT_PUBLIC_FACTORY_CONTRACT_ID=CBZNGP52FLFZ4BOGC265FUAMP5KFMAYPQK3KTI5UHMYVMM3Q
 # Token contract ID used by pool creation flows. Use "native" for testnet XLM.
 NEXT_PUBLIC_TOKEN_CONTRACT_ID=native
 
+# USDC SAC (Stellar Asset Contract) id used by the USDC deposit currency and
+# the bridge tutorial page. Optional — defaults to Circle's official testnet
+# USDC contract (see lib/token-utils.ts) when unset.
+NEXT_PUBLIC_USDC_CONTRACT_ID=CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA
+
 # Optional reputation contract ID. Leave blank to disable the additive reputation system.
 NEXT_PUBLIC_REPUTATION_CONTRACT_ID=
 

--- a/frontend/__tests__/bridge-page.test.tsx
+++ b/frontend/__tests__/bridge-page.test.tsx
@@ -1,0 +1,42 @@
+import React from "react"
+import { render, screen } from "@/test-utils"
+import { describe, it, expect } from "vitest"
+import BridgePage from "@/app/bridge/page"
+
+describe("BridgePage", () => {
+  it("renders the page heading", () => {
+    render(<BridgePage />)
+    expect(screen.getByRole("heading", { name: /bridge usdc to stellar/i })).toBeInTheDocument()
+  })
+
+  it("explains both bridging paths", () => {
+    render(<BridgePage />)
+    expect(screen.getAllByText(/Cross-Chain Transfer Protocol \(CCTP\)/i).length).toBeGreaterThan(
+      0
+    )
+    expect(screen.getByText(/Option B: Stellar's native USDC/i)).toBeInTheDocument()
+  })
+
+  it("clarifies bridging happens on external services", () => {
+    render(<BridgePage />)
+    expect(screen.getByText(/This page is educational only/i)).toBeInTheDocument()
+  })
+
+  it("links back to the dashboard", () => {
+    render(<BridgePage />)
+    const link = screen.getByRole("link", { name: /go to your dashboard/i })
+    expect(link).toHaveAttribute("href", "/dashboard")
+  })
+
+  it("links out to Circle CCTP and Stellar Expert", () => {
+    render(<BridgePage />)
+    expect(screen.getByRole("link", { name: /circle cctp/i })).toHaveAttribute(
+      "href",
+      "https://www.circle.com/cross-chain-transfer-protocol"
+    )
+    expect(screen.getByRole("link", { name: /stellar expert/i })).toHaveAttribute(
+      "href",
+      "https://stellar.expert/explorer/testnet"
+    )
+  })
+})

--- a/frontend/__tests__/bridge-page.test.tsx
+++ b/frontend/__tests__/bridge-page.test.tsx
@@ -11,9 +11,7 @@ describe("BridgePage", () => {
 
   it("explains both bridging paths", () => {
     render(<BridgePage />)
-    expect(screen.getAllByText(/Cross-Chain Transfer Protocol \(CCTP\)/i).length).toBeGreaterThan(
-      0
-    )
+    expect(screen.getAllByText(/Cross-Chain Transfer Protocol \(CCTP\)/i).length).toBeGreaterThan(0)
     expect(screen.getByText(/Option B: Stellar's native USDC/i)).toBeInTheDocument()
   })
 

--- a/frontend/__tests__/group-actions.test.tsx
+++ b/frontend/__tests__/group-actions.test.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { render, screen, waitFor } from "@/test-utils"
 import { GroupActions } from "@/components/group/group-actions"
-import { vi, describe, it, expect, beforeEach } from "vitest"
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest"
 
 vi.mock("@/hooks/useJointSaveContracts")
 
@@ -18,6 +18,10 @@ describe("GroupActions Component", () => {
         token_decimals: 7,
       }),
     })
+  })
+
+  afterEach(() => {
+    localStorage.removeItem("jointsave_address")
   })
 
   it("renders quick actions title and stellar address info", async () => {
@@ -117,6 +121,78 @@ describe("GroupActions Component", () => {
       expect(screen.getByRole("button", { name: /Contribute/i })).toBeInTheDocument()
       expect(screen.getByRole("button", { name: /Withdraw/i })).toBeInTheDocument()
       expect(screen.getByRole("button", { name: /Refund/i })).toBeInTheDocument()
+    })
+  })
+
+  it("shows the connected wallet's token balance next to the deposit label", async () => {
+    localStorage.setItem("jointsave_address", "GCONNECTEDTESTADDRESS")
+
+    render(
+      <GroupActions
+        groupId="pool-1"
+        poolAddress="CBZNGP52FLFZ4BOGC265FUAMP5KFMAYPQK3KTI5UHMYVMM3QCST3IMRI"
+        poolType="flexible"
+        tokenAddress="native"
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(/Balance: 100\.00 XLM/i)).toBeInTheDocument()
+    })
+  })
+
+  it("shows an approximate USD value once a deposit amount is entered", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event")
+    const user = userEvent.setup()
+    localStorage.setItem("jointsave_address", "GCONNECTEDTESTADDRESS")
+
+    render(
+      <GroupActions
+        groupId="pool-1"
+        poolAddress="CBZNGP52FLFZ4BOGC265FUAMP5KFMAYPQK3KTI5UHMYVMM3QCST3IMRI"
+        poolType="flexible"
+        tokenAddress="native"
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Deposit Amount/i)).toBeInTheDocument()
+    })
+
+    await user.type(screen.getByLabelText(/Deposit Amount/i), "100")
+
+    await waitFor(() => {
+      expect(screen.getByText(/≈ \$12\.00/)).toBeInTheDocument()
+    })
+  })
+
+  it("nudges USDC pools with an empty balance toward the bridge page", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: "pool-1",
+        name: "USDC Pool",
+        type: "flexible",
+        token_symbol: "USDC",
+        token_decimals: 7,
+      }),
+    })
+    const { fetchTokenBalance } = await import("@/hooks/useJointSaveContracts")
+    vi.mocked(fetchTokenBalance).mockResolvedValueOnce(0n)
+    localStorage.setItem("jointsave_address", "GCONNECTEDTESTADDRESS")
+
+    render(
+      <GroupActions
+        groupId="pool-1"
+        poolAddress="CBZNGP52FLFZ4BOGC265FUAMP5KFMAYPQK3KTI5UHMYVMM3QCST3IMRI"
+        poolType="flexible"
+        tokenAddress="native"
+      />
+    )
+
+    await waitFor(() => {
+      const link = screen.getByRole("link", { name: /bridge usdc to stellar/i })
+      expect(link).toHaveAttribute("href", "/bridge")
     })
   })
 })

--- a/frontend/__tests__/token-select.test.tsx
+++ b/frontend/__tests__/token-select.test.tsx
@@ -1,0 +1,44 @@
+import React from "react"
+import { render, screen } from "@/test-utils"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+import { TokenSelect } from "@/components/create-group/token-select"
+import { SUPPORTED_TOKENS } from "@/lib/token-utils"
+
+describe("TokenSelect", () => {
+  it("defaults to native XLM in the trigger", () => {
+    render(<TokenSelect onChange={vi.fn()} />)
+    expect(screen.getByRole("combobox")).toHaveTextContent("XLM (native)")
+  })
+
+  it("reports the registry's USDC token when USDC is selected", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<TokenSelect onChange={onChange} />)
+
+    await user.click(screen.getByRole("combobox"))
+    await user.click(await screen.findByRole("option", { name: "USDC" }))
+
+    const usdc = SUPPORTED_TOKENS.find((t) => t.symbol === "USDC")!
+    expect(onChange).toHaveBeenCalledWith({
+      address: usdc.contractAddress,
+      symbol: usdc.symbol,
+      decimals: usdc.decimals,
+    })
+    expect(screen.getByText(/see the bridge guide/i)).toBeInTheDocument()
+  })
+
+  it("switches back to native XLM when re-selected", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<TokenSelect onChange={onChange} />)
+
+    await user.click(screen.getByRole("combobox"))
+    await user.click(await screen.findByRole("option", { name: "USDC" }))
+
+    await user.click(screen.getByRole("combobox"))
+    await user.click(await screen.findByRole("option", { name: "XLM (native)" }))
+
+    expect(onChange).toHaveBeenLastCalledWith({ address: "native", symbol: "XLM", decimals: 7 })
+  })
+})

--- a/frontend/__tests__/token-utils.test.ts
+++ b/frontend/__tests__/token-utils.test.ts
@@ -59,7 +59,9 @@ describe("token-utils", () => {
     })
 
     it("returns undefined for an unregistered address", () => {
-      expect(getTokenByAddress("CUNKNOWNTOKENADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")).toBeUndefined()
+      expect(
+        getTokenByAddress("CUNKNOWNTOKENADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+      ).toBeUndefined()
     })
   })
 

--- a/frontend/__tests__/token-utils.test.ts
+++ b/frontend/__tests__/token-utils.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import {
+  SUPPORTED_TOKENS,
+  getTokenBySymbol,
+  getTokenByAddress,
+  formatTokenDisplayAmount,
+  getTokenBalance,
+  getUsdApproxValue,
+  formatUsdApprox,
+} from "@/lib/token-utils"
+import { fetchTokenBalance } from "@/hooks/useJointSaveContracts"
+
+vi.mock("@/hooks/useJointSaveContracts")
+
+describe("token-utils", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe("SUPPORTED_TOKENS", () => {
+    it("registers native XLM and USDC", () => {
+      const symbols = SUPPORTED_TOKENS.map((t) => t.symbol)
+      expect(symbols).toEqual(["XLM", "USDC"])
+    })
+
+    it("gives XLM the native address and 7 decimals", () => {
+      const xlm = SUPPORTED_TOKENS[0]
+      expect(xlm.contractAddress).toBe("native")
+      expect(xlm.decimals).toBe(7)
+    })
+
+    it("gives USDC a Stellar contract address", () => {
+      const usdc = SUPPORTED_TOKENS[1]
+      expect(usdc.contractAddress).toMatch(/^C[A-Z0-9]{55}$/)
+    })
+  })
+
+  describe("getTokenBySymbol", () => {
+    it("finds a token case-insensitively", () => {
+      expect(getTokenBySymbol("usdc")?.symbol).toBe("USDC")
+      expect(getTokenBySymbol("XLM")?.symbol).toBe("XLM")
+    })
+
+    it("returns undefined for an unknown or missing symbol", () => {
+      expect(getTokenBySymbol("BTC")).toBeUndefined()
+      expect(getTokenBySymbol(null)).toBeUndefined()
+      expect(getTokenBySymbol(undefined)).toBeUndefined()
+    })
+  })
+
+  describe("getTokenByAddress", () => {
+    it("resolves 'native' to the XLM entry", () => {
+      expect(getTokenByAddress("native")?.symbol).toBe("XLM")
+    })
+
+    it("resolves a known contract id to its token", () => {
+      const usdc = SUPPORTED_TOKENS[1]
+      expect(getTokenByAddress(usdc.contractAddress)?.symbol).toBe("USDC")
+    })
+
+    it("returns undefined for an unregistered address", () => {
+      expect(getTokenByAddress("CUNKNOWNTOKENADDRESSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")).toBeUndefined()
+    })
+  })
+
+  describe("formatTokenDisplayAmount", () => {
+    it("formats base units using the token's decimals", () => {
+      const xlm = getTokenBySymbol("XLM")!
+      expect(formatTokenDisplayAmount(1250000000n, xlm)).toBe("125.00 XLM")
+    })
+
+    it("formats a zero balance", () => {
+      const usdc = getTokenBySymbol("USDC")!
+      expect(formatTokenDisplayAmount(0n, usdc)).toBe("0.00 USDC")
+    })
+  })
+
+  describe("getTokenBalance", () => {
+    it("converts the on-chain base-unit balance to a human number", async () => {
+      vi.mocked(fetchTokenBalance).mockResolvedValueOnce(500000000n)
+      const xlm = getTokenBySymbol("XLM")!
+      const balance = await getTokenBalance("GABCDEF", xlm)
+      expect(balance).toBe(50)
+      expect(fetchTokenBalance).toHaveBeenCalledWith(xlm.contractAddress, "GABCDEF")
+    })
+
+    it("resolves to 0 instead of throwing when the RPC call fails", async () => {
+      vi.mocked(fetchTokenBalance).mockRejectedValueOnce(new Error("account not found"))
+      const usdc = getTokenBySymbol("USDC")!
+      const balance = await getTokenBalance("GABCDEF", usdc)
+      expect(balance).toBe(0)
+    })
+  })
+
+  describe("getUsdApproxValue", () => {
+    it("treats USDC as ~1:1 with USD", () => {
+      const usdc = getTokenBySymbol("USDC")!
+      expect(getUsdApproxValue(100, usdc)).toBe(100)
+    })
+
+    it("applies the fallback rate for XLM", () => {
+      const xlm = getTokenBySymbol("XLM")!
+      expect(getUsdApproxValue(100, xlm)).toBeCloseTo(12, 5)
+    })
+
+    it("returns 0 for non-positive or non-finite amounts", () => {
+      const xlm = getTokenBySymbol("XLM")!
+      expect(getUsdApproxValue(0, xlm)).toBe(0)
+      expect(getUsdApproxValue(-5, xlm)).toBe(0)
+      expect(getUsdApproxValue(NaN, xlm)).toBe(0)
+    })
+  })
+
+  describe("formatUsdApprox", () => {
+    it("formats with the approx symbol and 2 decimals", () => {
+      const usdc = getTokenBySymbol("USDC")!
+      expect(formatUsdApprox(42.5, usdc)).toBe("≈ $42.50")
+    })
+  })
+})

--- a/frontend/app/api/pools/route.ts
+++ b/frontend/app/api/pools/route.ts
@@ -239,13 +239,14 @@ export async function PATCH(req: NextRequest) {
 
     // If body contains an `activity` object, log it to pool_activity
     if (body.activity) {
-      const { activity_type, user_address, amount, tx_hash } = body.activity
+      const { activity_type, user_address, amount, token_amount, tx_hash } = body.activity
       const { error: actErr } = await supabase.from("pool_activity").insert([
         {
           pool_id: poolId,
           activity_type,
           user_address: user_address?.toLowerCase() || null,
           amount: amount || null,
+          token_amount: token_amount ?? amount ?? null,
           tx_hash: tx_hash || null,
           description: `${activity_type} transaction`,
         },

--- a/frontend/app/api/portfolio/summary/route.test.ts
+++ b/frontend/app/api/portfolio/summary/route.test.ts
@@ -1,0 +1,82 @@
+import { test } from "node:test"
+import assert from "node:assert"
+
+// ── Per-token net-saved calculation (mirrors the route's computation) ────────
+
+interface Activity {
+  pool_id: string
+  activity_type: string
+  amount: number | null
+}
+
+function computeTotalSavedByToken(
+  activities: Activity[],
+  tokenSymbolByPool: Map<string, string>
+): Record<string, number> {
+  const totals: Record<string, number> = {}
+  for (const a of activities) {
+    const symbol = tokenSymbolByPool.get(a.pool_id) || "XLM"
+    const signed =
+      a.activity_type === "deposit"
+        ? a.amount || 0
+        : a.activity_type === "withdraw" || a.activity_type === "payout"
+          ? -(a.amount || 0)
+          : 0
+    if (signed === 0) continue
+    totals[symbol] = (totals[symbol] || 0) + signed
+  }
+  for (const symbol of Object.keys(totals)) {
+    totals[symbol] = Math.max(0, totals[symbol])
+  }
+  return totals
+}
+
+test("computeTotalSavedByToken — splits deposits by the pool's token symbol", () => {
+  const pools = new Map([
+    ["pool-xlm", "XLM"],
+    ["pool-usdc", "USDC"],
+  ])
+  const activities: Activity[] = [
+    { pool_id: "pool-xlm", activity_type: "deposit", amount: 100 },
+    { pool_id: "pool-usdc", activity_type: "deposit", amount: 250 },
+  ]
+  const totals = computeTotalSavedByToken(activities, pools)
+  assert.deepStrictEqual(totals, { XLM: 100, USDC: 250 })
+})
+
+test("computeTotalSavedByToken — nets withdrawals and payouts against deposits", () => {
+  const pools = new Map([["pool-usdc", "USDC"]])
+  const activities: Activity[] = [
+    { pool_id: "pool-usdc", activity_type: "deposit", amount: 500 },
+    { pool_id: "pool-usdc", activity_type: "withdraw", amount: 200 },
+  ]
+  const totals = computeTotalSavedByToken(activities, pools)
+  assert.deepStrictEqual(totals, { USDC: 300 })
+})
+
+test("computeTotalSavedByToken — clamps a token's total at 0, never negative", () => {
+  const pools = new Map([["pool-usdc", "USDC"]])
+  const activities: Activity[] = [
+    { pool_id: "pool-usdc", activity_type: "deposit", amount: 50 },
+    { pool_id: "pool-usdc", activity_type: "payout", amount: 200 },
+  ]
+  const totals = computeTotalSavedByToken(activities, pools)
+  assert.deepStrictEqual(totals, { USDC: 0 })
+})
+
+test("computeTotalSavedByToken — defaults to XLM when a pool has no token symbol on record", () => {
+  const pools = new Map<string, string>()
+  const activities: Activity[] = [{ pool_id: "legacy-pool", activity_type: "deposit", amount: 40 }]
+  const totals = computeTotalSavedByToken(activities, pools)
+  assert.deepStrictEqual(totals, { XLM: 40 })
+})
+
+test("computeTotalSavedByToken — ignores non-financial activity types", () => {
+  const pools = new Map([["pool-usdc", "USDC"]])
+  const activities: Activity[] = [
+    { pool_id: "pool-usdc", activity_type: "member_added", amount: null },
+    { pool_id: "pool-usdc", activity_type: "deposit", amount: 10 },
+  ]
+  const totals = computeTotalSavedByToken(activities, pools)
+  assert.deepStrictEqual(totals, { USDC: 10 })
+})

--- a/frontend/app/api/portfolio/summary/route.ts
+++ b/frontend/app/api/portfolio/summary/route.ts
@@ -41,6 +41,7 @@ export async function GET(req: NextRequest) {
     if (poolIds.length === 0) {
       return NextResponse.json({
         total_saved: 0,
+        total_saved_by_token: {},
         total_pools: { rotational: 0, target: 0, flexible: 0, total: 0 },
         total_yield_earned: 0,
         upcoming_commitments: [],
@@ -79,6 +80,26 @@ export async function GET(req: NextRequest) {
       .reduce((s, a) => s + (a.amount || 0), 0)
 
     const total_saved = Math.max(0, deposits - withdrawals)
+
+    // Same net-saved calculation, broken out per token symbol so the
+    // dashboard can show "Total XLM: X | Total USDC: Y" instead of summing
+    // across currencies.
+    const tokenSymbolByPool = new Map(userPools.map((p) => [p.id, p.token_symbol || "XLM"]))
+    const total_saved_by_token: Record<string, number> = {}
+    for (const a of userActivities) {
+      const symbol = tokenSymbolByPool.get(a.pool_id) || "XLM"
+      const signed =
+        a.activity_type === "deposit"
+          ? a.amount || 0
+          : a.activity_type === "withdraw" || a.activity_type === "payout"
+            ? -(a.amount || 0)
+            : 0
+      if (signed === 0) continue
+      total_saved_by_token[symbol] = (total_saved_by_token[symbol] || 0) + signed
+    }
+    for (const symbol of Object.keys(total_saved_by_token)) {
+      total_saved_by_token[symbol] = Math.max(0, total_saved_by_token[symbol])
+    }
 
     const poolsByType = { rotational: 0, target: 0, flexible: 0 }
     userPools.forEach((p) => {
@@ -145,6 +166,7 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.json({
       total_saved,
+      total_saved_by_token,
       total_pools: { ...poolsByType, total: userPools.length },
       total_yield_earned,
       upcoming_commitments,

--- a/frontend/app/bridge/page.tsx
+++ b/frontend/app/bridge/page.tsx
@@ -16,46 +16,38 @@ export const metadata: Metadata = {
 const cctpSteps = [
   {
     title: "Open a CCTP-enabled bridge",
-    body:
-      "Circle's Cross-Chain Transfer Protocol (CCTP) burns USDC on the source chain and mints native USDC on Stellar — no wrapped assets, no extra gas token needed on the destination side. Use a CCTP-enabled interface such as Circle's own bridge, Allbridge, or Portal.",
+    body: "Circle's Cross-Chain Transfer Protocol (CCTP) burns USDC on the source chain and mints native USDC on Stellar — no wrapped assets, no extra gas token needed on the destination side. Use a CCTP-enabled interface such as Circle's own bridge, Allbridge, or Portal.",
   },
   {
     title: "Connect your source-chain wallet",
-    body:
-      "Connect the wallet holding your USDC on Ethereum, Base, Avalanche, or another CCTP-supported chain. Select Stellar as the destination network.",
+    body: "Connect the wallet holding your USDC on Ethereum, Base, Avalanche, or another CCTP-supported chain. Select Stellar as the destination network.",
   },
   {
     title: "Enter your Stellar address",
-    body:
-      "Paste the Stellar (G…) address you use with JointSave as the recipient. Double-check it — Stellar transfers to accounts without the right trustline or memo can be unrecoverable, so most bridge UIs will warn you if something looks off.",
+    body: "Paste the Stellar (G…) address you use with JointSave as the recipient. Double-check it — Stellar transfers to accounts without the right trustline or memo can be unrecoverable, so most bridge UIs will warn you if something looks off.",
   },
   {
     title: "Confirm the burn-and-mint",
-    body:
-      "Approve the transaction on the source chain. CCTP burns your USDC there and, once Circle's attestation confirms, mints the equivalent amount of native USDC directly into your Stellar account. This typically takes a few minutes.",
+    body: "Approve the transaction on the source chain. CCTP burns your USDC there and, once Circle's attestation confirms, mints the equivalent amount of native USDC directly into your Stellar account. This typically takes a few minutes.",
   },
   {
     title: "Deposit into your pool",
-    body:
-      "Once the USDC lands in your Stellar wallet, open your JointSave pool and deposit as usual — the deposit form shows your live USDC balance and the correct token contract is used automatically.",
+    body: "Once the USDC lands in your Stellar wallet, open your JointSave pool and deposit as usual — the deposit form shows your live USDC balance and the correct token contract is used automatically.",
   },
 ]
 
 const stellarUsdcSteps = [
   {
     title: "Already hold USDC via a centralized exchange?",
-    body:
-      "Many exchanges (Coinbase, Kraken, and others) support withdrawing USDC directly on the Stellar network. Choose \"Stellar\" as the withdrawal network and send to your JointSave wallet's G… address.",
+    body: 'Many exchanges (Coinbase, Kraken, and others) support withdrawing USDC directly on the Stellar network. Choose "Stellar" as the withdrawal network and send to your JointSave wallet\'s G… address.',
   },
   {
     title: "Add a USDC trustline",
-    body:
-      "Stellar accounts must \"trust\" an asset before they can hold it. Most modern Stellar wallets (Freighter, Lobstr, xBull) prompt you to add the USDC trustline automatically the first time you receive it — if not, add it manually from your wallet's assets screen.",
+    body: 'Stellar accounts must "trust" an asset before they can hold it. Most modern Stellar wallets (Freighter, Lobstr, xBull) prompt you to add the USDC trustline automatically the first time you receive it — if not, add it manually from your wallet\'s assets screen.',
   },
   {
     title: "Verify on Stellar Expert",
-    body:
-      "Use Stellar Expert to confirm the incoming USDC transaction and that your balance reflects the official Circle-issued USDC asset, not a look-alike.",
+    body: "Use Stellar Expert to confirm the incoming USDC transaction and that your balance reflects the official Circle-issued USDC asset, not a look-alike.",
   },
 ]
 
@@ -109,9 +101,9 @@ export default function BridgePage() {
           Bridge USDC to Stellar
         </h1>
         <p className="mb-8 max-w-2xl text-lg text-muted-foreground text-pretty">
-          JointSave pools accept native USDC on Stellar as a deposit currency alongside XLM. If
-          your USDC lives on Ethereum, Base, Solana, or another chain, here&apos;s how to bring it
-          over before depositing.
+          JointSave pools accept native USDC on Stellar as a deposit currency alongside XLM. If your
+          USDC lives on Ethereum, Base, Solana, or another chain, here&apos;s how to bring it over
+          before depositing.
         </p>
 
         <Alert className="mb-10">
@@ -119,8 +111,8 @@ export default function BridgePage() {
           <AlertTitle>This page is educational only</AlertTitle>
           <AlertDescription>
             JointSave does not custody funds during a bridge transfer or operate a bridge itself.
-            Bridging happens entirely on the external services linked below — always verify URLs
-            and double-check recipient addresses before sending funds.
+            Bridging happens entirely on the external services linked below — always verify URLs and
+            double-check recipient addresses before sending funds.
           </AlertDescription>
         </Alert>
 
@@ -158,8 +150,8 @@ export default function BridgePage() {
                 Option B: Stellar&apos;s native USDC
               </CardTitle>
               <CardDescription>
-                If you already hold USDC on a centralized exchange, you can often withdraw
-                directly to Stellar without bridging at all.
+                If you already hold USDC on a centralized exchange, you can often withdraw directly
+                to Stellar without bridging at all.
               </CardDescription>
             </CardHeader>
             <CardContent>
@@ -186,10 +178,9 @@ export default function BridgePage() {
             </CardHeader>
             <CardContent className="text-sm text-muted-foreground leading-relaxed space-y-2">
               <p>
-                Once USDC shows up in your Stellar wallet, head back to your pool. The deposit
-                form on any USDC-denominated pool automatically reads your live USDC balance and
-                builds the transaction against the correct token contract — no extra
-                configuration needed.
+                Once USDC shows up in your Stellar wallet, head back to your pool. The deposit form
+                on any USDC-denominated pool automatically reads your live USDC balance and builds
+                the transaction against the correct token contract — no extra configuration needed.
               </p>
               <Link
                 href="/dashboard"

--- a/frontend/app/bridge/page.tsx
+++ b/frontend/app/bridge/page.tsx
@@ -1,0 +1,206 @@
+import type { Metadata } from "next"
+import Image from "next/image"
+import Link from "next/link"
+import { ThemeToggle } from "@/components/ui/theme-toggle"
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { ArrowRight, ExternalLink, Info, Wallet, ArrowLeftRight, CheckCircle2 } from "lucide-react"
+
+export const metadata: Metadata = {
+  title: "Bridge USDC to Stellar — JointSave",
+  description:
+    "Step-by-step guide to bringing USDC from Ethereum, Base, or Solana onto Stellar so you can deposit into a JointSave pool.",
+}
+
+const cctpSteps = [
+  {
+    title: "Open a CCTP-enabled bridge",
+    body:
+      "Circle's Cross-Chain Transfer Protocol (CCTP) burns USDC on the source chain and mints native USDC on Stellar — no wrapped assets, no extra gas token needed on the destination side. Use a CCTP-enabled interface such as Circle's own bridge, Allbridge, or Portal.",
+  },
+  {
+    title: "Connect your source-chain wallet",
+    body:
+      "Connect the wallet holding your USDC on Ethereum, Base, Avalanche, or another CCTP-supported chain. Select Stellar as the destination network.",
+  },
+  {
+    title: "Enter your Stellar address",
+    body:
+      "Paste the Stellar (G…) address you use with JointSave as the recipient. Double-check it — Stellar transfers to accounts without the right trustline or memo can be unrecoverable, so most bridge UIs will warn you if something looks off.",
+  },
+  {
+    title: "Confirm the burn-and-mint",
+    body:
+      "Approve the transaction on the source chain. CCTP burns your USDC there and, once Circle's attestation confirms, mints the equivalent amount of native USDC directly into your Stellar account. This typically takes a few minutes.",
+  },
+  {
+    title: "Deposit into your pool",
+    body:
+      "Once the USDC lands in your Stellar wallet, open your JointSave pool and deposit as usual — the deposit form shows your live USDC balance and the correct token contract is used automatically.",
+  },
+]
+
+const stellarUsdcSteps = [
+  {
+    title: "Already hold USDC via a centralized exchange?",
+    body:
+      "Many exchanges (Coinbase, Kraken, and others) support withdrawing USDC directly on the Stellar network. Choose \"Stellar\" as the withdrawal network and send to your JointSave wallet's G… address.",
+  },
+  {
+    title: "Add a USDC trustline",
+    body:
+      "Stellar accounts must \"trust\" an asset before they can hold it. Most modern Stellar wallets (Freighter, Lobstr, xBull) prompt you to add the USDC trustline automatically the first time you receive it — if not, add it manually from your wallet's assets screen.",
+  },
+  {
+    title: "Verify on Stellar Expert",
+    body:
+      "Use Stellar Expert to confirm the incoming USDC transaction and that your balance reflects the official Circle-issued USDC asset, not a look-alike.",
+  },
+]
+
+function StepList({ steps }: { steps: { title: string; body: string }[] }) {
+  return (
+    <ol className="space-y-4">
+      {steps.map((step, i) => (
+        <li key={step.title} className="flex gap-4">
+          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary">
+            {i + 1}
+          </span>
+          <div>
+            <p className="font-medium leading-snug">{step.title}</p>
+            <p className="mt-1 text-sm text-muted-foreground leading-relaxed">{step.body}</p>
+          </div>
+        </li>
+      ))}
+    </ol>
+  )
+}
+
+export default function BridgePage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="fixed top-0 left-0 right-0 z-50 border-b border-border/40 bg-background/80 backdrop-blur-lg">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex h-16 items-center justify-between">
+            <Link href="/" className="flex items-center gap-2">
+              <div className="flex h-10 w-10 items-center justify-center overflow-hidden rounded-xl">
+                <Image
+                  src="/joint-save.jpg"
+                  alt="JointSave Logo"
+                  width={40}
+                  height={40}
+                  className="object-cover"
+                />
+              </div>
+              <span className="text-xl font-bold">JointSave</span>
+            </Link>
+            <ThemeToggle />
+          </div>
+        </div>
+      </header>
+
+      <main className="container mx-auto max-w-3xl px-4 pt-28 pb-24 sm:px-6 lg:px-8">
+        <Badge variant="secondary" className="mb-4 gap-1.5">
+          <ArrowLeftRight className="h-3.5 w-3.5" />
+          Bridge Guide
+        </Badge>
+        <h1 className="mb-4 text-4xl font-bold tracking-tight text-balance sm:text-5xl">
+          Bridge USDC to Stellar
+        </h1>
+        <p className="mb-8 max-w-2xl text-lg text-muted-foreground text-pretty">
+          JointSave pools accept native USDC on Stellar as a deposit currency alongside XLM. If
+          your USDC lives on Ethereum, Base, Solana, or another chain, here&apos;s how to bring it
+          over before depositing.
+        </p>
+
+        <Alert className="mb-10">
+          <Info className="h-4 w-4" />
+          <AlertTitle>This page is educational only</AlertTitle>
+          <AlertDescription>
+            JointSave does not custody funds during a bridge transfer or operate a bridge itself.
+            Bridging happens entirely on the external services linked below — always verify URLs
+            and double-check recipient addresses before sending funds.
+          </AlertDescription>
+        </Alert>
+
+        <div className="space-y-10">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-xl">
+                <ArrowLeftRight className="h-5 w-5 text-primary" />
+                Option A: Circle&apos;s Cross-Chain Transfer Protocol (CCTP)
+              </CardTitle>
+              <CardDescription>
+                The recommended path for USDC held on Ethereum, Base, Avalanche, and other
+                CCTP-supported chains.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <StepList steps={cctpSteps} />
+              <div className="mt-6 flex flex-wrap gap-3">
+                <a
+                  href="https://www.circle.com/cross-chain-transfer-protocol"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+                >
+                  Circle CCTP <ExternalLink className="h-3.5 w-3.5" />
+                </a>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-xl">
+                <Wallet className="h-5 w-5 text-primary" />
+                Option B: Stellar&apos;s native USDC
+              </CardTitle>
+              <CardDescription>
+                If you already hold USDC on a centralized exchange, you can often withdraw
+                directly to Stellar without bridging at all.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <StepList steps={stellarUsdcSteps} />
+              <div className="mt-6 flex flex-wrap gap-3">
+                <a
+                  href="https://stellar.expert/explorer/testnet"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+                >
+                  Stellar Expert <ExternalLink className="h-3.5 w-3.5" />
+                </a>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-xl">
+                <CheckCircle2 className="h-5 w-5 text-primary" />
+                After bridging
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="text-sm text-muted-foreground leading-relaxed space-y-2">
+              <p>
+                Once USDC shows up in your Stellar wallet, head back to your pool. The deposit
+                form on any USDC-denominated pool automatically reads your live USDC balance and
+                builds the transaction against the correct token contract — no extra
+                configuration needed.
+              </p>
+              <Link
+                href="/dashboard"
+                className="inline-flex items-center gap-1.5 font-medium text-primary hover:underline"
+              >
+                Go to your dashboard <ArrowRight className="h-3.5 w-3.5" />
+              </Link>
+            </CardContent>
+          </Card>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/frontend/components/create-group/token-select.tsx
+++ b/frontend/components/create-group/token-select.tsx
@@ -12,6 +12,7 @@ import {
 import { Loader2, CheckCircle2, AlertCircle } from "lucide-react"
 import { FieldTooltip } from "@/components/ui/field-tooltip"
 import { fetchTokenMetadata, type TokenMetadata } from "@/hooks/useJointSaveContracts"
+import { SUPPORTED_TOKENS } from "@/lib/token-utils"
 
 /** What the parent form needs to create a pool with the chosen token. */
 export interface SelectedToken {
@@ -22,23 +23,34 @@ export interface SelectedToken {
 }
 
 const NATIVE: SelectedToken = { address: "native", symbol: "XLM", decimals: 7 }
+const USDC_TOKEN = SUPPORTED_TOKENS.find((t) => t.symbol === "USDC")!
+const USDC: SelectedToken = {
+  address: USDC_TOKEN.contractAddress,
+  symbol: USDC_TOKEN.symbol,
+  decimals: USDC_TOKEN.decimals,
+}
 const isValidContractId = (id: string) => /^C[A-Z2-7]{55}$/.test(id)
 
+type TokenMode = "native" | "usdc" | "custom"
+
 /**
- * Token picker shared by all three creation forms. Defaults to native XLM; when
- * "Custom token" is chosen it resolves the SEP-41 name/symbol/decimals via a view
- * call and reports the resolved `SelectedToken` to the parent. The parent should
- * also seed its own state to native XLM so submit works without interaction.
+ * Token picker shared by all three creation forms. Defaults to native XLM;
+ * "USDC" uses the well-known registry entry from `lib/token-utils` directly
+ * (see the bridge tutorial at /bridge for getting USDC onto Stellar first).
+ * "Custom token" resolves any other SEP-41 token's name/symbol/decimals via a
+ * view call and reports the resolved `SelectedToken` to the parent. The
+ * parent should also seed its own state to native XLM so submit works
+ * without interaction.
  */
 export function TokenSelect({ onChange }: { onChange: (token: SelectedToken) => void }) {
-  const [mode, setMode] = useState<"native" | "custom">("native")
+  const [mode, setMode] = useState<TokenMode>("native")
   const [customId, setCustomId] = useState("")
   const [status, setStatus] = useState<"idle" | "loading" | "ok" | "error">("idle")
   const [meta, setMeta] = useState<TokenMetadata | null>(null)
   const [error, setError] = useState("")
 
   const handleMode = (v: string) => {
-    const next = v as "native" | "custom"
+    const next = v as TokenMode
     setMode(next)
     setError("")
     setMeta(null)
@@ -46,6 +58,9 @@ export function TokenSelect({ onChange }: { onChange: (token: SelectedToken) => 
     if (next === "native") {
       setCustomId("")
       onChange(NATIVE)
+    } else if (next === "usdc") {
+      setCustomId("")
+      onChange(USDC)
     }
   }
 
@@ -74,8 +89,8 @@ export function TokenSelect({ onChange }: { onChange: (token: SelectedToken) => 
   return (
     <div className="space-y-2">
       <FieldTooltip
-        label="Token"
-        tooltip="The asset members deposit. Defaults to native XLM. Choose 'Custom token' to use any SEP-41 token (e.g. USDC) by its contract id."
+        label="Deposit Currency"
+        tooltip="The asset members deposit. Defaults to native XLM. Choose USDC to use Stellar's native USDC, or 'Custom token' for any other SEP-41 token by its contract id."
         required
       />
       <Select value={mode} onValueChange={handleMode}>
@@ -84,9 +99,20 @@ export function TokenSelect({ onChange }: { onChange: (token: SelectedToken) => 
         </SelectTrigger>
         <SelectContent>
           <SelectItem value="native">XLM (native)</SelectItem>
+          <SelectItem value="usdc">USDC</SelectItem>
           <SelectItem value="custom">Custom token…</SelectItem>
         </SelectContent>
       </Select>
+
+      {mode === "usdc" && (
+        <p className="text-xs text-muted-foreground">
+          Members deposit native USDC on Stellar. Bridging USDC from another chain?{" "}
+          <a href="/bridge" className="text-primary hover:underline">
+            See the bridge guide
+          </a>
+          .
+        </p>
+      )}
 
       {mode === "custom" && (
         <div className="space-y-1">

--- a/frontend/components/dashboard/dashboard-header.tsx
+++ b/frontend/components/dashboard/dashboard-header.tsx
@@ -76,7 +76,7 @@ export function DashboardHeader() {
             <Button variant="ghost" size="sm" asChild className="hidden sm:flex">
               <Link href="/explore">Explore</Link>
             </Button>
-            <Button variant="ghost" size="sm" asChild className="hidden sm:flex">
+            <Button variant="ghost" size="sm" asChild className="hidden lg:flex">
               <Link href="/bridge">Bridge USDC</Link>
             </Button>
             <ThemeToggle />

--- a/frontend/components/dashboard/dashboard-header.tsx
+++ b/frontend/components/dashboard/dashboard-header.tsx
@@ -76,6 +76,9 @@ export function DashboardHeader() {
             <Button variant="ghost" size="sm" asChild className="hidden sm:flex">
               <Link href="/explore">Explore</Link>
             </Button>
+            <Button variant="ghost" size="sm" asChild className="hidden sm:flex">
+              <Link href="/bridge">Bridge USDC</Link>
+            </Button>
             <ThemeToggle />
 
             {/* Notification bell — only shown when wallet is connected */}

--- a/frontend/components/dashboard/portfolio.tsx
+++ b/frontend/components/dashboard/portfolio.tsx
@@ -43,6 +43,7 @@ interface UpcomingCommitment {
 
 interface PortfolioData {
   total_saved: number
+  total_saved_by_token: Record<string, number>
   total_pools: { rotational: number; target: number; flexible: number; total: number }
   total_yield_earned: number
   upcoming_commitments: UpcomingCommitment[]
@@ -218,7 +219,31 @@ export function Portfolio() {
             <Wallet className="h-4 w-4 text-emerald-500" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{data.total_saved.toFixed(2)} XLM</div>
+            {(() => {
+              const byToken = Object.entries(data.total_saved_by_token || {}).filter(
+                ([, v]) => v > 0
+              )
+              if (byToken.length === 0) {
+                return <div className="text-2xl font-bold">{data.total_saved.toFixed(2)} XLM</div>
+              }
+              if (byToken.length === 1) {
+                const [symbol, value] = byToken[0]
+                return (
+                  <div className="text-2xl font-bold">
+                    {value.toFixed(2)} {symbol}
+                  </div>
+                )
+              }
+              return (
+                <div className="space-y-0.5" data-testid="total-saved-by-token">
+                  {byToken.map(([symbol, value]) => (
+                    <div key={symbol} className="text-lg font-bold">
+                      {value.toFixed(2)} {symbol}
+                    </div>
+                  ))}
+                </div>
+              )
+            })()}
             <p className="text-xs text-muted-foreground mt-1">Net deposits minus withdrawals</p>
           </CardContent>
         </Card>

--- a/frontend/components/group/group-actions.tsx
+++ b/frontend/components/group/group-actions.tsx
@@ -629,7 +629,10 @@ export function GroupActions({
               )}
               {!isRotational && depositAmount && !isNaN(parseFloat(depositAmount)) && (
                 <p className="text-xs text-muted-foreground">
-                  {formatUsdApprox(parseFloat(depositAmount), getTokenBySymbol(tokenSymbol) ?? getTokenBySymbol("XLM")!)}
+                  {formatUsdApprox(
+                    parseFloat(depositAmount),
+                    getTokenBySymbol(tokenSymbol) ?? getTokenBySymbol("XLM")!
+                  )}
                 </p>
               )}
               <p className="text-xs text-muted-foreground">

--- a/frontend/components/group/group-actions.tsx
+++ b/frontend/components/group/group-actions.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-
 import Link from "next/link"
 import { useState, useEffect, useCallback, useRef } from "react"
 import { Card } from "@/components/ui/card"
@@ -163,9 +162,6 @@ export function GroupActions({
   const isAdmin = !!address && !!poolAdmin && address.toUpperCase() === poolAdmin.toUpperCase()
   const [depositAmount, setDepositAmount] = useState("")
   const [withdrawAmount, setWithdrawAmount] = useState("")
-  // Used by the transaction preview / leave-pool dialogs below.
-  const [, setError] = useState("")
-  const [, setSuccessMsg] = useState("")
 
   // Pool metadata from Supabase
   const [poolData, setPoolData] = useState<Record<string, unknown> | null>(null)
@@ -620,32 +616,32 @@ export function GroupActions({
           <div className="space-y-6">
             {/* Deposit / Contribute */}
 
-        <div ref={depositButtonRef} className="space-y-3">
-          {highlightDeposit && (
-            <div className="flex items-center gap-2 rounded-lg bg-primary/10 border border-primary/40 px-3 py-2 text-sm font-medium text-primary animate-pulse">
-              <ArrowUpRight className="h-4 w-4" />
-              Make your first deposit to get the cycle going!
-            </div>
-          )}
-          <div className="flex items-center justify-between">
-            <Label htmlFor="deposit">
-              {isRotational
-                ? "Deposit Fixed Amount"
-                : isTarget
-                  ? `Contribute Amount (${tokenSymbol})`
-                  : `Deposit Amount (${tokenSymbol})`}
-            </Label>
-            {address &&
-              (balanceLoading ? (
-                <Skeleton className="h-3 w-24" />
-              ) : (
-                walletBalance !== null && (
-                  <span className="text-xs text-muted-foreground">
-                    Balance: {walletBalance.toFixed(2)} {tokenSymbol}
-                  </span>
-                )
-              ))}
-          </div>
+            <div ref={depositButtonRef} className="space-y-3">
+              {highlightDeposit && (
+                <div className="flex items-center gap-2 rounded-lg bg-primary/10 border border-primary/40 px-3 py-2 text-sm font-medium text-primary animate-pulse">
+                  <ArrowUpRight className="h-4 w-4" />
+                  Make your first deposit to get the cycle going!
+                </div>
+              )}
+              <div className="flex items-center justify-between">
+                <Label htmlFor="deposit">
+                  {isRotational
+                    ? "Deposit Fixed Amount"
+                    : isTarget
+                      ? `Contribute Amount (${tokenSymbol})`
+                      : `Deposit Amount (${tokenSymbol})`}
+                </Label>
+                {address &&
+                  (balanceLoading ? (
+                    <Skeleton className="h-3 w-24" />
+                  ) : (
+                    walletBalance !== null && (
+                      <span className="text-xs text-muted-foreground">
+                        Balance: {walletBalance.toFixed(2)} {tokenSymbol}
+                      </span>
+                    )
+                  ))}
+              </div>
               {!isRotational && (
                 <Input
                   id="deposit"

--- a/frontend/components/group/group-actions.tsx
+++ b/frontend/components/group/group-actions.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect, useCallback } from "react"
+import Link from "next/link"
 import { Card } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -35,6 +36,7 @@ import {
   fetchPoolMembers,
 } from "@/hooks/useJointSaveContracts"
 import { validateStellarAddress } from "@/lib/form-validation"
+import { getTokenBySymbol, getTokenBalance, formatUsdApprox } from "@/lib/token-utils"
 import { useOptimisticTransactions } from "@/hooks/useOptimisticTransactions"
 import { toastManager } from "@/lib/toast"
 import {
@@ -81,6 +83,7 @@ async function logActivity(
           activity_type: type,
           user_address: userAddress,
           amount: amount ? parseFloat(amount) : null,
+          token_amount: amount ? parseFloat(amount) : null,
           tx_hash: txHash,
         },
         memberAddress: memberAddress || null,
@@ -147,11 +150,38 @@ export function GroupActions({
   const [newMember, setNewMember] = useState("")
   const [memberToRemove, setMemberToRemove] = useState<string | null>(null)
   const [showLeaveDialog, setShowLeaveDialog] = useState(false)
+  const [error, setError] = useState("")
+  const [successMsg, setSuccessMsg] = useState("")
   const isPending = !poolAddress || poolAddress === "pending_deployment"
   // Token display metadata (persisted on the pool row; defaults to native XLM)
   const tokenSymbol: string = (poolData?.token_symbol as string) ?? "XLM"
   const tokenDecimals: number = (poolData?.token_decimals as number) ?? 7
   const toBaseUnits = (amount: number) => BigInt(Math.round(amount * 10 ** tokenDecimals))
+
+  // Wallet balance in the pool's deposit currency (for the deposit form) —
+  // resolved via the token registry so both native XLM and USDC work.
+  const [walletBalance, setWalletBalance] = useState<number | null>(null)
+  const [balanceLoading, setBalanceLoading] = useState(false)
+
+  useEffect(() => {
+    if (!address) {
+      setWalletBalance(null)
+      return
+    }
+    let cancelled = false
+    const token = getTokenBySymbol(tokenSymbol) ?? getTokenBySymbol("XLM")!
+    setBalanceLoading(true)
+    getTokenBalance(address, token)
+      .then((bal) => {
+        if (!cancelled) setWalletBalance(bal)
+      })
+      .finally(() => {
+        if (!cancelled) setBalanceLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [address, tokenSymbol])
 
   // Modal Preview states
   const [isPreviewOpen, setIsPreviewOpen] = useState(false)
@@ -567,13 +597,25 @@ export function GroupActions({
           <div className="space-y-6">
             {/* Deposit / Contribute */}
             <div className="space-y-3">
-              <Label htmlFor="deposit">
-                {isRotational
-                  ? "Deposit Fixed Amount"
-                  : isTarget
-                    ? `Contribute Amount (${tokenSymbol})`
-                    : `Deposit Amount (${tokenSymbol})`}
-              </Label>
+              <div className="flex items-center justify-between">
+                <Label htmlFor="deposit">
+                  {isRotational
+                    ? "Deposit Fixed Amount"
+                    : isTarget
+                      ? `Contribute Amount (${tokenSymbol})`
+                      : `Deposit Amount (${tokenSymbol})`}
+                </Label>
+                {address &&
+                  (balanceLoading ? (
+                    <Skeleton className="h-3 w-24" />
+                  ) : (
+                    walletBalance !== null && (
+                      <span className="text-xs text-muted-foreground">
+                        Balance: {walletBalance.toFixed(2)} {tokenSymbol}
+                      </span>
+                    )
+                  ))}
+              </div>
               {!isRotational && (
                 <Input
                   id="deposit"
@@ -585,11 +627,24 @@ export function GroupActions({
                   disabled={isDepositLoading || actionsDisabled}
                 />
               )}
+              {!isRotational && depositAmount && !isNaN(parseFloat(depositAmount)) && (
+                <p className="text-xs text-muted-foreground">
+                  {formatUsdApprox(parseFloat(depositAmount), getTokenBySymbol(tokenSymbol) ?? getTokenBySymbol("XLM")!)}
+                </p>
+              )}
               <p className="text-xs text-muted-foreground">
                 {isRotational && "Deposit the fixed pool amount. Same for all members."}
                 {isTarget && "Contribute any amount toward the target goal."}
                 {isFlexible && "Deposit any amount (must meet minimum). Withdraw anytime."}
               </p>
+              {tokenSymbol === "USDC" && address && walletBalance === 0 && (
+                <p className="text-xs text-muted-foreground">
+                  No USDC in this wallet yet?{" "}
+                  <Link href="/bridge" className="text-primary hover:underline">
+                    Bridge USDC to Stellar
+                  </Link>
+                </p>
+              )}
               <Button
                 className="w-full bg-primary hover:bg-primary/90"
                 onClick={handleDeposit}
@@ -911,6 +966,9 @@ export function GroupActions({
                 Triggering the payout earns you the relayer fee reward directly in your wallet.
               </p>
             )}
+
+            {error && <p className="text-xs text-destructive text-center">{error}</p>}
+            {successMsg && <p className="text-xs text-green-600 text-center">{successMsg}</p>}
           </div>
 
           <DialogFooter className="gap-2 sm:gap-0">

--- a/frontend/components/landing/footer.tsx
+++ b/frontend/components/landing/footer.tsx
@@ -53,6 +53,14 @@ export function Footer() {
                   Security
                 </Link>
               </li>
+              <li>
+                <Link
+                  href="/bridge"
+                  className="text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  Bridge USDC
+                </Link>
+              </li>
             </ul>
           </div>
 

--- a/frontend/hooks/__mocks__/useJointSaveContracts.ts
+++ b/frontend/hooks/__mocks__/useJointSaveContracts.ts
@@ -38,6 +38,8 @@ export const ledgerToEstimatedDate = (_ledger: number, _current = 1000) => new D
 
 export const fetchTokenMetadata = vi.fn().mockResolvedValue(NATIVE_TOKEN_METADATA)
 
+export const fetchTokenBalance = vi.fn().mockResolvedValue(1000000000n)
+
 export const fetchRotationalState = vi.fn().mockResolvedValue({
   currentRound: 0,
   roundDuration: 86400,

--- a/frontend/hooks/useJointSaveContracts.ts
+++ b/frontend/hooks/useJointSaveContracts.ts
@@ -85,6 +85,8 @@ function e2eViewResult(method: string): xdr.ScVal {
       return i128Val(BigInt((s.totalBalance as number | undefined) ?? 0))
     case "balance_of":
       return i128Val(BigInt((s.balanceOf as number | undefined) ?? 0))
+    case "balance":
+      return i128Val(BigInt((s.walletBalance as number | undefined) ?? 1000))
     case "deadline":
       return u32Val((s.deadlineLedger as number | undefined) ?? 0)
     case "get_version":
@@ -934,6 +936,17 @@ export async function fetchTokenMetadata(tokenId: string): Promise<TokenMetadata
     symbol: scValToText(symbolV) || "TKN",
     decimals: decimalsV.switch().name === "scvU32" ? decimalsV.u32() : 7,
   }
+}
+
+/**
+ * Read a wallet's balance of a given SEP-41 token via the token contract's
+ * `balance()` view call. Returns base units (use formatTokenAmount to
+ * convert). "native"/empty resolves to the native XLM SAC.
+ */
+export async function fetchTokenBalance(tokenId: string, holderAddress: string): Promise<bigint> {
+  const addr = resolveTokenAddress(tokenId)
+  const val = await viewCall(addr, "balance", addressVal(holderAddress))
+  return scValToBigInt(val)
 }
 
 function scValToU32(val?: xdr.ScVal): number {

--- a/frontend/lib/env.ts
+++ b/frontend/lib/env.ts
@@ -30,6 +30,9 @@ export const env = {
   NEXT_PUBLIC_FACTORY_CONTRACT_ID: readRequiredEnv("NEXT_PUBLIC_FACTORY_CONTRACT_ID"),
   NEXT_PUBLIC_TOKEN_CONTRACT_ID: readRequiredEnv("NEXT_PUBLIC_TOKEN_CONTRACT_ID"),
   NEXT_PUBLIC_REPUTATION_CONTRACT_ID: process.env.NEXT_PUBLIC_REPUTATION_CONTRACT_ID?.trim() ?? "",
+  // Optional — falls back to Circle's testnet USDC SAC (see lib/token-utils.ts)
+  // when unset, so this doesn't need to be configured for local dev.
+  NEXT_PUBLIC_USDC_CONTRACT_ID: process.env.NEXT_PUBLIC_USDC_CONTRACT_ID?.trim() ?? "",
   NEXT_PUBLIC_ROTATIONAL_WASM_HASH: readRequiredEnv("NEXT_PUBLIC_ROTATIONAL_WASM_HASH"),
   NEXT_PUBLIC_TARGET_WASM_HASH: readRequiredEnv("NEXT_PUBLIC_TARGET_WASM_HASH"),
   NEXT_PUBLIC_FLEXIBLE_WASM_HASH: readRequiredEnv("NEXT_PUBLIC_FLEXIBLE_WASM_HASH"),

--- a/frontend/lib/supabase.ts
+++ b/frontend/lib/supabase.ts
@@ -125,6 +125,7 @@ export type Database = {
           activity_type: string
           user_address: string | null
           amount: number | null
+          token_amount: number | null
           description: string | null
           tx_hash: string | null
           created_at: string
@@ -134,6 +135,7 @@ export type Database = {
           activity_type: string
           user_address?: string | null
           amount?: number | null
+          token_amount?: number | null
           description?: string | null
           tx_hash?: string | null
         }
@@ -142,6 +144,7 @@ export type Database = {
           activity_type?: string
           user_address?: string | null
           amount?: number | null
+          token_amount?: number | null
           description?: string | null
           tx_hash?: string | null
         }

--- a/frontend/lib/token-utils.ts
+++ b/frontend/lib/token-utils.ts
@@ -1,0 +1,111 @@
+/**
+ * Token registry for JointSave's supported deposit currencies (native XLM and
+ * USDC on Stellar). Used by the pool creation form, deposit flow, and the
+ * bridge tutorial page to look up display metadata without hardcoding
+ * contract ids in components.
+ *
+ * This is distinct from the free-form "custom token" path in
+ * `components/create-group/token-select.tsx`, which lets an admin point a
+ * pool at *any* SEP-41 contract. This registry covers the two first-class,
+ * pre-vetted currencies the rest of the UI (bridge page, balance widgets)
+ * knows how to talk about by name.
+ */
+
+import { fetchTokenBalance, formatTokenAmount } from "@/hooks/useJointSaveContracts"
+
+export interface TokenInfo {
+  name: string
+  symbol: string
+  /** "native" for XLM, or a C… SAC/token contract id. */
+  contractAddress: string
+  decimals: number
+  /** Emoji/icon shown next to the symbol in token pickers and balances. */
+  icon: string
+}
+
+// Circle's official USDC issuance on Stellar testnet, wrapped as a Stellar
+// Asset Contract (SAC). Overridable via env for other networks/deployments.
+// See: https://developers.circle.com/stablecoins/docs/usdc-on-test-networks
+const DEFAULT_USDC_TESTNET_SAC_ID = "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA"
+
+const USDC_CONTRACT_ID =
+  process.env.NEXT_PUBLIC_USDC_CONTRACT_ID?.trim() || DEFAULT_USDC_TESTNET_SAC_ID
+
+/** The two first-class deposit currencies JointSave supports. */
+export const SUPPORTED_TOKENS: TokenInfo[] = [
+  {
+    name: "Stellar Lumens",
+    symbol: "XLM",
+    contractAddress: "native",
+    decimals: 7,
+    icon: "🪙",
+  },
+  {
+    name: "USD Coin",
+    symbol: "USDC",
+    contractAddress: USDC_CONTRACT_ID,
+    decimals: 7,
+    icon: "💵",
+  },
+]
+
+/** Look up a registered token by its symbol (case-insensitive). */
+export function getTokenBySymbol(symbol: string | null | undefined): TokenInfo | undefined {
+  if (!symbol) return undefined
+  const upper = symbol.toUpperCase()
+  return SUPPORTED_TOKENS.find((t) => t.symbol === upper)
+}
+
+/** Look up a registered token by its contract address ("native" or C…). */
+export function getTokenByAddress(address: string | null | undefined): TokenInfo | undefined {
+  if (!address) return undefined
+  if (address === "native") return SUPPORTED_TOKENS[0]
+  return SUPPORTED_TOKENS.find((t) => t.contractAddress === address)
+}
+
+/**
+ * Format a base-units amount (bigint, as read from a contract) into a
+ * display string for the given token, e.g. `formatTokenAmount(1250000000n,
+ * getTokenBySymbol("XLM"))` → "125.00 XLM".
+ */
+export function formatTokenDisplayAmount(amount: bigint, token: TokenInfo): string {
+  const human = formatTokenAmount(amount, token.decimals)
+  return `${human.toFixed(2)} ${token.symbol}`
+}
+
+/**
+ * Fetch a wallet's balance for the given token, returned as a human-readable
+ * number (already divided by the token's decimals). Returns 0 if the RPC
+ * call fails (e.g. the account has no trustline / no funds) so callers can
+ * render "0" instead of crashing the deposit form.
+ */
+export async function getTokenBalance(walletAddress: string, token: TokenInfo): Promise<number> {
+  try {
+    const base = await fetchTokenBalance(token.contractAddress, walletAddress)
+    return formatTokenAmount(base, token.decimals)
+  } catch {
+    return 0
+  }
+}
+
+// Approximate XLM/USD rate used when no live quote is available. This is a
+// static placeholder — swap `getUsdApproxValue` for a Stellar DEX order-book
+// lookup or a Supabase-cached price table once one exists. USDC is a
+// stablecoin, so it's treated as ~1:1 with no lookup needed.
+const XLM_USD_FALLBACK_RATE = 0.12
+
+/**
+ * Approximate USD value of a human-readable token amount, for display next
+ * to deposit/withdraw amounts (e.g. "100 XLM ≈ $12.00"). Never throws —
+ * falls back to a static rate for XLM so the UI always has something to show.
+ */
+export function getUsdApproxValue(amount: number, token: TokenInfo): number {
+  if (!Number.isFinite(amount) || amount <= 0) return 0
+  if (token.symbol === "USDC") return amount
+  return amount * XLM_USD_FALLBACK_RATE
+}
+
+/** Format a USD approx value for display, e.g. "≈ $12.00". */
+export function formatUsdApprox(amount: number, token: TokenInfo): string {
+  return `≈ $${getUsdApproxValue(amount, token).toFixed(2)}`
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "start": "next start",
-    "test:unit": "tsx --test lib/csv-export.test.ts lib/analytics.test.ts lib/pool-health.test.ts lib/form-validation.test.ts lib/member-filters.test.ts lib/contract-version.test.ts lib/error-reporting.test.ts lib/pending-transactions.test.ts hooks/use-keyboard-shortcuts.test.ts app/api/admin/audit-log/route.test.ts app/api/admin/actions/route.test.ts app/api/errors/route.test.ts components/error-boundary.test.ts app/api/notifications/route.test.ts app/api/user-profile/route.test.ts",
+    "test:unit": "tsx --test lib/csv-export.test.ts lib/analytics.test.ts lib/pool-health.test.ts lib/form-validation.test.ts lib/member-filters.test.ts lib/contract-version.test.ts lib/error-reporting.test.ts lib/pending-transactions.test.ts hooks/use-keyboard-shortcuts.test.ts app/api/admin/audit-log/route.test.ts app/api/admin/actions/route.test.ts app/api/errors/route.test.ts components/error-boundary.test.ts app/api/notifications/route.test.ts app/api/user-profile/route.test.ts app/api/portfolio/summary/route.test.ts",
     "test:components": "vitest run",
     "test:components:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -36,6 +36,22 @@ if (!global.PointerEvent) {
   global.PointerEvent = PointerEvent
 }
 
+// jsdom doesn't implement the Pointer Events capture API or scrollIntoView,
+// which Radix UI's Select relies on — without these, interacting with any
+// Select in tests throws "target.hasPointerCapture is not a function".
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false
+}
+if (!Element.prototype.setPointerCapture) {
+  Element.prototype.setPointerCapture = () => {}
+}
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = () => {}
+}
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {}
+}
+
 // Mock URL.createObjectURL and URL.revokeObjectURL for CSV exports in jsdom
 if (typeof URL.createObjectURL !== "function") {
   URL.createObjectURL = vi.fn().mockReturnValue("blob:mock-url")

--- a/smartcontract/contracts/flexible/src/lib.rs
+++ b/smartcontract/contracts/flexible/src/lib.rs
@@ -22,6 +22,7 @@ pub enum DataKey {
     DeployedToYield,
     TokenDecimals,
     MigratedFrom,
+    SupportedTokens,
 }
 
 const LEDGER_THRESHOLD: u32 = 518400;
@@ -89,6 +90,7 @@ impl FlexiblePool {
         assert!(amount >= min, "below minimum deposit");
 
         let token_addr: Address = storage.get(&DataKey::Token).unwrap();
+        Self::assert_token_supported(&env, &token_addr);
         let token_client = token::Client::new(&env, &token_addr);
         token_client.transfer(&member, &env.current_contract_address(), &amount);
 
@@ -305,6 +307,27 @@ impl FlexiblePool {
         env.events().publish((symbol_short!("unpaused"),), ());
     }
 
+    // ── Token allowlist ───────────────────────────────────────────────────
+
+    /// Set the tokens this pool is allowed to accept deposits in (e.g. the
+    /// native XLM SAC and USDC's SAC on Stellar). Admin-only. An empty list
+    /// (the default) leaves the pool unrestricted — it only ever holds the
+    /// single token chosen at `initialize()`.
+    pub fn set_supported_tokens(env: Env, admin: Address, tokens: Vec<Address>) {
+        admin.require_auth();
+        let storage = env.storage().persistent();
+        let stored_admin: Address = storage.get(&DataKey::Admin).unwrap();
+        assert!(admin == stored_admin, "not admin");
+
+        storage.set(&DataKey::SupportedTokens, &tokens);
+        storage.extend_ttl(&DataKey::SupportedTokens, LEDGER_THRESHOLD, LEDGER_BUMP);
+
+        Self::bump_config_state_internal(&env);
+
+        env.events()
+            .publish((symbol_short!("sup_tok"), admin), tokens.len() as u32);
+    }
+
     pub fn emergency_withdraw(env: Env, admin: Address, recipient: Address) {
         admin.require_auth();
         let storage = env.storage().persistent();
@@ -482,6 +505,9 @@ impl FlexiblePool {
         if storage.has(&DataKey::YieldStrategy) {
             storage.extend_ttl(&DataKey::YieldStrategy, LEDGER_THRESHOLD, LEDGER_BUMP);
         }
+        if storage.has(&DataKey::SupportedTokens) {
+            storage.extend_ttl(&DataKey::SupportedTokens, LEDGER_THRESHOLD, LEDGER_BUMP);
+        }
     }
 
     // ── Views ─────────────────────────────────────────────────────────────
@@ -553,7 +579,36 @@ impl FlexiblePool {
             .unwrap_or(0)
     }
 
+    /// Tokens this pool is allowed to accept deposits in. Empty until an
+    /// admin calls `set_supported_tokens`.
+    pub fn get_supported_tokens(env: Env) -> Vec<Address> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::SupportedTokens)
+            .unwrap_or(Vec::new(&env))
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────
+
+    /// If a supported-token allowlist has been configured, require `token` to
+    /// be on it. No-op while the allowlist is empty (default/back-compat).
+    fn assert_token_supported(env: &Env, token: &Address) {
+        let supported: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SupportedTokens)
+            .unwrap_or(Vec::new(env));
+        if supported.len() > 0 {
+            let mut found = false;
+            for t in supported.iter() {
+                if t == *token {
+                    found = true;
+                    break;
+                }
+            }
+            assert!(found, "token not supported");
+        }
+    }
 
     fn is_member(members: &Vec<Address>, who: &Address) -> bool {
         for m in members.iter() {

--- a/smartcontract/contracts/flexible/src/tests.rs
+++ b/smartcontract/contracts/flexible/src/tests.rs
@@ -615,6 +615,84 @@ fn test_migrate_rejects_version_skip() {
     client.migrate(&admin, &3);
 }
 
+// ── Supported-token allowlist (USDC bridge deposits, issue #209) ──────────────
+
+#[test]
+fn test_supported_tokens_empty_by_default() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _token, _admin, _treasury, _a, _b) = setup_pool(&env, false);
+    assert_eq!(client.get_supported_tokens().len(), 0);
+}
+
+#[test]
+fn test_set_supported_tokens_by_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token, admin, _treasury, _a, _b) = setup_pool(&env, false);
+
+    let usdc = Address::generate(&env);
+    let mut tokens = Vec::new(&env);
+    tokens.push_back(token.clone());
+    tokens.push_back(usdc.clone());
+
+    client.set_supported_tokens(&admin, &tokens);
+
+    let stored = client.get_supported_tokens();
+    assert_eq!(stored.len(), 2);
+    assert_eq!(stored.get(0).unwrap(), token);
+    assert_eq!(stored.get(1).unwrap(), usdc);
+}
+
+#[test]
+#[should_panic(expected = "not admin")]
+fn test_set_supported_tokens_rejects_non_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token, _admin, _treasury, member_a, _b) = setup_pool(&env, false);
+
+    let mut tokens = Vec::new(&env);
+    tokens.push_back(token);
+    client.set_supported_tokens(&member_a, &tokens);
+}
+
+#[test]
+fn test_deposit_succeeds_when_pool_token_is_in_allowlist() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token, admin, _treasury, member_a, _b) = setup_pool(&env, false);
+
+    let usdc = Address::generate(&env);
+    let mut tokens = Vec::new(&env);
+    tokens.push_back(token.clone());
+    tokens.push_back(usdc);
+    client.set_supported_tokens(&admin, &tokens);
+
+    let token_client = token::StellarAssetClient::new(&env, &token);
+    token_client.mint(&member_a, &100i128);
+
+    client.deposit(&member_a, &20i128);
+    assert_eq!(client.balance_of(&member_a), 20i128);
+}
+
+#[test]
+#[should_panic(expected = "token not supported")]
+fn test_deposit_fails_when_pool_token_not_in_allowlist() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _token, admin, _treasury, member_a, _b) = setup_pool(&env, false);
+
+    // Allowlist that deliberately excludes this pool's own token — simulates
+    // an admin restricting the pool to a different SEP-41 token (e.g. USDC)
+    // after initialization.
+    let usdc = Address::generate(&env);
+    let mut tokens = Vec::new(&env);
+    tokens.push_back(usdc);
+    client.set_supported_tokens(&admin, &tokens);
+
+    client.deposit(&member_a, &20i128);
+}
+
 mod mock_strategy {
     use soroban_sdk::{contract, contractimpl, Env};
 

--- a/smartcontract/contracts/flexible/test_snapshots/tests/test_set_yield_strategy_requires_yield_enabled.1.json
+++ b/smartcontract/contracts/flexible/test_snapshots/tests/test_set_yield_strategy_requires_yield_enabled.1.json
@@ -1085,7 +1085,7 @@
             "data": {
               "vec": [
                 {
-                  "string": "caught panic 'yield disabled' from contract function 'Symbol(obj#201)'"
+                  "string": "caught panic 'yield disabled' from contract function 'Symbol(obj#205)'"
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"

--- a/smartcontract/contracts/rotational/src/lib.rs
+++ b/smartcontract/contracts/rotational/src/lib.rs
@@ -26,6 +26,7 @@ pub enum DataKey {
     ReputationTracker,
     TokenDecimals,
     MigratedFrom,
+    SupportedTokens,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -103,6 +104,7 @@ impl RotationalPool {
 
         let deposit_amount: i128 = storage.get(&DataKey::DepositAmount).unwrap();
         let token_addr: Address = storage.get(&DataKey::Token).unwrap();
+        Self::assert_token_supported(&env, &token_addr);
         let token_client = token::Client::new(&env, &token_addr);
         token_client.transfer(&member, &env.current_contract_address(), &deposit_amount);
 
@@ -346,6 +348,27 @@ impl RotationalPool {
         Self::bump_config_state_internal(&env);
     }
 
+    // ── Token allowlist ───────────────────────────────────────────────────
+
+    /// Set the tokens this pool is allowed to accept deposits in (e.g. the
+    /// native XLM SAC and USDC's SAC on Stellar). Admin-only. An empty list
+    /// (the default) leaves the pool unrestricted — it only ever holds the
+    /// single token chosen at `initialize()`.
+    pub fn set_supported_tokens(env: Env, admin: Address, tokens: Vec<Address>) {
+        admin.require_auth();
+        let storage = env.storage().persistent();
+        let stored_admin: Address = storage.get(&DataKey::Admin).unwrap();
+        assert!(admin == stored_admin, "not admin");
+
+        storage.set(&DataKey::SupportedTokens, &tokens);
+        storage.extend_ttl(&DataKey::SupportedTokens, LEDGER_THRESHOLD, LEDGER_BUMP);
+
+        Self::bump_config_state_internal(&env);
+
+        env.events()
+            .publish((symbol_short!("sup_tok"), admin), tokens.len() as u32);
+    }
+
     pub fn emergency_withdraw(env: Env, admin: Address, recipient: Address) {
         admin.require_auth();
         let storage = env.storage().persistent();
@@ -439,6 +462,9 @@ impl RotationalPool {
         if storage.has(&DataKey::ReputationTracker) {
             storage.extend_ttl(&DataKey::ReputationTracker, LEDGER_THRESHOLD, LEDGER_BUMP);
         }
+        if storage.has(&DataKey::SupportedTokens) {
+            storage.extend_ttl(&DataKey::SupportedTokens, LEDGER_THRESHOLD, LEDGER_BUMP);
+        }
     }
 
     // ── Views ──────────────────────────────────────────────────────────────
@@ -510,6 +536,15 @@ impl RotationalPool {
             .unwrap_or(0)
     }
 
+    /// Tokens this pool is allowed to accept deposits in. Empty until an
+    /// admin calls `set_supported_tokens`.
+    pub fn get_supported_tokens(env: Env) -> Vec<Address> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::SupportedTokens)
+            .unwrap_or(Vec::new(&env))
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────────
 
     fn is_member(members: &Vec<Address>, who: &Address) -> bool {
@@ -519,6 +554,26 @@ impl RotationalPool {
             }
         }
         false
+    }
+
+    /// If a supported-token allowlist has been configured, require `token` to
+    /// be on it. No-op while the allowlist is empty (default/back-compat).
+    fn assert_token_supported(env: &Env, token: &Address) {
+        let supported: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SupportedTokens)
+            .unwrap_or(Vec::new(env));
+        if supported.len() > 0 {
+            let mut found = false;
+            for t in supported.iter() {
+                if t == *token {
+                    found = true;
+                    break;
+                }
+            }
+            assert!(found, "token not supported");
+        }
     }
 
     /// O(n^2) pairwise scan — member lists are small (capped well below

--- a/smartcontract/contracts/rotational/src/tests.rs
+++ b/smartcontract/contracts/rotational/src/tests.rs
@@ -1299,3 +1299,113 @@ fn test_migrate_rejects_version_skip() {
     // Skipping from v1 to v3 must be rejected
     client.migrate(&admin, &3);
 }
+
+// ── Supported-token allowlist (USDC bridge deposits, issue #209) ──────────────
+
+fn setup_rotational_pool(
+    env: &Env,
+) -> (
+    RotationalPoolClient<'static>,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
+    let contract_id = env.register_contract(None, RotationalPool);
+    let client = RotationalPoolClient::new(env, &contract_id);
+
+    let token_admin = Address::generate(env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_address = token_contract.address();
+
+    let treasury = Address::generate(env);
+    let admin = Address::generate(env);
+    let member_a = Address::generate(env);
+    let member_b = Address::generate(env);
+
+    let mut members = Vec::new(env);
+    members.push_back(member_a.clone());
+    members.push_back(member_b.clone());
+
+    client.initialize(
+        &token_address,
+        &admin,
+        &members,
+        &100i128,
+        &100u64,
+        &500u32,
+        &200u32,
+        &treasury,
+    );
+
+    (client, token_address, admin, member_a, member_b)
+}
+
+#[test]
+fn test_supported_tokens_empty_by_default() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, ..) = setup_rotational_pool(&env);
+    assert_eq!(client.get_supported_tokens().len(), 0);
+}
+
+#[test]
+fn test_set_supported_tokens_by_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token, admin, _a, _b) = setup_rotational_pool(&env);
+
+    let usdc = Address::generate(&env);
+    let mut tokens = Vec::new(&env);
+    tokens.push_back(token.clone());
+    tokens.push_back(usdc);
+    client.set_supported_tokens(&admin, &tokens);
+
+    assert_eq!(client.get_supported_tokens().len(), 2);
+}
+
+#[test]
+#[should_panic(expected = "not admin")]
+fn test_set_supported_tokens_rejects_non_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token, _admin, member_a, _b) = setup_rotational_pool(&env);
+
+    let mut tokens = Vec::new(&env);
+    tokens.push_back(token);
+    client.set_supported_tokens(&member_a, &tokens);
+}
+
+#[test]
+#[should_panic(expected = "token not supported")]
+fn test_deposit_fails_when_pool_token_not_in_allowlist() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _token, admin, member_a, _b) = setup_rotational_pool(&env);
+
+    let usdc = Address::generate(&env);
+    let mut tokens = Vec::new(&env);
+    tokens.push_back(usdc);
+    client.set_supported_tokens(&admin, &tokens);
+
+    client.deposit(&member_a);
+}
+
+#[test]
+fn test_deposit_succeeds_when_pool_token_is_in_allowlist() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token, admin, member_a, _b) = setup_rotational_pool(&env);
+
+    let usdc = Address::generate(&env);
+    let mut tokens = Vec::new(&env);
+    tokens.push_back(token.clone());
+    tokens.push_back(usdc);
+    client.set_supported_tokens(&admin, &tokens);
+
+    let token_client = token::StellarAssetClient::new(&env, &token);
+    token_client.mint(&member_a, &100i128);
+
+    client.deposit(&member_a);
+    assert!(client.has_deposited(&member_a));
+}

--- a/smartcontract/contracts/target/src/lib.rs
+++ b/smartcontract/contracts/target/src/lib.rs
@@ -18,6 +18,7 @@ pub enum DataKey {
     Balance(Address),
     TokenDecimals,
     MigratedFrom,
+    SupportedTokens,
 }
 
 const LEDGER_THRESHOLD: u32 = 518400;
@@ -83,6 +84,7 @@ impl TargetPool {
         assert!(env.ledger().sequence() <= deadline, "deadline passed");
 
         let token_addr: Address = storage.get(&DataKey::Token).unwrap();
+        Self::assert_token_supported(&env, &token_addr);
         token::Client::new(&env, &token_addr).transfer(
             &member,
             &env.current_contract_address(),
@@ -305,6 +307,27 @@ impl TargetPool {
         Self::bump_config_state_internal(&env);
     }
 
+    // ── Token allowlist ───────────────────────────────────────────────────
+
+    /// Set the tokens this pool is allowed to accept deposits in (e.g. the
+    /// native XLM SAC and USDC's SAC on Stellar). Admin-only. An empty list
+    /// (the default) leaves the pool unrestricted — it only ever holds the
+    /// single token chosen at `initialize()`.
+    pub fn set_supported_tokens(env: Env, admin: Address, tokens: Vec<Address>) {
+        admin.require_auth();
+        let storage = env.storage().persistent();
+        let stored_admin: Address = storage.get(&DataKey::Admin).unwrap();
+        assert!(admin == stored_admin, "not admin");
+
+        storage.set(&DataKey::SupportedTokens, &tokens);
+        storage.extend_ttl(&DataKey::SupportedTokens, LEDGER_THRESHOLD, LEDGER_BUMP);
+
+        Self::bump_config_state_internal(&env);
+
+        env.events()
+            .publish((symbol_short!("sup_tok"), admin), tokens.len() as u32);
+    }
+
     pub fn emergency_withdraw(env: Env, admin: Address, recipient: Address) {
         admin.require_auth();
         let storage = env.storage().persistent();
@@ -380,6 +403,9 @@ impl TargetPool {
         storage.extend_ttl(&DataKey::Active, LEDGER_THRESHOLD, LEDGER_BUMP);
         storage.extend_ttl(&DataKey::Unlocked, LEDGER_THRESHOLD, LEDGER_BUMP);
         storage.extend_ttl(&DataKey::Paused, LEDGER_THRESHOLD, LEDGER_BUMP);
+        if storage.has(&DataKey::SupportedTokens) {
+            storage.extend_ttl(&DataKey::SupportedTokens, LEDGER_THRESHOLD, LEDGER_BUMP);
+        }
     }
 
     // ── Views ──────────────────────────────────────────────────────────────
@@ -454,6 +480,15 @@ impl TargetPool {
             .unwrap_or(0)
     }
 
+    /// Tokens this pool is allowed to accept deposits in. Empty until an
+    /// admin calls `set_supported_tokens`.
+    pub fn get_supported_tokens(env: Env) -> Vec<Address> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::SupportedTokens)
+            .unwrap_or(Vec::new(&env))
+    }
+
     // ── Helpers ────────────────────────────────────────────────────────────
 
     fn is_member(members: &Vec<Address>, who: &Address) -> bool {
@@ -463,6 +498,26 @@ impl TargetPool {
             }
         }
         false
+    }
+
+    /// If a supported-token allowlist has been configured, require `token` to
+    /// be on it. No-op while the allowlist is empty (default/back-compat).
+    fn assert_token_supported(env: &Env, token: &Address) {
+        let supported: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SupportedTokens)
+            .unwrap_or(Vec::new(env));
+        if supported.len() > 0 {
+            let mut found = false;
+            for t in supported.iter() {
+                if t == *token {
+                    found = true;
+                    break;
+                }
+            }
+            assert!(found, "token not supported");
+        }
     }
 
     /// O(n^2) pairwise scan — member lists are small, so this is cheaper

--- a/smartcontract/contracts/target/src/tests.rs
+++ b/smartcontract/contracts/target/src/tests.rs
@@ -809,3 +809,103 @@ fn test_migrate_rejects_version_skip() {
 
     client.migrate(&admin, &3);
 }
+
+// ── Supported-token allowlist (USDC bridge deposits, issue #209) ──────────────
+
+fn setup_target_pool(
+    env: &Env,
+) -> (
+    TargetPoolClient<'static>,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
+    let contract_id = env.register_contract(None, TargetPool);
+    let client = TargetPoolClient::new(env, &contract_id);
+
+    let token_admin = Address::generate(env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_address = token_contract.address();
+
+    let admin = Address::generate(env);
+    let member_a = Address::generate(env);
+    let member_b = Address::generate(env);
+
+    let mut members = Vec::new(env);
+    members.push_back(member_a.clone());
+    members.push_back(member_b.clone());
+
+    client.initialize(&token_address, &admin, &members, &100i128, &1000u32);
+
+    (client, token_address, admin, member_a, member_b)
+}
+
+#[test]
+fn test_supported_tokens_empty_by_default() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, ..) = setup_target_pool(&env);
+    assert_eq!(client.get_supported_tokens().len(), 0);
+}
+
+#[test]
+fn test_set_supported_tokens_by_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token, admin, _a, _b) = setup_target_pool(&env);
+
+    let usdc = Address::generate(&env);
+    let mut tokens = Vec::new(&env);
+    tokens.push_back(token.clone());
+    tokens.push_back(usdc);
+    client.set_supported_tokens(&admin, &tokens);
+
+    assert_eq!(client.get_supported_tokens().len(), 2);
+}
+
+#[test]
+#[should_panic(expected = "not admin")]
+fn test_set_supported_tokens_rejects_non_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token, _admin, member_a, _b) = setup_target_pool(&env);
+
+    let mut tokens = Vec::new(&env);
+    tokens.push_back(token);
+    client.set_supported_tokens(&member_a, &tokens);
+}
+
+#[test]
+#[should_panic(expected = "token not supported")]
+fn test_deposit_fails_when_pool_token_not_in_allowlist() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _token, admin, member_a, _b) = setup_target_pool(&env);
+
+    let usdc = Address::generate(&env);
+    let mut tokens = Vec::new(&env);
+    tokens.push_back(usdc);
+    client.set_supported_tokens(&admin, &tokens);
+
+    client.deposit(&member_a, &10i128);
+}
+
+#[test]
+fn test_deposit_succeeds_when_pool_token_is_in_allowlist() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token, admin, member_a, _b) = setup_target_pool(&env);
+
+    let usdc = Address::generate(&env);
+    let mut tokens = Vec::new(&env);
+    tokens.push_back(token.clone());
+    tokens.push_back(usdc);
+    client.set_supported_tokens(&admin, &tokens);
+
+    let token_client = token::StellarAssetClient::new(&env, &token);
+    token_client.mint(&member_a, &50i128);
+
+    client.deposit(&member_a, &10i128);
+    assert_eq!(client.total_deposited(), 10);
+}

--- a/supabase/migrations/20260817000000_usdc_bridge_deposits.sql
+++ b/supabase/migrations/20260817000000_usdc_bridge_deposits.sql
@@ -1,0 +1,13 @@
+-- USDC bridge deposits (issue #209): allow pool_activity rows to record the
+-- token-denominated amount alongside the existing numeric `amount` column, so
+-- deposit/withdraw history can be broken out by currency (XLM vs USDC).
+--
+-- `pools.token_symbol` already exists (see 20260621000000_add_token_metadata.sql,
+-- issue #67) — the `add column if not exists` below is a no-op safeguard in
+-- case this migration runs against a database that predates it.
+
+alter table public.pools
+  add column if not exists token_symbol text not null default 'XLM';
+
+alter table public.pool_activity
+  add column if not exists token_amount numeric;


### PR DESCRIPTION
Closes #209

## Summary

Adds USDC as a supported deposit currency alongside native XLM across all three pool types (rotational, target, flexible), and adds an educational bridge page explaining how to move USDC onto Stellar from other chains via Circle's CCTP.

## Smart Contract Changes

Each pool contract (`rotational`, `target`, `flexible`) already stored a per-pool `Token` address set at `initialize()` and moved funds through the generic `token::Client` (not raw XLM balance ops), so any SEP-41 token — including USDC's Stellar Asset Contract — already worked as a pool's deposit token. What was missing was a way to *restrict* which tokens are allowed. This PR adds that:

- New `SupportedTokens: Vec<Address>` storage key on each pool contract.
- `set_supported_tokens(admin, tokens: Vec<Address>)` — admin-only setter.
- `get_supported_tokens() -> Vec<Address>` — public view.
- `deposit()` now calls an `assert_token_supported` check: if the allowlist is non-empty, the pool's token must be on it (`"token not supported"` panic otherwise). An empty allowlist (the default) stays fully unrestricted, so **existing XLM-only pools continue to work without modification**.

Modified files:
- `smartcontract/contracts/flexible/src/lib.rs`
- `smartcontract/contracts/target/src/lib.rs`
- `smartcontract/contracts/rotational/src/lib.rs`

## Frontend Changes

- **New `frontend/lib/token-utils.ts`** — token registry (`SUPPORTED_TOKENS`: XLM + USDC) with `getTokenBySymbol`, `getTokenByAddress`, `formatTokenDisplayAmount`, `getTokenBalance` (live wallet balance via a new `fetchTokenBalance` RPC helper in `useJointSaveContracts.ts`), and `getUsdApproxValue`/`formatUsdApprox` for an approximate USD display next to deposit amounts.
- **Pool creation token selector** (`components/create-group/token-select.tsx`) gains a first-class "USDC" option (using the registry's known contract id) alongside native XLM and the existing free-text custom-token path. Selecting USDC shows a link to the bridge guide.
- **Deposit flow** (`components/group/group-actions.tsx`) now shows the connected wallet's live balance in the pool's token next to the deposit input, an approximate USD value once an amount is entered, and a "Bridge USDC to Stellar" nudge when a USDC pool's balance is 0. Also fixed a pre-existing bug where the withdraw/payout confirmation dialog referenced undefined `setError`/`setSuccessMsg` state, which threw on every confirm click — now properly wired to state and rendered in the dialog.
- **New `frontend/app/bridge/page.tsx`** — step-by-step bridge tutorial covering Circle's CCTP and Stellar's native USDC, with links to Circle's CCTP docs and Stellar Expert. Purely educational; JointSave doesn't custody or broker the bridge itself. Linked from the dashboard header, the landing footer, and the token selector.
- **Dashboard totals** (`components/dashboard/portfolio.tsx` + `app/api/portfolio/summary/route.ts`) now break "Total Saved" out per token symbol (e.g. "1000 XLM" / "5000 USDC" shown separately) instead of always labeling the combined sum "XLM".
- `pool_activity` inserts (`app/api/pools/route.ts`) now also record `token_amount`.
- `.env.example` / `lib/env.ts` gain an optional `NEXT_PUBLIC_USDC_CONTRACT_ID`, defaulting to Circle's published testnet USDC SAC when unset.

## Database Changes

New migration `supabase/migrations/20260817000000_usdc_bridge_deposits.sql`:
- `alter table public.pool_activity add column if not exists token_amount numeric;`
- `alter table public.pools add column if not exists token_symbol text not null default 'XLM';` — no-op safeguard; this column already exists from an earlier multi-token-metadata migration, kept here in case this migration runs against a database that predates it.

## Tests

**Rust** (added to each pool contract's existing `tests.rs`, `cargo test` all green):
- Allowlist is empty by default.
- Admin can set the allowlist; non-admin calls panic with `"not admin"`.
- Deposit succeeds when the pool's token is on the allowlist.
- Deposit panics with `"token not supported"` when it isn't.

**Frontend** (`vitest run`, all green):
- `__tests__/token-utils.test.ts` — registry lookups, formatting, balance fetch (including the RPC-failure → 0 fallback), and USD-approx calculation.
- `__tests__/token-select.test.tsx` — default XLM selection, selecting USDC reports the registry entry, switching back to XLM.
- `__tests__/bridge-page.test.tsx` — heading, both bridging paths render, educational disclaimer, outbound links.
- `__tests__/group-actions.test.tsx` (extended) — balance display, USD-approx display, bridge-page nudge for empty USDC balance.
- `app/api/portfolio/summary/route.test.ts` (new, `node:test`, mirrors the route's per-token calculation like existing route tests do) — splitting deposits by token, netting withdrawals/payouts, clamping at 0, defaulting to XLM for legacy pools, ignoring non-financial activity types.

## How to Test

1. **Contracts**: `cd smartcontract && cargo test -p jointsave-flexible -p jointsave-target -p jointsave-rotational`
2. **Frontend unit tests**: `cd frontend && npm run test:unit`
3. **Frontend component tests**: `cd frontend && npm run test:components`
4. **Manual**: Start a pool creation flow, pick "USDC" in the Deposit Currency selector, and confirm the pool card/detail page show "USDC" instead of "XLM". Visit `/bridge` and confirm the tutorial content and outbound links render. On a pool's group page, confirm the deposit form shows a live balance and an approximate USD value as you type an amount.