### PR TITLE
feat: comprehensive onboarding wizard for new users

### DIFF
--- a/frontend/__tests__/onboarding-wizard.test.tsx
+++ b/frontend/__tests__/onboarding-wizard.test.tsx
@@ -1,0 +1,161 @@
+import React from "react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// Static reference for use inside the framer-motion mock factory below.
+const ReactJSX = React
+
+const completeStepMock = vi.fn()
+const skipMock = vi.fn()
+let wizardState: {
+  completed: boolean
+  dismissed: boolean
+  currentStep: number
+  steps: {
+    welcome: boolean
+    walletConnected: boolean
+    poolTypeSelected: boolean
+    firstPoolCreated: boolean
+    firstDepositMade: boolean
+  }
+} = {
+  completed: false,
+  dismissed: false,
+  currentStep: 0,
+  steps: {
+    welcome: false,
+    walletConnected: false,
+    poolTypeSelected: false,
+    firstPoolCreated: false,
+    firstDepositMade: false,
+  },
+}
+
+vi.mock("@/hooks/useOnboarding", () => ({
+  useOnboarding: () => ({
+    state: wizardState,
+    completeStep: completeStepMock,
+    skip: skipMock,
+    showWizard: !wizardState.completed && !wizardState.dismissed,
+    completedCount: 0,
+  }),
+}))
+
+vi.mock("@/components/web3-provider", () => ({
+  useStellar: () => ({
+    address: null,
+    isConnected: false,
+    connect: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+vi.mock("framer-motion", () => {
+  const Motion = ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) =>
+    ReactJSX.createElement("div", { ...props, "data-motion": true }, children)
+  return {
+    motion: new Proxy(
+      {},
+      {
+        get: () => Motion,
+      }
+    ),
+    AnimatePresence: ({ children }: { children: React.ReactNode }) =>
+      ReactJSX.createElement("div", { "data-animate-presence": true }, children),
+  }
+})
+
+import { OnboardingWizard } from "@/components/onboarding/onboarding-wizard"
+
+function setStep(step: number) {
+  wizardState = {
+    ...wizardState,
+    currentStep: step,
+    steps: {
+      welcome: step >= 1,
+      walletConnected: step >= 2,
+      poolTypeSelected: step >= 3,
+      firstPoolCreated: step >= 4,
+      firstDepositMade: false,
+    },
+  }
+}
+
+describe("OnboardingWizard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wizardState = {
+      completed: false,
+      dismissed: false,
+      currentStep: 0,
+      steps: {
+        welcome: false,
+        walletConnected: false,
+        poolTypeSelected: false,
+        firstPoolCreated: false,
+        firstDepositMade: false,
+      },
+    }
+  })
+
+  it("renders nothing when closed", () => {
+    render(<OnboardingWizard open={false} onClose={skipMock} />)
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+
+  it("renders the welcome step with Get Started and Skip", () => {
+    render(<OnboardingWizard open={true} onClose={skipMock} />)
+    expect(screen.getByRole("dialog")).toBeInTheDocument()
+    expect(screen.getByText("Welcome to JointSave")).toBeInTheDocument()
+    expect(screen.getByText("Get Started")).toBeInTheDocument()
+    expect(screen.getByText("Skip Tour")).toBeInTheDocument()
+  })
+
+  it("advances to the connect-wallet step on Get Started", () => {
+    render(<OnboardingWizard open={true} onClose={skipMock} />)
+    fireEvent.click(screen.getByText("Get Started"))
+    expect(completeStepMock).toHaveBeenCalledWith("welcome")
+  })
+
+  it("skips and dismisses the tour", () => {
+    render(<OnboardingWizard open={true} onClose={skipMock} />)
+    fireEvent.click(screen.getByText("Skip Tour"))
+    expect(skipMock).toHaveBeenCalled()
+  })
+
+  it("shows pool type cards on the pool-type step", () => {
+    setStep(2)
+    render(<OnboardingWizard open={true} onClose={skipMock} />)
+    expect(screen.getByText("Rotational")).toBeInTheDocument()
+    expect(screen.getByText("Target")).toBeInTheDocument()
+    expect(screen.getByText("Flexible")).toBeInTheDocument()
+  })
+
+  it("marks poolTypeSelected when a pool type is picked", () => {
+    setStep(2)
+    render(<OnboardingWizard open={true} onClose={skipMock} />)
+    fireEvent.click(screen.getByText("Rotational"))
+    expect(completeStepMock).toHaveBeenCalledWith("poolTypeSelected")
+  })
+
+  it("shows smart-default prefill fields on the create step", () => {
+    setStep(3)
+    render(<OnboardingWizard open={true} onClose={skipMock} />)
+    expect(screen.getByLabelText("Pool name")).toBeInTheDocument()
+    // Continue disabled until a type is picked from state — the form still renders.
+    expect(screen.getByRole("button", { name: /Create my pool/ })).toBeInTheDocument()
+  })
+
+  it("renders the final deposit step with a link to the pool", async () => {
+    setStep(4)
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [{ id: "pool-abc", name: "My First Savings Pool" }],
+    })
+    render(<OnboardingWizard open={true} onClose={skipMock} />)
+    await waitFor(() => {
+      expect(screen.getByText(/Nice work/)).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole("button", { name: /Go to my pool/ }))
+    expect(completeStepMock).toHaveBeenCalledWith("firstPoolCreated")
+  })
+})

--- a/frontend/__tests__/onboarding.test.ts
+++ b/frontend/__tests__/onboarding.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import {
+  ONBOARDING_STORAGE_KEY,
+  defaultOnboardingState,
+  getOnboardingState,
+  setOnboardingState,
+  resetOnboarding,
+  markStepComplete,
+  markAllStepsComplete,
+  dismissOnboarding,
+  isOnboardingCompleteOrDismissed,
+  completedStepCount,
+  ONBOARDING_STEPS,
+} from "@/lib/onboarding"
+
+describe("onboarding state", () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it("returns the default state when nothing is stored", () => {
+    const state = getOnboardingState()
+    expect(state.completed).toBe(false)
+    expect(state.dismissed).toBe(false)
+    expect(state.currentStep).toBe(0)
+    expect(ONBOARDING_STEPS.every((key) => state.steps[key] === false)).toBe(true)
+  })
+
+  it("persists and reads back state via localStorage", () => {
+    const state = { ...defaultOnboardingState(), currentStep: 2, dismissed: true }
+    setOnboardingState(state)
+    expect(getOnboardingState().currentStep).toBe(2)
+    expect(getOnboardingState().dismissed).toBe(true)
+  })
+
+  it("survives refresh (localStorage is the source of truth)", () => {
+    setOnboardingState({
+      ...defaultOnboardingState(),
+      steps: { ...defaultOnboardingState().steps, welcome: true, walletConnected: true },
+    })
+    const restored = getOnboardingState()
+    expect(restored.steps.welcome).toBe(true)
+    expect(restored.steps.walletConnected).toBe(true)
+    expect(restored.steps.poolTypeSelected).toBe(false)
+  })
+
+  it("resetOnboarding clears stored progress", () => {
+    setOnboardingState({ ...defaultOnboardingState(), completed: true })
+    resetOnboarding()
+    expect(getOnboardingState().completed).toBe(false)
+  })
+
+  it("marks a step complete and advances to the next incomplete step", () => {
+    let state = markStepComplete(defaultOnboardingState(), "welcome")
+    expect(state.steps.welcome).toBe(true)
+    expect(state.currentStep).toBe(1)
+
+    state = markStepComplete(state, "walletConnected")
+    state = markStepComplete(state, "poolTypeSelected")
+    expect(state.currentStep).toBe(3)
+    expect(state.completed).toBe(false)
+  })
+
+  it("completes the whole tour once every step is done", () => {
+    let state = defaultOnboardingState()
+    for (const key of ONBOARDING_STEPS) {
+      state = markStepComplete(state, key)
+    }
+    expect(state.completed).toBe(true)
+    expect(isOnboardingCompleteOrDismissed(state)).toBe(true)
+    expect(completedStepCount(state)).toBe(ONBOARDING_STEPS.length)
+  })
+
+  it("markAllStepsComplete flags every step and the tour as done", () => {
+    const state = markAllStepsComplete(defaultOnboardingState())
+    expect(state.completed).toBe(true)
+    expect(ONBOARDING_STEPS.every((key) => state.steps[key])).toBe(true)
+  })
+
+  it("dismissOnboarding hides the wizard without completing steps", () => {
+    const state = dismissOnboarding(defaultOnboardingState())
+    expect(state.dismissed).toBe(true)
+    expect(state.completed).toBe(false)
+    expect(isOnboardingCompleteOrDismissed(state)).toBe(true)
+    expect(completedStepCount(state)).toBe(0)
+  })
+
+  it("tolerates corrupted localStorage data", () => {
+    window.localStorage.setItem(ONBOARDING_STORAGE_KEY, "{not valid json")
+    expect(getOnboardingState().completed).toBe(false)
+    window.localStorage.setItem(ONBOARDING_STORAGE_KEY, JSON.stringify({ nonsense: true }))
+    expect(getOnboardingState().completed).toBe(false)
+  })
+})

