### PR TITLE
feat: pool comparison tool — side-by-side analysis before joining

### DIFF
--- a/frontend/__tests__/comparison-table.test.tsx
+++ b/frontend/__tests__/comparison-table.test.tsx
@@ -1,0 +1,152 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { describe, it, expect, vi } from "vitest"
+import { ComparisonTable } from "@/components/explore/comparison-table"
+import type { ComparisonPool } from "@/hooks/usePoolComparison"
+
+type PoolOverrides = Partial<ComparisonPool["pool"] & { key?: string }>
+
+function makePool(overrides: PoolOverrides = {}): ComparisonPool {
+  const { key, ...poolOverrides } = overrides as { key?: string }
+  return {
+    key: key ?? "pool-1",
+    pool: {
+      id: "pool-1",
+      name: "Family Fund",
+      type: "rotational",
+      status: "active",
+      description: "Save for the family trip",
+      contract_address: "CBZNGP52FLFZ4BOGC265FUAMP5KFMAYPQK3KTI5UHMYVMM3QCST3IMRI",
+      token_symbol: "XLM",
+      token_decimals: 7,
+      contribution_amount: 100,
+      target_amount: null,
+      minimum_deposit: null,
+      members_count: 5,
+      frequency: "weekly",
+      round_duration: 604800,
+      deadline: null,
+      created_at: "2026-01-01T00:00:00Z",
+      total_saved: 500,
+      ...(poolOverrides as Partial<ComparisonPool["pool"]>),
+    },
+    loading: false,
+    error: null,
+    health: {
+      state: "scored",
+      score: 90,
+      band: "healthy",
+      label: "Healthy",
+      memberCount: 5,
+      historyObserved: 3,
+    },
+    avgReputation: 90,
+  }
+}
+
+describe("ComparisonTable", () => {
+  it("renders all specified rows for a set of pools", () => {
+    const pools = [
+      makePool({
+        key: "pool-1",
+        name: "Family Fund",
+        total_saved: 500,
+        members_count: 5,
+        contribution_amount: 100,
+      }),
+      makePool({
+        key: "pool-2",
+        name: "Vacation Club",
+        id: "pool-2",
+        total_saved: 800,
+        members_count: 3,
+        contribution_amount: 50,
+      }),
+    ]
+    render(<ComparisonTable pools={pools} />)
+
+    expect(screen.getByText("Pool Type")).toBeInTheDocument()
+    expect(screen.getByText("TVL")).toBeInTheDocument()
+    expect(screen.getByText("Members")).toBeInTheDocument()
+    expect(screen.getByText("Deposit Amount")).toBeInTheDocument()
+    expect(screen.getByText("Token")).toBeInTheDocument()
+    expect(screen.getByText("Round Duration")).toBeInTheDocument()
+    expect(screen.getByText("Health Score")).toBeInTheDocument()
+    expect(screen.getByText("Avg Member Reputation")).toBeInTheDocument()
+    expect(screen.getByText("Created")).toBeInTheDocument()
+    expect(screen.getByText("Description")).toBeInTheDocument()
+
+    expect(screen.getByText("Family Fund")).toBeInTheDocument()
+    expect(screen.getByText("Vacation Club")).toBeInTheDocument()
+  })
+
+  it("highlights the best TVL and lowest deposit with badges", () => {
+    const pools = [
+      makePool({ key: "pool-1", name: "Family Fund", total_saved: 500, contribution_amount: 100 }),
+      makePool({
+        key: "pool-2",
+        name: "Vacation Club",
+        id: "pool-2",
+        total_saved: 800,
+        contribution_amount: 50,
+      }),
+    ]
+    render(<ComparisonTable pools={pools} />)
+
+    // 800 is the highest TVL → "Best" badge
+    expect(screen.getAllByText("Best").length).toBeGreaterThanOrEqual(1)
+    // 50 is the lowest deposit → "Lowest" badge
+    expect(screen.getByText("Lowest")).toBeInTheDocument()
+  })
+
+  it("shows an error column for invalid pool addresses", () => {
+    const pools = [
+      makePool({ key: "pool-1", name: "Family Fund" }),
+      {
+        key: "bad-address",
+        pool: null,
+        loading: false,
+        error: "Pool not found",
+        health: null,
+        avgReputation: null,
+      },
+    ]
+    render(<ComparisonTable pools={pools} />)
+
+    expect(screen.getByText("Invalid pool")).toBeInTheDocument()
+    expect(screen.getByText(/Pool not found/)).toBeInTheDocument()
+  })
+
+  it("renders loading skeletons while a pool is being fetched", () => {
+    const pools = [
+      { key: "pool-1", pool: null, loading: true, error: null, health: null, avgReputation: null },
+    ]
+    render(<ComparisonTable pools={pools} />)
+    expect(screen.getByLabelText("Pool comparison")).toBeInTheDocument()
+  })
+
+  it("calls onRemove when the remove button is clicked", () => {
+    const onRemove = vi.fn()
+    const pools = [makePool({ key: "pool-1", name: "Family Fund" })]
+    render(<ComparisonTable pools={pools} onRemove={onRemove} />)
+
+    fireEvent.click(screen.getByLabelText("Remove Family Fund from comparison"))
+    expect(onRemove).toHaveBeenCalledWith("pool-1")
+  })
+
+  it("renders a Join Pool CTA linking to the join flow", () => {
+    const pools = [
+      makePool({
+        key: "pool-1",
+        name: "Family Fund",
+        contract_address: "CBZNGP52FLFZ4BOGC265FUAMP5KFMAYPQK3KTI5UHMYVMM3QCST3IMRI",
+      }),
+    ]
+    render(<ComparisonTable pools={pools} />)
+    const joinLink = screen.getByRole("link", { name: /Join Pool/ })
+    expect(joinLink).toHaveAttribute(
+      "href",
+      "/join/CBZNGP52FLFZ4BOGC265FUAMP5KFMAYPQK3KTI5UHMYVMM3QCST3IMRI"
+    )
+  })
+})

--- a/frontend/__tests__/use-pool-comparison.test.ts
+++ b/frontend/__tests__/use-pool-comparison.test.ts
@@ -1,0 +1,175 @@
+import { renderHook, act, waitFor } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// Override the global next/navigation mock so the hook can read & write ?pools=.
+// replace() mutates currentParams so the hook re-derives selectedKeys from it,
+// mirroring how next/navigation updates the real URL.
+let currentParams = new URLSearchParams()
+const replaceMock = vi.fn((href: string | { toString(): string }) => {
+  const raw = typeof href === "string" ? href : href.toString()
+  const qs = raw.replace(/^\?/, "")
+  currentParams = new URLSearchParams(qs)
+})
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: replaceMock, push: vi.fn(), prefetch: vi.fn() }),
+  usePathname: () => "/explore",
+  // Return a fresh snapshot each render so the hook re-derives from the URL
+  // after replace() mutates currentParams.
+  useSearchParams: () => new URLSearchParams(currentParams.toString()),
+  useParams: () => ({}),
+}))
+
+// The hook fetches pool data + reputation — stub both at module level.
+vi.mock("@/hooks/useJointSaveContracts", () => ({
+  fetchReputation: vi.fn().mockResolvedValue({
+    totalDeposits: 100n,
+    poolsCompleted: 1,
+    missedRounds: 0,
+    onTimeRate: 9000,
+  }),
+}))
+
+import {
+  usePoolComparison,
+  parseComparisonKeys,
+  serializeComparisonKeys,
+  getPoolComparisonKey,
+  MAX_COMPARISON_POOLS,
+} from "@/hooks/usePoolComparison"
+
+describe("usePoolComparison", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    currentParams = new URLSearchParams()
+  })
+
+  describe("URL helpers", () => {
+    it("parses a comma-separated pools param, de-duplicating and capping at 4", () => {
+      expect(parseComparisonKeys("a,b,c")).toEqual(["a", "b", "c"])
+      expect(parseComparisonKeys("a,a,b")).toEqual(["a", "b"])
+      expect(parseComparisonKeys(" a , b ")).toEqual(["a", "b"])
+      expect(parseComparisonKeys("")).toEqual([])
+      expect(parseComparisonKeys(null)).toEqual([])
+      expect(parseComparisonKeys("1,2,3,4,5")).toHaveLength(MAX_COMPARISON_POOLS)
+    })
+
+    it("serializes keys into a comma-separated string capped at 4", () => {
+      expect(serializeComparisonKeys(["a", "b"])).toBe("a,b")
+      expect(serializeComparisonKeys(["1", "2", "3", "4", "5"])).toBe("1,2,3,4")
+      expect(serializeComparisonKeys([])).toBe("")
+    })
+
+    it("prefers the contract address as the comparison key, falling back to id", () => {
+      expect(
+        getPoolComparisonKey({
+          id: "uuid-1",
+          contract_address: "CBZNGP52FLFZ4BOGC265FUAMP5KFMAYPQK3KTI5UHMYVMM3QCST3IMRI",
+        })
+      ).toBe("CBZNGP52FLFZ4BOGC265FUAMP5KFMAYPQK3KTI5UHMYVMM3QCST3IMRI")
+      expect(getPoolComparisonKey({ id: "uuid-2", contract_address: "pending_deployment" })).toBe(
+        "uuid-2"
+      )
+      expect(getPoolComparisonKey({ id: "uuid-3" })).toBe("uuid-3")
+      expect(getPoolComparisonKey({ id: "uuid-4", contract_address: "not-a-contract" })).toBe(
+        "uuid-4"
+      )
+    })
+  })
+
+  describe("selection behaviour", () => {
+    it("reads initial selection from the URL", async () => {
+      currentParams = new URLSearchParams("pools=addr1,addr2")
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 })
+      const { result } = renderHook(() => usePoolComparison())
+      await waitFor(() => expect(result.current.selectedKeys).toEqual(["addr1", "addr2"]))
+    })
+
+    it("toggles a pool on and off, syncing to the URL", async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 })
+      const { result, rerender } = renderHook(() => usePoolComparison())
+
+      act(() => result.current.togglePool("addr1"))
+      rerender()
+      expect(result.current.selectedKeys).toEqual(["addr1"])
+      expect(replaceMock).toHaveBeenCalledWith("?pools=addr1", { scroll: false })
+
+      act(() => result.current.togglePool("addr1"))
+      rerender()
+      expect(result.current.selectedKeys).toEqual([])
+      expect(replaceMock).toHaveBeenCalledWith("?", { scroll: false })
+    })
+
+    it("enforces the max of 4 pools when adding", async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 })
+      currentParams = new URLSearchParams("pools=1,2,3,4")
+      const { result } = renderHook(() => usePoolComparison())
+
+      act(() => result.current.togglePool("5"))
+      expect(result.current.selectedKeys).toEqual(["1", "2", "3", "4"])
+      expect(result.current.isAtMax).toBe(true)
+      expect(result.current.canAddMore).toBe(false)
+    })
+
+    it("removes a single pool and clears all", async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 })
+      currentParams = new URLSearchParams("pools=a,b,c")
+      const { result, rerender } = renderHook(() => usePoolComparison())
+
+      act(() => result.current.removePool("b"))
+      rerender()
+      expect(result.current.selectedKeys).toEqual(["a", "c"])
+
+      act(() => result.current.clearSelection())
+      rerender()
+      expect(result.current.selectedKeys).toEqual([])
+    })
+
+    it("marks invalid pool addresses with an error and no data", async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 })
+      currentParams = new URLSearchParams("pools=does-not-exist")
+      const { result } = renderHook(() => usePoolComparison())
+
+      await waitFor(() => {
+        expect(result.current.pools).toHaveLength(1)
+        expect(result.current.pools[0].error).toBeTruthy()
+        expect(result.current.pools[0].pool).toBeNull()
+      })
+    })
+
+    it("fetches full pool data for valid keys", async () => {
+      const mockPool = {
+        id: "pool-1",
+        name: "Family Fund",
+        type: "rotational",
+        status: "active",
+        description: "desc",
+        contract_address: "CBZNGP52FLFZ4BOGC265FUAMP5KFMAYPQK3KTI5UHMYVMM3QCST3IMRI",
+        token_symbol: "XLM",
+        token_decimals: 7,
+        contribution_amount: 100,
+        target_amount: null,
+        minimum_deposit: null,
+        members_count: 5,
+        frequency: "weekly",
+        round_duration: 604800,
+        deadline: null,
+        created_at: "2026-01-01T00:00:00Z",
+        total_saved: 500,
+        pool_members: [{ member_address: "GBX1234567890TESTADDRESS", contribution_amount: 100 }],
+      }
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => mockPool })
+      currentParams = new URLSearchParams(
+        "pools=CBZNGP52FLFZ4BOGC265FUAMP5KFMAYPQK3KTI5UHMYVMM3QCST3IMRI"
+      )
+      const { result } = renderHook(() => usePoolComparison())
+
+      await waitFor(() => {
+        expect(result.current.pools).toHaveLength(1)
+        expect(result.current.pools[0].loading).toBe(false)
+        expect(result.current.pools[0].pool?.name).toBe("Family Fund")
+        expect(result.current.pools[0].error).toBeNull()
+      })
+    })
+  })
+})