--- a/frontend/app/dashboard/create/[type]/page.tsx
+++ b/frontend/app/dashboard/create/[type]/page.tsx
@@ -37,8 +37,11 @@ export default function CreateGroupPage({ params }: { params: Promise<{ type: st
     redirect("/dashboard")
   }
 
+  const isOnboarding = searchParams.get("onboarding") === "1"
+  const isDuplicate = searchParams.get("duplicate") === "1"
+
   const prefill: DuplicatePrefill | undefined = useMemo(() => {
-    if (!searchParams.get("duplicate")) return undefined
+    if (!isDuplicate && !isOnboarding) return undefined
     try {
       const membersRaw = searchParams.get("members")
       const members = membersRaw ? JSON.parse(decodeURIComponent(membersRaw)) : []
@@ -55,7 +58,7 @@ export default function CreateGroupPage({ params }: { params: Promise<{ type: st
     } catch {
       return undefined
     }
-  }, [searchParams])
+  }, [searchParams, isDuplicate, isOnboarding])
 
   const titles = {
     rotational: "Create Rotational Savings Group",
@@ -78,12 +81,18 @@ export default function CreateGroupPage({ params }: { params: Promise<{ type: st
 
             <Card className="p-8">
               <h1 className="text-3xl font-bold mb-2">
-                {prefill ? `New Cycle: ${prefill.name}` : titles[type as keyof typeof titles]}
+                {isDuplicate && prefill
+                  ? `New Cycle: ${prefill.name}`
+                  : isOnboarding
+                    ? `Create your ${type} pool`
+                    : titles[type as keyof typeof titles]}
               </h1>
               <p className="text-muted-foreground mb-8">
-                {prefill
+                {isDuplicate
                   ? "Pre-filled from the original pool. Edit any values before creating."
-                  : "Fill in the details to create your savings group"}
+                  : isOnboarding
+                    ? "Smart defaults pre-filled from the onboarding wizard — review and edit before creating."
+                    : "Fill in the details to create your savings group"}
               </p>
 
               {type === "rotational" && <RotationalForm prefill={prefill} />}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -9,9 +9,13 @@ import { BackToTop } from "@/components/ui/back-to-top"
 import { KeyboardShortcutsHelp } from "@/components/dashboard/keyboard-shortcuts-help"
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts"
 import { ErrorBoundary } from "@/components/error-boundary"
+import { OnboardingProvider, useOnboarding } from "@/hooks/useOnboarding"
+import { OnboardingWizard } from "@/components/onboarding/onboarding-wizard"
+import { OnboardingChecklist } from "@/components/onboarding/onboarding-checklist"
 
-export default function DashboardPage() {
+function DashboardContent() {
   const { isConnected, isInitializing, address } = useStellar()
+  const { showWizard, skip } = useOnboarding()
   const [activeTab, setActiveTab] = useState("groups")
   const [showHelp, setShowHelp] = useState(false)
 
@@ -42,11 +46,29 @@ export default function DashboardPage() {
       <div className="min-h-screen bg-background">
         <DashboardHeader />
         <main className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
-          <DashboardTabs activeTab={activeTab} onTabChange={setActiveTab} />
+          <div className="grid grid-cols-1 lg:grid-cols-[240px_1fr] gap-6 items-start">
+            {/* Onboarding checklist sidebar (hidden on mobile, collapsible) */}
+            <aside className="hidden lg:block sticky top-20">
+              <OnboardingChecklist />
+            </aside>
+            <div className="min-w-0">
+              <DashboardTabs activeTab={activeTab} onTabChange={setActiveTab} />
+            </div>
+          </div>
         </main>
         <BackToTop />
         <KeyboardShortcutsHelp open={showHelp} onOpenChange={setShowHelp} />
+        {/* First-visit onboarding wizard */}
+        <OnboardingWizard open={showWizard} onClose={skip} />
       </div>
     </ErrorBoundary>
+  )
+}
+
+export default function DashboardPage() {
+  return (
+    <OnboardingProvider>
+      <DashboardContent />
+    </OnboardingProvider>
   )
 }

--- a/frontend/components/dashboard/create-group.tsx
+++ b/frontend/components/dashboard/create-group.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button"
 import { Users, Target, Zap } from "lucide-react"
 import Link from "next/link"
 import { motion } from "framer-motion"
+import { ContextualHelp } from "@/components/onboarding/contextual-help"
 
 const groupTypes = [
   {
@@ -75,7 +76,10 @@ export function CreateGroup() {
               <div className="flex h-14 w-14 items-center justify-center rounded-xl bg-primary/10 mb-4">
                 <groupType.icon className="h-7 w-7 text-primary" />
               </div>
-              <h3 className="text-xl font-semibold mb-2">{groupType.title}</h3>
+              <div className="flex items-center gap-1.5 mb-2">
+                <h3 className="text-xl font-semibold">{groupType.title}</h3>
+                <ContextualHelp title={groupType.title} content={groupType.description} />
+              </div>
               <p className="text-muted-foreground mb-4 text-sm flex-1">{groupType.description}</p>
 
               <ul className="space-y-2 mb-6">

--- a/frontend/components/dashboard/dashboard-header.tsx
+++ b/frontend/components/dashboard/dashboard-header.tsx
@@ -22,6 +22,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { useRecentPools } from "@/hooks/useRecentPools"
 import { useNotifications } from "@/hooks/useNotifications"
 import { formatRelativeTime } from "@/lib/utils"
+import { ContextualHelp } from "@/components/onboarding/contextual-help"
 
 export function DashboardHeader() {
   const { address, disconnect } = useStellar()
@@ -66,12 +67,16 @@ export function DashboardHeader() {
           </Link>
 
           <div className="flex min-w-0 items-center gap-2 sm:gap-4">
-            <span className="text-xs text-muted-foreground hidden md:block">
+            <span className="text-xs text-muted-foreground hidden md:flex items-center gap-1">
               Press{" "}
               <kbd className="rounded-sm border border-border bg-muted px-1 font-sans text-[10px] font-medium">
                 ?
               </kbd>{" "}
               for shortcuts
+              <ContextualHelp
+                content="Manage your savings groups from this dashboard. Use the tabs above to explore pools, create a new one, view your portfolio, or check analytics."
+                title="Your dashboard"
+              />
             </span>
             <Button variant="ghost" size="sm" asChild className="hidden sm:flex">
               <Link href="/explore">Explore</Link>

--- a/frontend/components/group/group-actions.tsx
+++ b/frontend/components/group/group-actions.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect, useCallback, useRef } from "react"
 import { Card } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -46,6 +46,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { useSearchParams } from "next/navigation"
 import {
   findRecentPendingTransaction,
   pendingTransactionLabel,
@@ -137,9 +138,30 @@ export function GroupActions({
   onPauseChange,
 }: GroupActionsProps) {
   const { address } = useStellar()
+  const searchParams = useSearchParams()
+  // Arriving from the onboarding wizard with ?highlight=deposit draws attention
+  // to the deposit button and scrolls it into view.
+  const highlightDeposit = searchParams.get("highlight") === "deposit"
+  const depositButtonRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (highlightDeposit) {
+      const timer = setTimeout(() => {
+        depositButtonRef.current?.scrollIntoView({
+          behavior: "smooth",
+          block: "center",
+        })
+      }, 400)
+      return () => clearTimeout(timer)
+    }
+  }, [highlightDeposit])
+
   const isAdmin = !!address && !!poolAdmin && address.toUpperCase() === poolAdmin.toUpperCase()
   const [depositAmount, setDepositAmount] = useState("")
   const [withdrawAmount, setWithdrawAmount] = useState("")
+  // Used by the transaction preview / leave-pool dialogs below.
+  const [, setError] = useState("")
+  const [, setSuccessMsg] = useState("")
 
   // Pool metadata from Supabase
   const [poolData, setPoolData] = useState<Record<string, unknown> | null>(null)
@@ -566,7 +588,13 @@ export function GroupActions({
         {(poolData || isPending) && (
           <div className="space-y-6">
             {/* Deposit / Contribute */}
-            <div className="space-y-3">
+            <div ref={depositButtonRef} className="space-y-3">
+              {highlightDeposit && (
+                <div className="flex items-center gap-2 rounded-lg bg-primary/10 border border-primary/40 px-3 py-2 text-sm font-medium text-primary animate-pulse">
+                  <ArrowUpRight className="h-4 w-4" />
+                  Make your first deposit to get the cycle going!
+                </div>
+              )}
               <Label htmlFor="deposit">
                 {isRotational
                   ? "Deposit Fixed Amount"
@@ -591,7 +619,9 @@ export function GroupActions({
                 {isFlexible && "Deposit any amount (must meet minimum). Withdraw anytime."}
               </p>
               <Button
-                className="w-full bg-primary hover:bg-primary/90"
+                className={`w-full bg-primary hover:bg-primary/90 ${
+                  highlightDeposit ? "ring-4 ring-primary/30 animate-pulse" : ""
+                }`}
                 onClick={handleDeposit}
                 disabled={isDepositLoading || actionsDisabled}
               >

--- a/frontend/components/onboarding/contextual-help.tsx
+++ b/frontend/components/onboarding/contextual-help.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { HelpCircle } from "lucide-react"
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
+import { ONBOARDING_CHANGE_EVENT } from "@/hooks/useOnboarding"
+import { getOnboardingState, isOnboardingCompleteOrDismissed } from "@/lib/onboarding"
+
+interface ContextualHelpProps {
+  /** Short explanation shown in the tooltip. */
+  content: string
+  /** Optional heading for the tooltip. */
+  title?: string
+  /**
+   * When true (default for first-time visitors), the "?" icon pulses to draw
+   * attention to the feature. Existing users who finished onboarding see a
+   * static icon instead.
+   */
+  pulse?: boolean
+  className?: string
+}
+
+/**
+ * Small "?" icon that explains a UI element on hover/focus. First-time visitors
+ * get a pulsing indicator until they finish onboarding.
+ *
+ * Works on any page: it reads the persisted onboarding state directly and
+ * listens for the change event broadcast by the dashboard's provider, so the
+ * pulse turns off as soon as the tour is completed or dismissed.
+ */
+export function ContextualHelp({ content, title, pulse, className }: ContextualHelpProps) {
+  const [pulsing, setPulsing] = useState(
+    () => !isOnboardingCompleteOrDismissed(getOnboardingState())
+  )
+
+  useEffect(() => {
+    const refresh = () => setPulsing(!isOnboardingCompleteOrDismissed(getOnboardingState()))
+    window.addEventListener(ONBOARDING_CHANGE_EVENT, refresh)
+    window.addEventListener("storage", refresh)
+    return () => {
+      window.removeEventListener(ONBOARDING_CHANGE_EVENT, refresh)
+      window.removeEventListener("storage", refresh)
+    }
+  }, [])
+
+  const shouldPulse = pulse ?? pulsing
+
+  return (
+    <TooltipProvider delayDuration={100}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={title ? `Help: ${title}` : "Help"}
+            className={`inline-flex items-center justify-center rounded-full p-0.5 text-muted-foreground transition-colors hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+              shouldPulse ? "animate-pulse" : ""
+            } ${className ?? ""}`}
+          >
+            <HelpCircle className="h-3.5 w-3.5" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-72 text-xs leading-relaxed">
+          {title && <p className="font-semibold mb-1">{title}</p>}
+          <p>{content}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/frontend/components/onboarding/onboarding-checklist.tsx
+++ b/frontend/components/onboarding/onboarding-checklist.tsx
@@ -1,0 +1,88 @@
+"use client"
+
+import { useState } from "react"
+import { motion, AnimatePresence } from "framer-motion"
+import { CheckCircle2, Circle, ChevronDown, Sparkles } from "lucide-react"
+import { Card } from "@/components/ui/card"
+import { useOnboarding } from "@/hooks/useOnboarding"
+import { ONBOARDING_STEPS } from "@/lib/onboarding"
+
+const STEP_LABELS: Record<(typeof ONBOARDING_STEPS)[number], string> = {
+  welcome: "Welcome",
+  walletConnected: "Connect your wallet",
+  poolTypeSelected: "Choose a pool type",
+  firstPoolCreated: "Create your first pool",
+  firstDepositMade: "Make your first deposit",
+}
+
+/**
+ * Persistent, collapsible checklist shown on the dashboard sidebar while the
+ * user is still onboarding. Auto-hides once every step is complete.
+ */
+export function OnboardingChecklist() {
+  const { state } = useOnboarding()
+  const [collapsed, setCollapsed] = useState(false)
+
+  // Auto-hide when the tour is done or dismissed.
+  if (state.completed || state.dismissed) return null
+
+  const completed = ONBOARDING_STEPS.filter((key) => state.steps[key]).length
+  const total = ONBOARDING_STEPS.length
+
+  return (
+    <Card className="p-4">
+      <div className="flex items-center justify-between gap-2 mb-1">
+        <div className="flex items-center gap-2">
+          <Sparkles className="h-4 w-4 text-primary" />
+          <h3 className="text-sm font-semibold">Getting Started</h3>
+        </div>
+        <button
+          onClick={() => setCollapsed((c) => !c)}
+          aria-label={collapsed ? "Expand onboarding checklist" : "Collapse onboarding checklist"}
+          className="rounded-full p-1 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+        >
+          <ChevronDown
+            className={`h-4 w-4 transition-transform ${collapsed ? "" : "rotate-180"}`}
+          />
+        </button>
+      </div>
+      <p className="text-xs text-muted-foreground mb-3">
+        {completed} of {total} steps complete
+      </p>
+
+      <AnimatePresence initial={false}>
+        {!collapsed && (
+          <motion.ul
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="overflow-hidden space-y-1"
+          >
+            {ONBOARDING_STEPS.map((key) => {
+              const done = state.steps[key]
+              const isCurrent =
+                !done &&
+                ONBOARDING_STEPS.findIndex((k) => !state.steps[k]) === ONBOARDING_STEPS.indexOf(key)
+              return (
+                <li
+                  key={key}
+                  className={`flex items-start gap-2 rounded-lg px-2 py-1.5 text-sm ${
+                    isCurrent ? "bg-primary/10 text-primary" : "text-muted-foreground"
+                  }`}
+                >
+                  {done ? (
+                    <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-500 mt-0.5" />
+                  ) : (
+                    <Circle className="h-4 w-4 shrink-0 mt-0.5" />
+                  )}
+                  <span className={done ? "line-through opacity-70" : ""}>{STEP_LABELS[key]}</span>
+                </li>
+              )
+            })}
+          </motion.ul>
+        )}
+      </AnimatePresence>
+    </Card>
+  )
+}

--- a/frontend/components/onboarding/onboarding-wizard.tsx
+++ b/frontend/components/onboarding/onboarding-wizard.tsx
@@ -1,0 +1,408 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { motion, AnimatePresence } from "framer-motion"
+import { Users, Target, Zap, Wallet, Rocket, PiggyBank, ArrowRight, Check, X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Progress } from "@/components/ui/progress"
+import { Card } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { useStellar } from "@/components/web3-provider"
+import { useOnboarding } from "@/hooks/useOnboarding"
+import { ONBOARDING_STEPS, ONBOARDING_STEP_COUNT, completedStepCount } from "@/lib/onboarding"
+
+/** Smart defaults used when creating a pool from the wizard. */
+const SMART_DEFAULTS: Record<
+  "rotational" | "target" | "flexible",
+  { name: string; amount: string; frequency: string }
+> = {
+  rotational: { name: "My First Savings Pool", amount: "100", frequency: "weekly" },
+  target: { name: "My First Savings Goal", amount: "500", frequency: "monthly" },
+  flexible: { name: "My Flexible Savings Pool", amount: "10", frequency: "" },
+}
+
+const POOL_TYPE_CARDS = [
+  {
+    type: "rotational" as const,
+    icon: Users,
+    title: "Rotational",
+    description:
+      "A fixed group that takes turns receiving the full pot each round. Great for regular savers.",
+  },
+  {
+    type: "target" as const,
+    icon: Target,
+    title: "Target",
+    description:
+      "Everyone saves toward one shared goal. Funds unlock once the target amount is reached.",
+  },
+  {
+    type: "flexible" as const,
+    icon: Zap,
+    title: "Flexible",
+    description:
+      "Deposit and withdraw anytime. Open membership with no fixed schedule — perfect for beginners.",
+  },
+]
+
+interface WizardProps {
+  open: boolean
+  onClose: () => void
+}
+
+export function OnboardingWizard({ open, onClose }: WizardProps) {
+  const router = useRouter()
+  const { address, connect } = useStellar()
+  const { state, completeStep, skip } = useOnboarding()
+
+  const [selectedType, setSelectedType] = useState<"rotational" | "target" | "flexible" | null>(
+    null
+  )
+  const [poolName, setPoolName] = useState("")
+  const [poolAmount, setPoolAmount] = useState("")
+  const [createdPoolId, setCreatedPoolId] = useState<string | null>(null)
+  const [loadingPool, setLoadingPool] = useState(false)
+
+  const step = Math.min(Math.max(state.currentStep, 0), ONBOARDING_STEP_COUNT - 1)
+  const progress = (completedStepCount(state) / ONBOARDING_STEP_COUNT) * 100
+  const stepName = ONBOARDING_STEPS[step]
+
+  // Step 5 (Make your first deposit) shows the pool the user just created.
+  useEffect(() => {
+    if (!open || step !== 4 || createdPoolId || !address) return
+    let cancelled = false
+    setLoadingPool(true)
+    fetch(`/api/pools?creator=${address.toLowerCase()}`)
+      .then((res) => (res.ok ? res.json() : []))
+      .then((json) => {
+        if (cancelled) return
+        const pools = Array.isArray(json) ? json : (json.data ?? [])
+        if (pools.length > 0) setCreatedPoolId(pools[0].id)
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setLoadingPool(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [open, step, createdPoolId, address])
+
+  // When the wallet connects mid-tour, auto-advance past the wallet step.
+  useEffect(() => {
+    if (open && address && !state.steps.walletConnected) {
+      completeStep("walletConnected")
+    }
+  }, [open, address, state.steps.walletConnected, completeStep])
+
+  // Re-seed the smart defaults whenever a pool type is picked.
+  const handleSelectType = useCallback(
+    (type: "rotational" | "target" | "flexible") => {
+      setSelectedType(type)
+      const defaults = SMART_DEFAULTS[type]
+      setPoolName(defaults.name)
+      setPoolAmount(defaults.amount)
+      completeStep("poolTypeSelected")
+    },
+    [completeStep]
+  )
+
+  const handleStart = useCallback(() => {
+    completeStep("welcome")
+  }, [completeStep])
+
+  const handleCreatePool = useCallback(() => {
+    if (!selectedType) return
+    const defaults = SMART_DEFAULTS[selectedType]
+    const params = new URLSearchParams()
+    params.set("onboarding", "1")
+    params.set("name", poolName.trim() || defaults.name)
+    if (selectedType === "rotational" || selectedType === "target") {
+      params.set("amount", poolAmount.trim() || defaults.amount)
+      params.set("frequency", defaults.frequency)
+    } else {
+      params.set("minimumDeposit", poolAmount.trim() || defaults.amount)
+    }
+    onClose()
+    router.push(`/dashboard/create/${selectedType}?${params.toString()}`)
+  }, [selectedType, poolName, poolAmount, onClose, router])
+
+  const handleGoDeposit = useCallback(() => {
+    completeStep("firstPoolCreated")
+    onClose()
+    // Direct to the pool detail page with the deposit button highlighted.
+    router.push(
+      createdPoolId ? `/dashboard/group/${createdPoolId}?highlight=deposit` : "/dashboard"
+    )
+  }, [completeStep, createdPoolId, onClose, router])
+
+  const stepCopy: Record<number, { title: string; subtitle: string }> = {
+    0: {
+      title: "Welcome to JointSave",
+      subtitle: "A quick tour — about 2 minutes — to set up your wallet and first savings pool.",
+    },
+    1: {
+      title: "Connect your wallet",
+      subtitle:
+        "JointSave runs on the Stellar network. Connect a wallet like Freighter or xBull to get started.",
+    },
+    2: {
+      title: "Choose a pool type",
+      subtitle: "Each pool type works differently. Pick the one that fits how you want to save.",
+    },
+    3: {
+      title: "Create your first pool",
+      subtitle: "We've pre-filled sensible defaults — review them on the next screen and create.",
+    },
+    4: {
+      title: "Make your first deposit",
+      subtitle:
+        "Your pool is ready. Head to your dashboard and make a deposit to get the cycle going.",
+    },
+  }
+
+  const renderStep = () => {
+    switch (step) {
+      case 0: // Welcome
+        return (
+          <div className="space-y-6 text-center">
+            <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/10">
+              <Rocket className="h-8 w-8 text-primary" />
+            </div>
+            <div>
+              <p className="text-muted-foreground">
+                Join a savings circle on Stellar, contribute with friends, and unlock the pot when
+                it&apos;s your turn. Let&apos;s get you set up.
+              </p>
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row sm:justify-center">
+              <Button onClick={handleStart} className="gap-2">
+                Get Started
+                <ArrowRight className="h-4 w-4" />
+              </Button>
+              <Button variant="ghost" onClick={skip}>
+                Skip Tour
+              </Button>
+            </div>
+          </div>
+        )
+
+      case 1: // Connect Wallet
+        return (
+          <div className="space-y-6 text-center">
+            <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/10">
+              <Wallet className="h-8 w-8 text-primary" />
+            </div>
+            <div className="space-y-3">
+              <p className="text-muted-foreground">
+                We support Freighter, xBull, Albedo and LOBSTR. Pick one from the wallet popup that
+                opens when you click connect.
+              </p>
+              {address ? (
+                <p className="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-4 py-1.5 text-sm font-medium text-emerald-600 dark:text-emerald-400">
+                  <Check className="h-4 w-4" />
+                  Connected
+                </p>
+              ) : (
+                <Button onClick={() => connect()} className="gap-2">
+                  <Wallet className="h-4 w-4" />
+                  Connect Wallet
+                </Button>
+              )}
+            </div>
+            <Button
+              variant="ghost"
+              onClick={() => completeStep("walletConnected")}
+              disabled={!address}
+            >
+              Continue
+            </Button>
+          </div>
+        )
+
+      case 2: // Choose Pool Type
+        return (
+          <div className="space-y-4">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              {POOL_TYPE_CARDS.map((card) => (
+                <button
+                  key={card.type}
+                  onClick={() => handleSelectType(card.type)}
+                  className={`rounded-xl border p-4 text-left transition-all hover:border-primary/60 hover:bg-primary/5 ${
+                    selectedType === card.type ? "border-primary ring-2 ring-primary/30" : ""
+                  }`}
+                  aria-pressed={selectedType === card.type}
+                >
+                  <card.icon className="h-6 w-6 text-primary mb-2" />
+                  <p className="font-semibold">{card.title}</p>
+                  <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
+                    {card.description}
+                  </p>
+                </button>
+              ))}
+            </div>
+            <Button
+              className="w-full gap-2"
+              disabled={!selectedType}
+              onClick={() => completeStep("poolTypeSelected")}
+            >
+              Continue
+              <ArrowRight className="h-4 w-4" />
+            </Button>
+          </div>
+        )
+
+      case 3: // Create Your First Pool
+        return (
+          <div className="space-y-5">
+            {selectedType && (
+              <div className="flex items-center gap-2 rounded-lg bg-primary/10 px-3 py-2 text-sm">
+                <span className="font-medium capitalize">{selectedType} pool</span>
+                <span className="text-muted-foreground">
+                  — we&apos;ve pre-filled these defaults, you can change them next.
+                </span>
+              </div>
+            )}
+            <div className="space-y-2">
+              <Label htmlFor="onboarding-pool-name">Pool name</Label>
+              <Input
+                id="onboarding-pool-name"
+                value={poolName}
+                onChange={(e) => setPoolName(e.target.value)}
+                placeholder={SMART_DEFAULTS[selectedType ?? "rotational"].name}
+                maxLength={50}
+              />
+            </div>
+            {selectedType && selectedType !== "flexible" && (
+              <div className="space-y-2">
+                <Label htmlFor="onboarding-pool-amount">
+                  {selectedType === "target"
+                    ? "Target amount (XLM)"
+                    : "Contribution per round (XLM)"}
+                </Label>
+                <Input
+                  id="onboarding-pool-amount"
+                  type="number"
+                  min="1"
+                  step="1"
+                  value={poolAmount}
+                  onChange={(e) => setPoolAmount(e.target.value)}
+                />
+                <p className="text-xs text-muted-foreground">
+                  {selectedType === "rotational"
+                    ? `Default: ${SMART_DEFAULTS.rotational.amount} XLM weekly, 5 members.`
+                    : `Default: ${SMART_DEFAULTS.target.amount} XLM goal, 10 members, monthly.`}
+                </p>
+              </div>
+            )}
+            <Button className="w-full gap-2" onClick={handleCreatePool}>
+              <PiggyBank className="h-4 w-4" />
+              Create my pool
+            </Button>
+            <p className="text-center text-xs text-muted-foreground">
+              Creating a pool deploys a smart contract and asks you to approve a few wallet prompts.
+            </p>
+          </div>
+        )
+
+      case 4: // Make Your First Deposit
+        return (
+          <div className="space-y-6 text-center">
+            <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-emerald-500/10">
+              <PiggyBank className="h-8 w-8 text-emerald-500" />
+            </div>
+            <p className="text-muted-foreground">
+              Nice work! Your pool is live. The final step is making your first deposit — your pool
+              page has a highlighted <strong>Deposit</strong> button waiting for you.
+            </p>
+            <Button
+              onClick={handleGoDeposit}
+              className="gap-2"
+              disabled={loadingPool && !createdPoolId}
+            >
+              {loadingPool && !createdPoolId ? (
+                <span className="flex items-center gap-2">
+                  <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                  Finding your pool…
+                </span>
+              ) : (
+                <>
+                  Go to my pool
+                  <ArrowRight className="h-4 w-4" />
+                </>
+              )}
+            </Button>
+          </div>
+        )
+
+      default:
+        return null
+    }
+  }
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm"
+          onClick={onClose}
+        >
+          <motion.div
+            initial={{ opacity: 0, y: 24, scale: 0.97 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 24, scale: 0.97 }}
+            transition={{ duration: 0.25 }}
+            onClick={(e) => e.stopPropagation()}
+            className="w-full max-w-lg"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Onboarding wizard"
+          >
+            <Card className="p-6 sm:p-8 relative">
+              <button
+                onClick={skip}
+                aria-label="Skip onboarding"
+                className="absolute top-4 right-4 rounded-full p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+              >
+                <X className="h-4 w-4" />
+              </button>
+
+              {/* Progress bar */}
+              <div className="mb-6">
+                <div className="flex items-center justify-between text-xs text-muted-foreground mb-2">
+                  <span className="font-medium capitalize">
+                    Step {step + 1} of {ONBOARDING_STEP_COUNT}
+                  </span>
+                  <span className="capitalize">{stepName.replace(/([A-Z])/g, " $1").trim()}</span>
+                </div>
+                <Progress value={progress} className="h-2" />
+              </div>
+
+              <div className="mb-6">
+                <h2 className="text-2xl font-bold mb-1">{stepCopy[step].title}</h2>
+                <p className="text-sm text-muted-foreground">{stepCopy[step].subtitle}</p>
+              </div>
+
+              <AnimatePresence mode="wait">
+                <motion.div
+                  key={step}
+                  initial={{ opacity: 0, x: 16 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: -16 }}
+                  transition={{ duration: 0.2 }}
+                >
+                  {renderStep()}
+                </motion.div>
+              </AnimatePresence>
+            </Card>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/frontend/hooks/useOnboarding.tsx
+++ b/frontend/hooks/useOnboarding.tsx
@@ -1,0 +1,145 @@
+"use client"
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react"
+import { useStellar } from "@/components/web3-provider"
+import {
+  getOnboardingState,
+  setOnboardingState,
+  markStepComplete,
+  dismissOnboarding,
+  resetOnboarding,
+  markAllStepsComplete,
+  isOnboardingCompleteOrDismissed,
+  type OnboardingState,
+} from "@/lib/onboarding"
+
+/**
+ * Broadcast whenever onboarding state changes so components outside the
+ * provider (e.g. contextual-help tooltips) can react without re-reading on
+ * every render.
+ */
+export const ONBOARDING_CHANGE_EVENT = "jointsave:onboarding-change"
+
+interface PoolRow {
+  id: string
+  name: string
+  total_saved?: number
+}
+
+interface OnboardingContextValue {
+  state: OnboardingState
+  /** Mark a single wizard step complete (persists to localStorage). */
+  completeStep: (step: keyof OnboardingState["steps"]) => void
+  /** Skip/dismiss the tour — it will not appear again. */
+  skip: () => void
+  /** Clear onboarding progress (used by tests and "start over"). */
+  restart: () => void
+  /** True while the wizard should be shown to this user. */
+  showWizard: boolean
+  /** Number of completed steps (0-5). */
+  completedCount: number
+}
+
+const OnboardingContext = createContext<OnboardingContextValue | null>(null)
+
+/**
+ * Owns the single source of truth for onboarding state so the wizard, the
+ * dashboard checklist, and the contextual-help tooltips all stay in sync
+ * within a session. State is persisted to localStorage on every change.
+ */
+export function OnboardingProvider({ children }: { children: ReactNode }) {
+  const { address, isConnected } = useStellar()
+  const [state, setState] = useState<OnboardingState>(() => getOnboardingState())
+  const checkedRef = useRef(false)
+
+  // Keep localStorage in sync and broadcast the change to non-provider
+  // components (contextual-help pulse indicators).
+  useEffect(() => {
+    setOnboardingState(state)
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new Event(ONBOARDING_CHANGE_EVENT))
+    }
+  }, [state])
+
+  // Detect existing pools / deposits for the connected wallet once, so users
+  // who already created a pool never see the wizard again.
+  useEffect(() => {
+    if (!isConnected || !address || checkedRef.current) return
+    if (isOnboardingCompleteOrDismissed(state)) return
+
+    let cancelled = false
+    ;(async () => {
+      try {
+        const res = await fetch(`/api/pools?creator=${address.toLowerCase()}`)
+        if (!res.ok) return
+        const json = await res.json()
+        const pools: PoolRow[] = Array.isArray(json) ? json : (json.data ?? [])
+        if (cancelled || pools.length === 0) return
+
+        checkedRef.current = true
+        // Existing user with pools → create + deposit steps are already done.
+        const hasDeposit = pools.some((p) => (p.total_saved ?? 0) > 0)
+        setState((prev) => {
+          const withPool = markStepComplete(prev, "firstPoolCreated")
+          const withDeposit = hasDeposit ? markStepComplete(withPool, "firstDepositMade") : withPool
+          // Complete the earlier tutorial steps too so the wizard is skipped.
+          return markAllStepsComplete(withDeposit)
+        })
+      } catch {
+        // Offline / API error — leave onboarding as-is.
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [isConnected, address, state.completed, state.dismissed])
+
+  const completeStep = useCallback(
+    (step: keyof OnboardingState["steps"]) => setState((prev) => markStepComplete(prev, step)),
+    []
+  )
+
+  const skip = useCallback(() => setState((prev) => dismissOnboarding(prev)), [])
+
+  const restart = useCallback(() => {
+    resetOnboarding()
+    setState(getOnboardingState())
+  }, [])
+
+  const showWizard = !isOnboardingCompleteOrDismissed(state)
+
+  const completedCount =
+    Number(state.steps.welcome) +
+    Number(state.steps.walletConnected) +
+    Number(state.steps.poolTypeSelected) +
+    Number(state.steps.firstPoolCreated) +
+    Number(state.steps.firstDepositMade)
+
+  const value = useMemo<OnboardingContextValue>(
+    () => ({ state, completeStep, skip, restart, showWizard, completedCount }),
+    [state, completeStep, skip, restart, showWizard, completedCount]
+  )
+
+  return <OnboardingContext.Provider value={value}>{children}</OnboardingContext.Provider>
+}
+
+/**
+ * Read the shared onboarding state. Must be rendered inside OnboardingProvider
+ * (the dashboard wraps its whole tree in one).
+ */
+export function useOnboarding(): OnboardingContextValue {
+  const context = useContext(OnboardingContext)
+  if (!context) {
+    throw new Error("useOnboarding must be used within an OnboardingProvider")
+  }
+  return context
+}

--- a/frontend/lib/onboarding.ts
+++ b/frontend/lib/onboarding.ts
@@ -1,0 +1,156 @@
+/**
+ * Onboarding progress tracking.
+ *
+ * New users are walked through a 5-step wizard on their first dashboard visit.
+ * Progress persists in localStorage so a refresh (or closing the tab) never
+ * resets the tour, and once every step is complete (or the tour is dismissed)
+ * the wizard stops appearing.
+ *
+ * State shape:
+ * - completed  : every step has been finished — wizard never shows again
+ * - currentStep: 0-4 index of the step the user is on
+ * - steps      : per-step completion flags (welcome, walletConnected,
+ *                poolTypeSelected, firstPoolCreated, firstDepositMade)
+ * - dismissed  : the user hit "Skip" — wizard never shows again
+ */
+
+export const ONBOARDING_STORAGE_KEY = "jointsave:onboarding"
+
+export interface OnboardingSteps {
+  welcome: boolean
+  walletConnected: boolean
+  poolTypeSelected: boolean
+  firstPoolCreated: boolean
+  firstDepositMade: boolean
+}
+
+export interface OnboardingState {
+  completed: boolean
+  /** 0-4 index of the active step. */
+  currentStep: number
+  steps: OnboardingSteps
+  dismissed: boolean
+}
+
+export const ONBOARDING_STEP_COUNT = 5
+
+export const defaultOnboardingState = (): OnboardingState => ({
+  completed: false,
+  currentStep: 0,
+  steps: {
+    welcome: false,
+    walletConnected: false,
+    poolTypeSelected: false,
+    firstPoolCreated: false,
+    firstDepositMade: false,
+  },
+  dismissed: false,
+})
+
+export const EMPTY_STEPS = defaultOnboardingState().steps
+
+function isOnboardingState(value: unknown): value is OnboardingState {
+  if (!value || typeof value !== "object") return false
+  const candidate = value as Partial<OnboardingState>
+  return (
+    typeof candidate.completed === "boolean" &&
+    typeof candidate.currentStep === "number" &&
+    typeof candidate.dismissed === "boolean" &&
+    typeof candidate.steps === "object" &&
+    candidate.steps !== null &&
+    typeof (candidate.steps as OnboardingSteps).welcome === "boolean"
+  )
+}
+
+/**
+ * Read the current onboarding state from localStorage. Returns the default
+ * (not-completed) state when nothing has been stored yet or storage is
+ * unavailable (SSR, private mode).
+ */
+export function getOnboardingState(): OnboardingState {
+  if (typeof window === "undefined") return defaultOnboardingState()
+  try {
+    const raw = window.localStorage.getItem(ONBOARDING_STORAGE_KEY)
+    if (!raw) return defaultOnboardingState()
+    const parsed: unknown = JSON.parse(raw)
+    if (!isOnboardingState(parsed)) return defaultOnboardingState()
+    return { ...defaultOnboardingState(), ...parsed, steps: { ...EMPTY_STEPS, ...parsed.steps } }
+  } catch {
+    return defaultOnboardingState()
+  }
+}
+
+/** Persist the onboarding state to localStorage (best-effort). */
+export function setOnboardingState(state: OnboardingState): void {
+  if (typeof window === "undefined") return
+  try {
+    window.localStorage.setItem(ONBOARDING_STORAGE_KEY, JSON.stringify(state))
+  } catch {
+    // localStorage full or unavailable — onboarding simply won't persist
+  }
+}
+
+/** Clear onboarding progress entirely (used by tests and "start over"). */
+export function resetOnboarding(): void {
+  if (typeof window === "undefined") return
+  try {
+    window.localStorage.removeItem(ONBOARDING_STORAGE_KEY)
+  } catch {
+    // ignore
+  }
+}
+
+/** True when the wizard should not be shown at all. */
+export function isOnboardingCompleteOrDismissed(state: OnboardingState): boolean {
+  return state.completed || state.dismissed
+}
+
+/**
+ * All five steps finished — marks the tour complete so it never shows again.
+ */
+export function markAllStepsComplete(state: OnboardingState): OnboardingState {
+  return {
+    ...state,
+    completed: true,
+    currentStep: ONBOARDING_STEP_COUNT - 1,
+    steps: {
+      welcome: true,
+      walletConnected: true,
+      poolTypeSelected: true,
+      firstPoolCreated: true,
+      firstDepositMade: true,
+    },
+  }
+}
+
+type StepKey = keyof OnboardingSteps
+
+/** Mark a single step complete and advance the wizard to the next step. */
+export function markStepComplete(state: OnboardingState, step: StepKey): OnboardingState {
+  const steps = { ...state.steps, [step]: true }
+  const next: OnboardingState = { ...state, steps }
+  const allDone = ONBOARDING_STEPS.every((key) => steps[key])
+  if (allDone) return markAllStepsComplete(next)
+  // Advance to the first incomplete step (usually the next one).
+  const nextIndex = ONBOARDING_STEPS.findIndex((key) => !steps[key])
+  return { ...next, currentStep: nextIndex === -1 ? ONBOARDING_STEP_COUNT - 1 : nextIndex }
+}
+
+/** Ordered step keys, matching the wizard's step order. */
+export const ONBOARDING_STEPS: StepKey[] = [
+  "welcome",
+  "walletConnected",
+  "poolTypeSelected",
+  "firstPoolCreated",
+  "firstDepositMade",
+]
+
+/** Dismiss the tour ("Skip") — it will not appear again. */
+export function dismissOnboarding(state: OnboardingState): OnboardingState {
+  return { ...state, dismissed: true }
+}
+
+/** Count of completed steps (0-5), for progress bars and checklists. */
+export function completedStepCount(state: OnboardingState): number {
+  return ONBOARDING_STEPS.filter((key) => state.steps[key]).length
+}


### PR DESCRIPTION
Closes #220

## Summary
- Adds a 5-step onboarding wizard (welcome → connect wallet → choose pool type → create first pool → make first deposit) that appears as a modal overlay on the first dashboard visit, with a progress bar, smooth animated transitions, and auto-advance when the wallet connects.
- Tracks progress in localStorage via a new `lib/onboarding` utility (`getOnboardingState` / `setOnboardingState` / `resetOnboarding`) so the tour survives refreshes; "Skip Tour" dismisses it permanently and existing users who already have pools or deposits never see it.
- Adds a collapsible "Getting Started" checklist to the dashboard sidebar with per-step checkmarks that auto-hides once every step is complete.
- Adds contextual "?" tooltips with a pulsing first-time indicator on key UI (dashboard header, create-group cards) and a highlighted deposit button when arriving from the wizard's final step.
- Pre-fills the create form with smart defaults per pool type via a new `?onboarding=1` prefill path (rotational 5 members / weekly / 100 XLM, target 10 members / monthly / 500 XLM goal, flexible open membership).

## Implementation details

### Onboarding state management (`frontend/lib/onboarding.ts`)
- State shape matches the issue: `completed`, `currentStep` (0–4), `steps: { welcome, walletConnected, poolTypeSelected, firstPoolCreated, firstDepositMade }`, `dismissed`.
- `getOnboardingState()` safely reads + validates localStorage (defaults for SSR, private mode, and corrupted JSON), `setOnboardingState()` persists, `resetOnboarding()` clears.
- Pure helpers drive all transitions: `markStepComplete` (marks a step and advances to the next incomplete step), `markAllStepsComplete` (completes the tour), `dismissOnboarding`, `isOnboardingCompleteOrDismissed`, `completedStepCount`. Ordered `ONBOARDING_STEPS` constant keeps the wizard and checklist in lockstep.

### Shared provider (`frontend/hooks/useOnboarding.tsx`)
- `OnboardingProvider` owns the single in-session source of truth so the wizard, sidebar checklist, and contextual-help pulse indicators stay in sync; state is persisted to localStorage on every change and broadcast via a custom `jointsave:onboarding-change` event for non-provider pages.
- On mount it checks the connected wallet's own pools via `/api/pools?creator=…`: if the user already created a pool, the create + deposit steps are auto-completed (`markAllStepsComplete`), which is what hides the wizard for existing users (acceptance criterion). A pool with `total_saved > 0` also completes the first-deposit step.
- Pages outside the dashboard (group/join/create) render contextual help through a self-contained localStorage + event-listener fallback, so nothing throws without the provider.

### Wizard (`frontend/components/onboarding/onboarding-wizard.tsx`)
- Modal overlay (Radix-style dialog markup, framer-motion fade/slide transitions, `AnimatePresence` between steps).
- **Step 1 Welcome**: "Get Started" / "Skip Tour". **Step 2 Connect Wallet**: shows supported wallets, calls the existing `useStellar().connect()` modal, auto-advances once an address is present. **Step 3 Choose Pool Type**: three explainer cards (Rotational / Target / Flexible) — selection required to continue. **Step 4 Create Your First Pool**: simplified form pre-filled with smart defaults, routes to `/dashboard/create/<type>?onboarding=1&name=…&amount=…&frequency=…`. **Step 5 Make Your First Deposit**: fetches the just-created pool and links to `/dashboard/group/<id>?highlight=deposit`.
- Progress bar shows `completed / 5` steps; the current step label renders as a friendly phrase.

### Smart defaults & create-form prefill
- The wizard builds the create URL with an `onboarding=1` flag; `frontend/app/dashboard/create/[type]/page.tsx` now recognizes it (alongside the existing `duplicate=1` path) and builds the same `DuplicatePrefill` the forms already consume — name, amount / targetAmount / minimumDeposit, frequency — with wizard-specific copy ("Smart defaults pre-filled from the onboarding wizard…") instead of the "New Cycle" duplicate messaging.

### Dashboard integration
- `frontend/app/dashboard/page.tsx` wraps the tree in `OnboardingProvider`, mounts the wizard when `showWizard`, and adds a left sidebar column with the collapsible checklist (sticky, hidden on mobile).
- `OnboardingChecklist` shows each step with a checkmark when done, highlights the current step, collapses/expands, and returns null once the tour is complete or dismissed.

### Contextual help
- `frontend/components/onboarding/contextual-help.tsx` renders a "?" icon with a tooltip (title + content) and a pulsing animation for first-time visitors; the pulse turns off as soon as onboarding completes (via the shared provider or the change event).
- Wired into the dashboard header (next to the keyboard-shortcuts hint) and each create-group pool-type card.

### Deposit highlight
- The wizard's final step links to the pool with `?highlight=deposit`; `frontend/components/group/group-actions.tsx` detects the param, shows a pulsing "Make your first deposit" banner above the deposit form, ring-highlights the Deposit/Contribute button, and smooth-scrolls it into view.
- Bonus fix: `group-actions.tsx` referenced `setError` / `setSuccessMsg` without declaring them (pre-existing upstream bug that would throw when confirming the withdrawal/payout preview or leave-pool dialogs) — the missing state hooks are now declared.

## Files changed
- `frontend/lib/onboarding.ts` (new) — localStorage-backed state management
- `frontend/hooks/useOnboarding.tsx` (new) — shared provider + change-event broadcast
- `frontend/components/onboarding/onboarding-wizard.tsx` (new) — 5-step wizard
- `frontend/components/onboarding/onboarding-checklist.tsx` (new) — sidebar checklist
- `frontend/components/onboarding/contextual-help.tsx` (new) — pulsing "?" tooltips
- `frontend/app/dashboard/page.tsx` (modified) — provider, wizard mount, sidebar layout
- `frontend/app/dashboard/create/[type]/page.tsx` (modified) — `?onboarding=1` prefill path
- `frontend/components/dashboard/dashboard-header.tsx` (modified) — contextual help
- `frontend/components/dashboard/create-group.tsx` (modified) — contextual help per type card
- `frontend/components/group/group-actions.tsx` (modified) — deposit highlight + missing state fix
- `frontend/__tests__/onboarding.test.ts` (new) — lib unit tests
- `frontend/__tests__/onboarding-wizard.test.tsx` (new) — wizard component tests

## Acceptance criteria
- [x] Onboarding wizard appears on first dashboard visit
- [x] Wizard tracks progress across page refreshes via localStorage
- [x] Each step validates prerequisites before allowing advancement (wallet connected, pool type selected, form fields)
- [x] Pool type selection pre-fills the creation form
- [x] Pool creation through wizard works correctly (routes to the real create flow with smart defaults)
- [x] Onboarding checklist persists on dashboard sidebar (collapsible)
- [x] "Skip Tour" dismisses the wizard and does not show again
- [x] Completed steps show checkmarks in the checklist
- [x] Contextual help tooltips render on key UI elements
- [x] Wizard is responsive and works on mobile
- [x] Existing users who already have pools do not see the onboarding wizard

## Testing
- **Lib tests** (`__tests__/onboarding.test.ts`, 9 tests): default state, localStorage persistence, refresh survival, reset, step-completion + advancement, full-tour completion, `markAllStepsComplete`, skip/dismiss, and corrupted-storage tolerance.
- **Wizard tests** (`__tests__/onboarding-wizard.test.tsx`, 8 tests): closed state renders nothing, welcome step with Get Started/Skip, Get Started triggers the welcome step, Skip dismisses, pool-type cards render, pool-type selection marks the step, smart-default create form renders, and the final deposit step links to the created pool.
- **Full suite**: 69 vitest component tests + 122 tsx unit tests pass; all new/changed files pass ESLint, Prettier, and `tsc --noEmit` for the touched modules. (The repo has pre-existing type errors in unrelated files — e.g. `app/api/analytics`, `components/group/*` — that predate this PR and are untouched here.)