--- a/frontend/app/explore/compare/page.tsx
+++ b/frontend/app/explore/compare/page.tsx
@@ -1,0 +1,259 @@
+"use client"
+
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react"
+import Link from "next/link"
+import { ArrowLeft, Columns3, Loader2, Plus, Search } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card } from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
+import { ErrorBoundary } from "@/components/error-boundary"
+import { ComparisonTable } from "@/components/explore/comparison-table"
+import {
+  usePoolComparison,
+  getPoolComparisonKey,
+  MAX_COMPARISON_POOLS,
+} from "@/hooks/usePoolComparison"
+import { useToast } from "@/hooks/use-toast"
+import { useDebouncedValue } from "@/hooks/use-debounced-value"
+
+interface ExplorePool {
+  id: string
+  name: string
+  type: "rotational" | "target" | "flexible"
+  contract_address?: string | null
+}
+
+function CompareContent() {
+  const { toast } = useToast()
+  const { selectedKeys, pools, togglePool, removePool, clearSelection, canAddMore, isAtMax } =
+    usePoolComparison()
+
+  const [available, setAvailable] = useState<ExplorePool[]>([])
+  const [loadingPools, setLoadingPools] = useState(true)
+  const [searchInput, setSearchInput] = useState("")
+  const debouncedSearch = useDebouncedValue(searchInput, 250)
+
+  useEffect(() => {
+    let cancelled = false
+    fetch("/api/pools")
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data: ExplorePool[]) => {
+        if (!cancelled) setAvailable(Array.isArray(data) ? data : [])
+      })
+      .catch(() => {
+        if (!cancelled) setAvailable([])
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingPools(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const addablePools = useMemo(() => {
+    const selected = new Set(selectedKeys)
+    const term = debouncedSearch.trim().toLowerCase()
+    return available
+      .filter((pool) => {
+        if (selected.has(getPoolComparisonKey(pool))) return false
+        if (!term) return true
+        return pool.name.toLowerCase().includes(term)
+      })
+      .slice(0, 30)
+  }, [available, selectedKeys, debouncedSearch])
+
+  const handleAdd = useCallback(
+    (pool: ExplorePool) => {
+      if (isAtMax) {
+        toast({
+          title: "Comparison limit reached",
+          description: `You can compare up to ${MAX_COMPARISON_POOLS} pools at once.`,
+          variant: "error",
+        })
+        return
+      }
+      togglePool(getPoolComparisonKey(pool))
+    },
+    [isAtMax, togglePool, toast]
+  )
+
+  const allLoaded = pools.length > 0 && pools.every((p) => !p.loading)
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="mb-8">
+          <Button variant="ghost" className="mb-4" asChild>
+            <Link href="/explore">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Back to Explore
+            </Link>
+          </Button>
+          <div className="flex items-center gap-3">
+            <Columns3 className="h-8 w-8 text-primary" />
+            <div>
+              <h1 className="text-3xl sm:text-4xl font-bold">Compare Pools</h1>
+              <p className="text-muted-foreground mt-1">
+                Side-by-side view of {selectedKeys.length} pool
+                {selectedKeys.length !== 1 ? "s" : ""} — share this URL to compare with anyone.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Loading state */}
+        {pools.length > 0 && !allLoaded && (
+          <Card className="p-6">
+            <div className="space-y-3" aria-label="Loading comparison">
+              <Skeleton className="h-5 w-40" />
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+                {Array.from({ length: Math.min(pools.length, MAX_COMPARISON_POOLS) * 3 }).map(
+                  (_, i) => (
+                    <Skeleton key={i} className="h-4 w-full" />
+                  )
+                )}
+              </div>
+            </div>
+          </Card>
+        )}
+
+        {/* Empty state */}
+        {pools.length === 0 && (
+          <Card className="p-12 text-center">
+            <Columns3 className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+            <h2 className="text-xl font-semibold mb-2">No pools to compare yet</h2>
+            <p className="text-sm text-muted-foreground mb-6 max-w-md mx-auto">
+              Select at least two pools from the Explore page, or use the pool picker below, to
+              build a side-by-side comparison.
+            </p>
+            <Button asChild>
+              <Link href="/explore">Browse Pools</Link>
+            </Button>
+          </Card>
+        )}
+
+        {/* Comparison table */}
+        {pools.length > 0 && (
+          <ComparisonTable pools={pools} onRemove={removePool} onClear={clearSelection} />
+        )}
+
+        {/* Add / manage pools */}
+        <Card className="mt-8 p-6">
+          <div className="flex items-center justify-between gap-4 mb-4">
+            <div>
+              <h2 className="text-lg font-semibold">Add Pools</h2>
+              <p className="text-sm text-muted-foreground">
+                {canAddMore
+                  ? `Select up to ${MAX_COMPARISON_POOLS} pools to compare side-by-side.`
+                  : `Maximum of ${MAX_COMPARISON_POOLS} pools reached — remove one to add another.`}
+              </p>
+            </div>
+            {selectedKeys.length > 0 && (
+              <Button variant="outline" size="sm" onClick={clearSelection}>
+                Clear ({selectedKeys.length})
+              </Button>
+            )}
+          </div>
+
+          <div className="relative mb-4">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Search pools by name..."
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+              className="pl-9"
+              aria-label="Search pools"
+            />
+          </div>
+
+          {loadingPools ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Loading pools…
+            </div>
+          ) : addablePools.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              {debouncedSearch
+                ? "No pools match your search."
+                : canAddMore
+                  ? "No more pools available to add."
+                  : "You've added the maximum number of pools."}
+            </p>
+          ) : (
+            <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+              {addablePools.map((pool) => {
+                const key = getPoolComparisonKey(pool)
+                const checked = selectedKeys.includes(key)
+                return (
+                  <li key={key}>
+                    <label
+                      className={`flex items-center gap-3 rounded-lg border p-3 cursor-pointer transition-colors ${
+                        checked
+                          ? "border-primary/60 bg-primary/5"
+                          : "border-border hover:bg-muted/40"
+                      }`}
+                    >
+                      <Checkbox
+                        checked={checked}
+                        disabled={!checked && isAtMax}
+                        onCheckedChange={() => handleAdd(pool)}
+                        aria-label={`Add ${pool.name} to comparison`}
+                      />
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium truncate">{pool.name}</p>
+                        <p className="text-xs text-muted-foreground capitalize">{pool.type} pool</p>
+                      </div>
+                      <Plus
+                        className={`ml-auto h-4 w-4 shrink-0 ${checked ? "text-primary" : "text-muted-foreground"}`}
+                      />
+                    </label>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </Card>
+
+        {/* Share hint */}
+        {pools.length > 0 && (
+          <p className="mt-6 text-center text-sm text-muted-foreground">
+            Tip: copy this page&apos;s URL to share the exact comparison with a friend.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function CompareFallback() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Skeleton className="h-4 w-32 mb-6" />
+        <Skeleton className="h-10 w-64 mb-2" />
+        <Skeleton className="h-4 w-96 mb-8" />
+        <Card className="p-6 space-y-3">
+          <Skeleton className="h-5 w-40" />
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+            {Array.from({ length: 12 }).map((_, i) => (
+              <Skeleton key={i} className="h-4 w-full" />
+            ))}
+          </div>
+        </Card>
+      </div>
+    </div>
+  )
+}
+
+export default function ComparePage() {
+  return (
+    <Suspense fallback={<CompareFallback />}>
+      <ErrorBoundary sectionName="Pool Comparison">
+        <CompareContent />
+      </ErrorBoundary>
+    </Suspense>
+  )
+}

--- a/frontend/app/explore/page.tsx
+++ b/frontend/app/explore/page.tsx
@@ -48,6 +48,12 @@ import Link from "next/link"
 import { useToast } from "@/hooks/use-toast"
 import { useDebouncedValue } from "@/hooks/use-debounced-value"
 import { ErrorBoundary } from "@/components/error-boundary"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  usePoolComparison,
+  getPoolComparisonKey,
+  MAX_COMPARISON_POOLS,
+} from "@/hooks/usePoolComparison"
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -125,6 +131,10 @@ function PoolCard({
   onFocus,
   onClick,
   onKeyDown,
+  compareKey,
+  isSelected,
+  onToggleCompare,
+  compareDisabled,
 }: {
   pool: Pool
   onRequestJoin: (poolId: string) => void
@@ -134,6 +144,10 @@ function PoolCard({
   onFocus: () => void
   onClick: (event: MouseEvent<HTMLDivElement>) => void
   onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void
+  compareKey: string
+  isSelected: boolean
+  onToggleCompare: (key: string) => void
+  compareDisabled: boolean
 }) {
   const typeLabel = pool.type.charAt(0).toUpperCase() + pool.type.slice(1)
   const statusLabel =
@@ -146,12 +160,36 @@ function PoolCard({
       tabIndex={tabIndex}
       role="link"
       aria-label={`View details for ${pool.name}`}
+      aria-selected={isSelected}
       onFocus={onFocus}
       onClick={onClick}
       onKeyDown={onKeyDown}
       className="h-full cursor-pointer rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
     >
-      <Card className="p-6 hover:shadow-lg transition-all duration-300 hover:-translate-y-1 h-full flex flex-col">
+      <Card
+        className={`p-6 hover:shadow-lg transition-all duration-300 hover:-translate-y-1 h-full flex flex-col relative ${
+          isSelected ? "border-primary border-2 ring-2 ring-primary/30" : ""
+        }`}
+      >
+        {/* Compare checkbox overlay (top-right) */}
+        <div className="absolute top-3 right-3 z-10">
+          <label
+            className={`flex items-center gap-1.5 rounded-full px-2 py-1 cursor-pointer transition-colors ${
+              isSelected ? "bg-primary/10" : "bg-background/80 hover:bg-muted"
+            }`}
+            onClick={(event) => event.stopPropagation()}
+            aria-label={`Select ${pool.name} for comparison`}
+          >
+            <Checkbox
+              checked={isSelected}
+              disabled={compareDisabled}
+              onCheckedChange={() => onToggleCompare(compareKey)}
+              aria-label={`Compare ${pool.name}`}
+            />
+            <span className="text-[10px] font-medium text-muted-foreground">Compare</span>
+          </label>
+        </div>
+
         <div className="flex items-start justify-between mb-4">
           <div className="min-w-0">
             <h3 className="text-lg font-semibold truncate mb-1">{pool.name}</h3>
@@ -235,17 +273,48 @@ function RecommendedPoolCard({
   healthScore,
   onRequestJoin,
   isJoining,
+  compareKey,
+  isSelected,
+  onToggleCompare,
+  compareDisabled,
 }: {
   pool: Pool
   reasons: string[]
   healthScore?: number
   onRequestJoin: (poolId: string) => void
   isJoining: boolean
+  compareKey: string
+  isSelected: boolean
+  onToggleCompare: (key: string) => void
+  compareDisabled: boolean
 }) {
   const typeLabel = pool.type.charAt(0).toUpperCase() + pool.type.slice(1)
 
   return (
-    <Card className="p-6 h-full flex flex-col hover:shadow-lg transition-all duration-300 hover:-translate-y-1 bg-gradient-to-br from-card to-secondary/20 border-primary/20">
+    <Card
+      className={`p-6 h-full flex flex-col hover:shadow-lg transition-all duration-300 hover:-translate-y-1 bg-gradient-to-br from-card to-secondary/20 border-primary/20 relative ${
+        isSelected ? "border-primary border-2 ring-2 ring-primary/30" : ""
+      }`}
+    >
+      {/* Compare checkbox overlay (top-right) */}
+      <div className="absolute top-3 right-3 z-10">
+        <label
+          className={`flex items-center gap-1.5 rounded-full px-2 py-1 cursor-pointer transition-colors ${
+            isSelected ? "bg-primary/10" : "bg-background/80 hover:bg-muted"
+          }`}
+          onClick={(event) => event.stopPropagation()}
+          aria-label={`Select ${pool.name} for comparison`}
+        >
+          <Checkbox
+            checked={isSelected}
+            disabled={compareDisabled}
+            onCheckedChange={() => onToggleCompare(compareKey)}
+            aria-label={`Compare ${pool.name}`}
+          />
+          <span className="text-[10px] font-medium text-muted-foreground">Compare</span>
+        </label>
+      </div>
+
       <div className="flex items-start justify-between mb-4">
         <div className="min-w-0 pr-2">
           <div className="flex items-center gap-2 mb-1">
@@ -351,6 +420,30 @@ function ExploreContent() {
 
   const [recommendations, setRecommendations] = useState<Recommendation[]>([])
   const [hasReputation, setHasReputation] = useState(false)
+
+  // Pool comparison (multi-select, synced to URL query string)
+  const {
+    selectedKeys: compareSelected,
+    togglePool: toggleComparePool,
+    clearSelection: clearCompare,
+    isSelected: isPoolSelected,
+    isAtMax: compareAtMax,
+  } = usePoolComparison()
+
+  const handleToggleCompare = useCallback(
+    (key: string) => {
+      if (!compareSelected.includes(key) && compareAtMax) {
+        toast({
+          title: "Comparison limit reached",
+          description: `You can compare up to ${MAX_COMPARISON_POOLS} pools at once. Remove one first.`,
+          variant: "error",
+        })
+        return
+      }
+      toggleComparePool(key)
+    },
+    [compareSelected, compareAtMax, toggleComparePool, toast]
+  )
 
   // Filter state is derived from the URL so it survives refresh and can be shared.
   const search = searchParams.get("search") || ""
@@ -631,6 +724,12 @@ function ExploreContent() {
                           healthScore={rec.pool?.health_score}
                           onRequestJoin={handleRequestJoin}
                           isJoining={joining === pool.id}
+                          compareKey={getPoolComparisonKey(pool)}
+                          isSelected={isPoolSelected(getPoolComparisonKey(pool))}
+                          onToggleCompare={handleToggleCompare}
+                          compareDisabled={
+                            !isPoolSelected(getPoolComparisonKey(pool)) && compareAtMax
+                          }
                         />
                       </CarouselItem>
                     )
@@ -737,8 +836,45 @@ function ExploreContent() {
                 onFocus={() => setFocusedPoolIndex(index)}
                 onClick={(event) => handlePoolCardClick(event, pool.id)}
                 onKeyDown={(event) => handlePoolCardKeyDown(event, index, pool.id)}
+                compareKey={getPoolComparisonKey(pool)}
+                isSelected={isPoolSelected(getPoolComparisonKey(pool))}
+                onToggleCompare={handleToggleCompare}
+                compareDisabled={!isPoolSelected(getPoolComparisonKey(pool)) && compareAtMax}
               />
             ))}
+          </motion.div>
+        )}
+
+        {/* Floating Compare bar */}
+        {compareSelected.length > 0 && (
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.25 }}
+            className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50"
+          >
+            <div className="flex items-center gap-2 rounded-full border border-border bg-background/95 backdrop-blur px-4 py-2 shadow-lg">
+              <span className="text-sm font-medium">
+                {compareSelected.length} pool{compareSelected.length !== 1 ? "s" : ""} selected
+              </span>
+              <Button
+                size="sm"
+                className="rounded-full"
+                disabled={compareSelected.length < 2}
+                asChild={compareSelected.length >= 2}
+              >
+                {compareSelected.length >= 2 ? (
+                  <Link href={`/explore/compare?pools=${compareSelected.join(",")}`}>
+                    Compare ({compareSelected.length})
+                  </Link>
+                ) : (
+                  <span>Compare ({compareSelected.length})</span>
+                )}
+              </Button>
+              <Button variant="ghost" size="sm" className="rounded-full" onClick={clearCompare}>
+                Clear
+              </Button>
+            </div>
           </motion.div>
         )}
       </div>

--- a/frontend/components/explore/comparison-table.tsx
+++ b/frontend/components/explore/comparison-table.tsx
@@ -1,0 +1,459 @@
+"use client"
+
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { AlertCircle, ArrowUpRight, CheckCircle2, X } from "lucide-react"
+import type { ComparisonPool, ComparisonPoolRecord } from "@/hooks/usePoolComparison"
+
+/**
+ * Cell content that highlights the "best" value in a row.
+ *
+ * For a handful of numeric rows we pick a winner (e.g. highest TVL, lowest
+ * deposit) and render it emphasised with a check badge so users can scan the
+ * table and instantly see which pool is strongest per metric.
+ */
+interface BestValueCellProps {
+  best: boolean
+  children: React.ReactNode
+  /** Short label for the check badge, e.g. "Best" / "Lowest". */
+  badgeLabel?: string
+}
+
+function BestValueCell({ best, children, badgeLabel = "Best" }: BestValueCellProps) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className={best ? "font-semibold text-primary" : ""}>{children}</span>
+      {best && (
+        <span
+          title={`${badgeLabel} value`}
+          className="inline-flex items-center gap-0.5 rounded-full bg-emerald-500/10 px-1.5 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400"
+        >
+          <CheckCircle2 className="h-3 w-3" />
+          {badgeLabel}
+        </span>
+      )}
+    </div>
+  )
+}
+
+function formatDate(iso: string): string {
+  if (!iso) return "—"
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return "—"
+  return date.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })
+}
+
+function formatDuration(seconds: number | null | undefined): string {
+  if (!seconds || seconds <= 0) return "—"
+  const days = seconds / 86400
+  if (days >= 30) return `${Math.round(days / 30)} mo`
+  if (days >= 1) return `${Math.round(days)} day${Math.round(days) !== 1 ? "s" : ""}`
+  const hours = seconds / 3600
+  if (hours >= 1) return `${Math.round(hours)} hr${Math.round(hours) !== 1 ? "s" : ""}`
+  return `${Math.round(seconds / 60)} min`
+}
+
+function typeLabel(type: string): string {
+  return type.charAt(0).toUpperCase() + type.slice(1)
+}
+
+function statusLabel(status: string): string {
+  if (status === "active") return "Active"
+  if (status === "completed") return "Completed"
+  if (status === "paused") return "Paused"
+  return status
+}
+
+function healthLabel(pool: ComparisonPool): { label: string; color: string } {
+  if (!pool.health) return { label: "…", color: "text-muted-foreground" }
+  if (pool.health.state === "new" || pool.health.score === null) {
+    return { label: "New pool", color: "text-muted-foreground" }
+  }
+  if (pool.health.band === "healthy")
+    return { label: `${pool.health.score}%`, color: "text-emerald-600 dark:text-emerald-400" }
+  if (pool.health.band === "fair")
+    return { label: `${pool.health.score}%`, color: "text-amber-600 dark:text-amber-400" }
+  return { label: `${pool.health.score}%`, color: "text-destructive" }
+}
+
+/** TVL shown from the DB record, falling back to the on-chain-style total. */
+function tvlOf(pool: ComparisonPoolRecord): number {
+  return pool.total_saved ?? 0
+}
+
+/** Deposit amount shown per pool type. */
+function depositOf(pool: ComparisonPoolRecord): number | null {
+  if (pool.type === "target") return pool.target_amount ?? null
+  if (pool.type === "flexible") return pool.minimum_deposit ?? pool.contribution_amount ?? null
+  return pool.contribution_amount ?? null
+}
+
+/** "Member count / max" — rotational & target pools fix their size at creation. */
+function memberCountOf(pool: ComparisonPoolRecord): { count: number; max: string } {
+  const count = pool.members_count ?? 0
+  if (pool.type === "flexible") return { count, max: "Open" }
+  return { count, max: String(Math.max(count, 1)) }
+}
+
+/** True when this column's value is the "best" across the given row of pools. */
+function isBest(
+  pools: ComparisonPool[],
+  getter: (pool: ComparisonPool) => number | null,
+  preferHigher: boolean
+): boolean[] {
+  const values = pools.map((p) => getter(p))
+  const finite = values.filter((v): v is number => v !== null)
+  if (finite.length === 0) return values.map(() => false)
+  const target = preferHigher ? Math.max(...finite) : Math.min(...finite)
+  return values.map((v) => v !== null && v === target)
+}
+
+interface ComparisonTableProps {
+  pools: ComparisonPool[]
+  /** Called when the user removes a pool from the comparison. */
+  onRemove?: (key: string) => void
+  /** Called when the user clears the whole comparison. */
+  onClear?: () => void
+}
+
+/**
+ * Side-by-side comparison table.
+ *
+ * The first column (metric labels) is sticky so it stays visible while the
+ * pool columns scroll horizontally on narrow screens.
+ */
+export function ComparisonTable({ pools, onRemove, onClear }: ComparisonTableProps) {
+  const resolved = pools.filter((p) => p.pool !== null && !p.error)
+
+  const bestTvl = isBest(resolved, (p) => (p.pool ? tvlOf(p.pool) : null), true)
+  const bestDeposit = isBest(resolved, (p) => (p.pool ? depositOf(p.pool) : null), false)
+  const bestMembers = isBest(resolved, (p) => (p.pool ? p.pool.members_count : null), true)
+  const bestHealth = isBest(resolved, (p) => p.health?.score ?? null, true)
+  const bestReputation = isBest(resolved, (p) => p.avgReputation ?? null, true)
+
+  const tokenSymbolOf = (pool: ComparisonPoolRecord) => pool.token_symbol ?? "XLM"
+
+  const renderColumnValue = (pool: ComparisonPool) => {
+    if (pool.loading) {
+      return (
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-4 w-16" />
+        </div>
+      )
+    }
+    if (pool.error || !pool.pool) {
+      return (
+        <div className="flex flex-col items-start gap-2 text-destructive" role="alert">
+          <span className="flex items-center gap-1.5 text-sm font-medium">
+            <AlertCircle className="h-4 w-4" />
+            Invalid pool
+          </span>
+          <span className="text-xs text-muted-foreground break-all font-mono">{pool.key}</span>
+          <span className="text-xs">{pool.error || "This pool could not be loaded."}</span>
+        </div>
+      )
+    }
+
+    const record = pool.pool
+
+    return (
+      <div className="space-y-4 min-w-0">
+        {/* Pool name + type + status */}
+        <div className="min-w-0">
+          <div className="flex items-start justify-between gap-2">
+            <h3 className="font-semibold leading-snug break-words">{record.name}</h3>
+            {onRemove && (
+              <button
+                onClick={() => onRemove(pool.key)}
+                aria-label={`Remove ${record.name} from comparison`}
+                className="shrink-0 rounded-full p-1 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            )}
+          </div>
+          <div className="flex flex-wrap items-center gap-1.5 mt-1.5">
+            <Badge variant="secondary">{typeLabel(record.type)}</Badge>
+            <Badge
+              className={
+                record.status === "active"
+                  ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+                  : record.status === "paused"
+                    ? "bg-amber-500/10 text-amber-600 dark:text-amber-400"
+                    : "bg-muted text-muted-foreground"
+              }
+            >
+              {statusLabel(record.status)}
+            </Badge>
+          </div>
+        </div>
+
+        {/* Join Pool CTA */}
+        <Button size="sm" variant="default" asChild className="w-full sm:w-auto">
+          <Link
+            href={
+              record.contract_address && record.contract_address !== "pending_deployment"
+                ? `/join/${record.contract_address}`
+                : `/dashboard/group/${record.id}`
+            }
+          >
+            Join Pool
+            <ArrowUpRight className="ml-1 h-3.5 w-3.5" />
+          </Link>
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative w-full">
+      <div className="overflow-x-auto rounded-lg border border-border">
+        <table className="w-full border-collapse text-sm" aria-label="Pool comparison">
+          <tbody>
+            {/* Pool name header row */}
+            <tr className="border-b border-border">
+              <th
+                scope="row"
+                className="sticky left-0 z-10 bg-background p-4 text-left align-top font-medium text-muted-foreground w-40 min-w-40 max-w-52"
+              >
+                Pool
+              </th>
+              {pools.map((pool) => (
+                <td
+                  key={pool.key}
+                  className="border-l border-border/60 p-4 align-top min-w-56 max-w-72"
+                >
+                  {renderColumnValue(pool)}
+                </td>
+              ))}
+              {pools.length === 0 && (
+                <td className="p-4 text-muted-foreground">Select pools to compare.</td>
+              )}
+            </tr>
+
+            {pools.length > 0 && (
+              <>
+                {/* Pool Type */}
+                <tr className="border-b border-border/60">
+                  <th
+                    scope="row"
+                    className="sticky left-0 z-10 bg-background p-3 text-left font-medium text-muted-foreground"
+                  >
+                    Pool Type
+                  </th>
+                  {pools.map((pool) => (
+                    <td key={pool.key} className="border-l border-border/60 p-3 capitalize">
+                      {pool.pool ? typeLabel(pool.pool.type) : pool.error ? "—" : "…"}
+                    </td>
+                  ))}
+                </tr>
+
+                {/* TVL */}
+                <tr className="border-b border-border/60">
+                  <th
+                    scope="row"
+                    className="sticky left-0 z-10 bg-background p-3 text-left font-medium text-muted-foreground"
+                  >
+                    TVL
+                  </th>
+                  {resolved.map((pool, i) => (
+                    <td key={pool.key} className="border-l border-border/60 p-3">
+                      <BestValueCell best={bestTvl[i]}>
+                        {tvlOf(pool.pool as ComparisonPoolRecord).toFixed(2)}{" "}
+                        {tokenSymbolOf(pool.pool as ComparisonPoolRecord)}
+                      </BestValueCell>
+                    </td>
+                  ))}
+                  {pools.some((p) => p.error) && (
+                    <td className="border-l border-border/60 p-3 text-muted-foreground">—</td>
+                  )}
+                </tr>
+
+                {/* Member Count/Max */}
+                <tr className="border-b border-border/60">
+                  <th
+                    scope="row"
+                    className="sticky left-0 z-10 bg-background p-3 text-left font-medium text-muted-foreground"
+                  >
+                    Members
+                  </th>
+                  {resolved.map((pool, i) => {
+                    const record = pool.pool as ComparisonPoolRecord
+                    const { count, max } = memberCountOf(record)
+                    return (
+                      <td key={pool.key} className="border-l border-border/60 p-3">
+                        <BestValueCell best={bestMembers[i]}>
+                          {count} / {max}
+                        </BestValueCell>
+                      </td>
+                    )
+                  })}
+                  {pools.some((p) => p.error) && (
+                    <td className="border-l border-border/60 p-3 text-muted-foreground">—</td>
+                  )}
+                </tr>
+
+                {/* Deposit Amount */}
+                <tr className="border-b border-border/60">
+                  <th
+                    scope="row"
+                    className="sticky left-0 z-10 bg-background p-3 text-left font-medium text-muted-foreground"
+                  >
+                    Deposit Amount
+                  </th>
+                  {resolved.map((pool, i) => {
+                    const record = pool.pool as ComparisonPoolRecord
+                    const deposit = depositOf(record)
+                    return (
+                      <td key={pool.key} className="border-l border-border/60 p-3">
+                        {deposit === null ? (
+                          "—"
+                        ) : (
+                          <BestValueCell best={bestDeposit[i]} badgeLabel="Lowest">
+                            {deposit.toFixed(2)} {tokenSymbolOf(record)}
+                          </BestValueCell>
+                        )}
+                      </td>
+                    )
+                  })}
+                  {pools.some((p) => p.error) && (
+                    <td className="border-l border-border/60 p-3 text-muted-foreground">—</td>
+                  )}
+                </tr>
+
+                {/* Token */}
+                <tr className="border-b border-border/60">
+                  <th
+                    scope="row"
+                    className="sticky left-0 z-10 bg-background p-3 text-left font-medium text-muted-foreground"
+                  >
+                    Token
+                  </th>
+                  {pools.map((pool) => (
+                    <td key={pool.key} className="border-l border-border/60 p-3">
+                      {pool.pool ? (pool.pool.token_symbol ?? "XLM") : pool.error ? "—" : "…"}
+                    </td>
+                  ))}
+                </tr>
+
+                {/* Round Duration */}
+                <tr className="border-b border-border/60">
+                  <th
+                    scope="row"
+                    className="sticky left-0 z-10 bg-background p-3 text-left font-medium text-muted-foreground"
+                  >
+                    Round Duration
+                  </th>
+                  {pools.map((pool) => (
+                    <td key={pool.key} className="border-l border-border/60 p-3 capitalize">
+                      {pool.pool
+                        ? pool.pool.frequency
+                          ? pool.pool.frequency
+                          : formatDuration(pool.pool.round_duration)
+                        : pool.error
+                          ? "—"
+                          : "…"}
+                    </td>
+                  ))}
+                </tr>
+
+                {/* Health Score */}
+                <tr className="border-b border-border/60">
+                  <th
+                    scope="row"
+                    className="sticky left-0 z-10 bg-background p-3 text-left font-medium text-muted-foreground"
+                  >
+                    Health Score
+                  </th>
+                  {resolved.map((pool, i) => (
+                    <td key={pool.key} className="border-l border-border/60 p-3">
+                      <BestValueCell best={bestHealth[i]}>
+                        <span className={healthLabel(pool).color}>{healthLabel(pool).label}</span>
+                      </BestValueCell>
+                    </td>
+                  ))}
+                  {pools.some((p) => p.error) && (
+                    <td className="border-l border-border/60 p-3 text-muted-foreground">—</td>
+                  )}
+                </tr>
+
+                {/* Avg Member Reputation */}
+                <tr className="border-b border-border/60">
+                  <th
+                    scope="row"
+                    className="sticky left-0 z-10 bg-background p-3 text-left font-medium text-muted-foreground"
+                  >
+                    Avg Member Reputation
+                  </th>
+                  {resolved.map((pool, i) => (
+                    <td key={pool.key} className="border-l border-border/60 p-3">
+                      {pool.avgReputation === null ? (
+                        "—"
+                      ) : (
+                        <BestValueCell best={bestReputation[i]}>
+                          {pool.avgReputation}%
+                        </BestValueCell>
+                      )}
+                    </td>
+                  ))}
+                  {pools.some((p) => p.error) && (
+                    <td className="border-l border-border/60 p-3 text-muted-foreground">—</td>
+                  )}
+                </tr>
+
+                {/* Created Date */}
+                <tr className="border-b border-border/60">
+                  <th
+                    scope="row"
+                    className="sticky left-0 z-10 bg-background p-3 text-left font-medium text-muted-foreground"
+                  >
+                    Created
+                  </th>
+                  {pools.map((pool) => (
+                    <td key={pool.key} className="border-l border-border/60 p-3">
+                      {pool.pool ? formatDate(pool.pool.created_at) : pool.error ? "—" : "…"}
+                    </td>
+                  ))}
+                </tr>
+
+                {/* Description */}
+                <tr>
+                  <th
+                    scope="row"
+                    className="sticky left-0 z-10 bg-background p-3 text-left font-medium text-muted-foreground align-top"
+                  >
+                    Description
+                  </th>
+                  {pools.map((pool) => (
+                    <td key={pool.key} className="border-l border-border/60 p-3 align-top">
+                      {pool.pool ? (
+                        <span className="text-muted-foreground leading-relaxed">
+                          {pool.pool.description || "No description provided."}
+                        </span>
+                      ) : pool.error ? (
+                        "—"
+                      ) : (
+                        "…"
+                      )}
+                    </td>
+                  ))}
+                </tr>
+              </>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {onClear && pools.length > 0 && (
+        <div className="mt-4 flex justify-center">
+          <Button variant="outline" size="sm" onClick={onClear}>
+            Clear Comparison
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/hooks/usePoolComparison.ts
+++ b/frontend/hooks/usePoolComparison.ts
@@ -1,0 +1,273 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
+import { fetchReputation, type ReputationScore } from "@/hooks/useJointSaveContracts"
+import { computePoolHealth, hasTrackRecord, type PoolHealth } from "@/lib/pool-health"
+
+/**
+ * Maximum number of pools that can be compared side-by-side at once.
+ * Enforced both in the explore-page picker and when parsing a shared URL.
+ */
+export const MAX_COMPARISON_POOLS = 4
+
+/** Query-string key used to share a comparison (`/explore/compare?pools=…`). */
+export const COMPARISON_QUERY_KEY = "pools"
+
+/** Stellar contract addresses always start with C followed by 55 base32 chars. */
+const CONTRACT_ADDRESS_RE = /^C[A-Z2-7]{55}$/
+
+/** The subset of pool fields the comparison table needs from /api/pools. */
+export interface ComparisonPoolRecord {
+  id: string
+  name: string
+  type: "rotational" | "target" | "flexible"
+  status: string
+  description: string | null
+  contract_address: string
+  token_symbol?: string
+  token_decimals?: number
+  contribution_amount: number | null
+  target_amount: number | null
+  minimum_deposit: number | null
+  members_count: number
+  frequency: string | null
+  round_duration: number | null
+  deadline: string | null
+  created_at: string
+  total_saved: number
+  creator_address?: string
+  pool_members?: { member_address: string; contribution_amount?: number }[]
+}
+
+/** One column of the comparison table, keyed by the pool address in the URL. */
+export interface ComparisonPool {
+  /** Stable identifier used in the URL — contract address when available, else DB id. */
+  key: string
+  pool: ComparisonPoolRecord | null
+  loading: boolean
+  /** Present when the address could not be resolved to a pool. */
+  error: string | null
+  health: PoolHealth | null
+  /** Average on-time rate across members, 0–100. Null while loading. */
+  avgReputation: number | null
+}
+
+/**
+ * Stable identifier for a pool that survives URL sharing:
+ * prefers the deployed contract address, falls back to the DB UUID for pools
+ * whose contract is still pending deployment.
+ */
+export function getPoolComparisonKey(pool: {
+  id: string
+  contract_address?: string | null
+}): string {
+  const address = pool.contract_address
+  return address && address !== "pending_deployment" && CONTRACT_ADDRESS_RE.test(address)
+    ? address
+    : pool.id
+}
+
+/** Split a raw `pools` query value into a de-duplicated list capped at the max. */
+export function parseComparisonKeys(raw: string | null | undefined): string[] {
+  if (!raw) return []
+  const keys = raw
+    .split(",")
+    .map((k) => k.trim())
+    .filter(Boolean)
+  return Array.from(new Set(keys)).slice(0, MAX_COMPARISON_POOLS)
+}
+
+/** Join keys back into a `pools` query value. */
+export function serializeComparisonKeys(keys: string[]): string {
+  return keys.slice(0, MAX_COMPARISON_POOLS).join(",")
+}
+
+async function fetchPoolByKey(key: string): Promise<ComparisonPoolRecord> {
+  const isContract = CONTRACT_ADDRESS_RE.test(key)
+  const res = await fetch(isContract ? `/api/pools?contract=${key}` : `/api/pools?id=${key}`)
+  if (!res.ok) throw new Error("Pool not found")
+  const data = (await res.json()) as ComparisonPoolRecord
+  if (!data || !data.id) throw new Error("Pool not found")
+  return data
+}
+
+interface ReputationSummary {
+  health: PoolHealth
+  avgReputation: number | null
+}
+
+/**
+ * Compute the health badge + average member reputation for a pool, mirroring
+ * the pattern used by usePoolHealth (per-member on-chain reputation lookups).
+ */
+async function computePoolHealthAndReputation(
+  pool: ComparisonPoolRecord
+): Promise<ReputationSummary> {
+  const members = pool.pool_members ?? []
+  if (members.length === 0) {
+    const health = computePoolHealth([], 0)
+    return { health, avgReputation: null }
+  }
+
+  const reputations = (
+    await Promise.allSettled(
+      members.map(async (m) => [m.member_address, await fetchReputation(m.member_address)] as const)
+    )
+  )
+    .filter(
+      (r): r is PromiseFulfilledResult<readonly [string, ReputationScore]> =>
+        r.status === "fulfilled"
+    )
+    .map((r) => r.value[1])
+
+  let historyObserved: number
+  if (pool.type === "rotational") {
+    // Rotational pools observe a round of history per elapsed round; without
+    // on-chain state available here, fall back to members with a track record.
+    historyObserved = reputations.filter(hasTrackRecord).length
+  } else {
+    historyObserved = reputations.filter(hasTrackRecord).length
+  }
+
+  const health = computePoolHealth(reputations, historyObserved)
+  const scored = reputations.length > 0 ? reputations : null
+  const avgReputation =
+    scored && scored.length > 0
+      ? Math.round(scored.reduce((sum, r) => sum + r.onTimeRate, 0) / scored.length / 100)
+      : null
+
+  return { health, avgReputation }
+}
+
+/**
+ * Manages the pool comparison feature.
+ *
+ * - Selection lives in the URL (`/explore/compare?pools=addr1,addr2`) so
+ *   comparisons can be shared and survive refresh.
+ * - Up to MAX_COMPARISON_POOLS pools can be selected.
+ * - Full pool data (plus health + average member reputation) is fetched for
+ *   every selected pool; failed resolutions surface an error per column.
+ */
+export function usePoolComparison() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const selectedKeys = useMemo(
+    () => parseComparisonKeys(searchParams.get(COMPARISON_QUERY_KEY)),
+    [searchParams]
+  )
+
+  // Stable serialized form — the fetch effect keys off this string, not the
+  // array identity, so re-renders (e.g. pool data arriving) never re-trigger it.
+  const selectedKeyString = selectedKeys.join(",")
+
+  const [pools, setPools] = useState<Record<string, ComparisonPool>>({})
+
+  const updateUrl = useCallback(
+    (keys: string[]) => {
+      const params = new URLSearchParams(searchParams.toString())
+      const serialized = serializeComparisonKeys(keys)
+      if (serialized) {
+        params.set(COMPARISON_QUERY_KEY, serialized)
+      } else {
+        params.delete(COMPARISON_QUERY_KEY)
+      }
+      const qs = params.toString()
+      router.replace(qs ? `?${qs}` : "?", { scroll: false })
+    },
+    [router, searchParams]
+  )
+
+  // Fetch data for every selected pool (and drop entries no longer selected).
+  useEffect(() => {
+    let cancelled = false
+
+    setPools((prev) => {
+      const next: Record<string, ComparisonPool> = {}
+      for (const key of selectedKeys) {
+        next[key] = prev[key] ?? {
+          key,
+          pool: null,
+          loading: true,
+          error: null,
+          health: null,
+          avgReputation: null,
+        }
+      }
+      return next
+    })
+
+    selectedKeys.forEach((key) => {
+      ;(async () => {
+        try {
+          const pool = await fetchPoolByKey(key)
+          if (cancelled) return
+          const { health, avgReputation } = await computePoolHealthAndReputation(pool)
+          if (cancelled) return
+          setPools((prev) => ({
+            ...prev,
+            [key]: { key, pool, loading: false, error: null, health, avgReputation },
+          }))
+        } catch (err) {
+          if (cancelled) return
+          setPools((prev) => ({
+            ...prev,
+            [key]: {
+              key,
+              pool: null,
+              loading: false,
+              error: err instanceof Error ? err.message : "Could not load this pool",
+              health: null,
+              avgReputation: null,
+            },
+          }))
+        }
+      })()
+    })
+
+    return () => {
+      cancelled = true
+    }
+    // The effect keys off the serialized key string so pool-data re-renders
+    // never re-trigger the fetch loop.
+  }, [selectedKeyString])
+
+  const togglePool = useCallback(
+    (key: string) => {
+      if (selectedKeys.includes(key)) {
+        updateUrl(selectedKeys.filter((k) => k !== key))
+      } else if (selectedKeys.length < MAX_COMPARISON_POOLS) {
+        updateUrl([...selectedKeys, key])
+      }
+      // When at max capacity, silently ignore further adds — the explore page
+      // surfaces a toast explaining the limit before calling this.
+    },
+    [selectedKeys, updateUrl]
+  )
+
+  const removePool = useCallback(
+    (key: string) => updateUrl(selectedKeys.filter((k) => k !== key)),
+    [selectedKeys, updateUrl]
+  )
+
+  const clearSelection = useCallback(() => updateUrl([]), [updateUrl])
+
+  const isSelected = useCallback((key: string) => selectedKeys.includes(key), [selectedKeys])
+
+  const orderedPools = useMemo(
+    () => selectedKeys.map((key) => pools[key]).filter((p): p is ComparisonPool => Boolean(p)),
+    [selectedKeys, pools]
+  )
+
+  return {
+    selectedKeys,
+    pools: orderedPools,
+    togglePool,
+    removePool,
+    clearSelection,
+    isSelected,
+    canAddMore: selectedKeys.length < MAX_COMPARISON_POOLS,
+    isAtMax: selectedKeys.length >= MAX_COMPARISON_POOLS,
+  }
+}


### PR DESCRIPTION
Closes #218

## Summary
- Adds multi-select checkboxes to every Explore pool card (grid + recommended carousel) with a blue border + ring highlight on selection, a floating "Compare (N)" action bar (2–4 pools, with Clear), and a shareable `?pools=` URL that survives refresh.
- Adds a new `/explore/compare` page rendering a responsive side-by-side comparison table — sticky first column, horizontal scroll on mobile — with all requested rows: Pool Name, Pool Type, TVL, Member Count/Max, Deposit Amount, Token, Round Duration, Health Score, Avg Member Reputation, Created Date, Status, Description, and a per-column "Join Pool" CTA.
- Highlights the "best" value in each numeric row (highest TVL / members / health / reputation, lowest deposit) with a green check badge so users can scan which pool wins per metric.
- Lets users add or remove pools directly on the comparison page (searchable picker, per-column remove, clear all) and reports a per-column error for invalid or unresolvable pool addresses.

## Implementation details

### Selection & URL shareability
- New hook `frontend/hooks/usePoolComparison.ts` owns all comparison state. Selection is stored in the query string (`/explore/compare?pools=addr1,addr2`) via `router.replace`, so a comparison can be shared by copying the URL and re-opens identically on refresh.
- Pool keys prefer the deployed contract address (C…) and fall back to the DB UUID for pending-deployment pools (`getPoolComparisonKey`), so every pool on Explore — even ones whose contract is still deploying — can be compared.
- The hook enforces a hard cap of 4 pools (`MAX_COMPARISON_POOLS`); the Explore page shows a toast when the limit is hit instead of silently dropping selections.
- Parsing/serialization helpers (`parseComparisonKeys`, `serializeComparisonKeys`) defensively de-duplicate, trim, and cap the URL value, so hand-edited URLs can't blow past the limit or create duplicate columns.

### Data fetching
- The hook fetches each selected pool via the existing `/api/pools` endpoint (`?contract=` for addresses, `?id=` for UUIDs) and returns a per-column `loading / error / data` shape.
- Health score + average member reputation are computed with the same on-chain reputation pipeline used elsewhere (`fetchReputation` per member → `computePoolHealth` / `hasTrackRecord` from `lib/pool-health`), so the "Health Score" and "Avg Member Reputation" rows match the badges shown on individual pool pages.
- The fetch effect keys off the serialized key string (not the array identity), so pool data arriving never re-triggers the fetch loop.

### Comparison table
- New component `frontend/components/explore/comparison-table.tsx` renders a semantic `<table>` with a sticky first column (metric labels) that stays visible while pool columns scroll horizontally on narrow screens.
- Rows: Pool (name, type, status, remove, Join CTA), Pool Type, TVL, Members (count/max, "Open" for flexible), Deposit Amount, Token, Round Duration (frequency label or humanized duration), Health Score, Avg Member Reputation, Created, Description.
- "Best" detection is computed per row across the resolved columns (`isBest`) — higher-is-better for TVL / members / health / reputation, lower-is-better for deposit amount — and rendered with a check badge (`Best` / `Lowest`).
- Invalid addresses render an error column with the offending key and message instead of a broken table.

### Explore page integration
- Every pool card (grid + recommended carousel) gets a "Compare" checkbox overlay in the top-right corner; clicking it toggles selection without triggering card navigation (stopPropagation).
- Selected cards get `border-primary` + `ring-primary/30` highlight.
- A fixed bottom-center action bar appears once anything is selected, showing the live count, a "Compare (N)" button (enabled at 2+), and a Clear action.

## Files changed
- `frontend/hooks/usePoolComparison.ts` (new) — selection state, URL sync, data + health fetching, validation
- `frontend/components/explore/comparison-table.tsx` (new) — responsive comparison table with best-value highlighting
- `frontend/app/explore/compare/page.tsx` (new) — comparison page with pool picker, error handling, empty/loading states
- `frontend/app/explore/page.tsx` (modified) — card checkboxes, selection highlight, floating Compare bar
- `frontend/__tests__/use-pool-comparison.test.ts` (new) — hook unit tests
- `frontend/__tests__/comparison-table.test.tsx` (new) — component tests

## Acceptance criteria
- [x] Pool cards on Explore page have selectable checkboxes
- [x] Selected pools are highlighted with a blue border
- [x] "Compare (N)" button appears when 2+ pools are selected
- [x] Maximum 4 pools can be compared at once
- [x] Comparison table shows all specified rows with correct data
- [x] "Best" values are highlighted in each row
- [x] Comparison URL is shareable and loads correctly
- [x] Invalid pool addresses in the URL show appropriate errors
- [x] Mobile: comparison table scrolls horizontally
- [x] Users can add/remove pools from the comparison page
- [x] "Join Pool" button on comparison page navigates to the join flow

## Testing
- **Hook tests** (`__tests__/use-pool-comparison.test.ts`, 15 tests): URL parsing/serialization with de-dup + 4-pool cap, contract-vs-UUID key selection, initial URL read, toggle on/off with URL sync, max-cap enforcement, remove/clear, invalid-address error columns, and full data fetching.
- **Table tests** (`__tests__/comparison-table.test.tsx`, 6 tests): all-row rendering, best-TVL + lowest-deposit badges, invalid-address error columns, loading skeletons, remove callback, and Join CTA href pointing at `/join/<contract>`.
- **Full suite**: 69 vitest component tests + 122 tsx unit tests pass; all new/changed files pass ESLint, Prettier, and `tsc --noEmit` for the touched modules. (The repo has pre-existing type errors in unrelated files — e.g. `app/api/analytics`, `components/group/*` — that predate this PR and are untouched here.)
