### PR TITLE
feat: on-chain event indexing and comprehensive transaction history (#210)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -604,7 +604,24 @@ CREATE TABLE pool_activity (
   activity_type TEXT NOT NULL,            -- 'deposit', 'withdraw', 'payout', 'refund'
   amount NUMERIC,
   tx_hash TEXT,
+  on_chain_timestamp TIMESTAMPTZ,         -- ledger close time (from Horizon / RPC)
+  block_number BIGINT,                    -- ledger sequence number
+  fee_charged BIGINT,                     -- fee in stroops (from Horizon)
   created_at TIMESTAMP DEFAULT NOW()
+);
+```
+
+### event_index_log table
+
+Tracks per-pool on-chain indexing progress so a re-index run never re-reads
+old ledgers (populated by `POST /api/pools/[id]/index-events`).
+
+```sql
+CREATE TABLE event_index_log (
+  id BIGSERIAL PRIMARY KEY,
+  pool_id UUID NOT NULL UNIQUE REFERENCES pools(id) ON DELETE CASCADE,
+  last_indexed_ledger BIGINT NOT NULL DEFAULT 0,
+  indexed_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 ```
 

--- a/frontend/__tests__/date-range-picker.test.tsx
+++ b/frontend/__tests__/date-range-picker.test.tsx
@@ -1,0 +1,71 @@
+import React from "react"
+import { render, screen, fireEvent } from "@/test-utils"
+import { format, subDays } from "date-fns"
+import { DateRangePicker } from "@/components/shared/date-range-picker"
+import { vi, describe, it, expect, beforeEach } from "vitest"
+
+describe("DateRangePicker", () => {
+  const onChange = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders from/to inputs and preset buttons", () => {
+    render(<DateRangePicker from="" to="" onChange={onChange} />)
+
+    expect(screen.getByLabelText("From")).toBeInTheDocument()
+    expect(screen.getByLabelText("To")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Last 7 days" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Last 30 days" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Last 90 days" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "All time" })).toBeInTheDocument()
+  })
+
+  it("fires onChange when a date input changes", () => {
+    render(<DateRangePicker from="" to="2026-08-18" onChange={onChange} />)
+
+    fireEvent.change(screen.getByLabelText("From"), { target: { value: "2026-08-01" } })
+    expect(onChange).toHaveBeenCalledWith("2026-08-01", "2026-08-18")
+
+    fireEvent.change(screen.getByLabelText("To"), { target: { value: "2026-08-20" } })
+    expect(onChange).toHaveBeenCalledWith("", "2026-08-20")
+  })
+
+  it("presets select the expected range ending today", () => {
+    render(<DateRangePicker from="" to="" onChange={onChange} />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Last 7 days" }))
+    expect(onChange).toHaveBeenCalledWith(
+      format(subDays(new Date(), 7), "yyyy-MM-dd"),
+      format(new Date(), "yyyy-MM-dd")
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Last 30 days" }))
+    expect(onChange).toHaveBeenLastCalledWith(
+      format(subDays(new Date(), 30), "yyyy-MM-dd"),
+      format(new Date(), "yyyy-MM-dd")
+    )
+  })
+
+  it("All time clears the range and Clear appears only when filtered", () => {
+    const { rerender } = render(
+      <DateRangePicker from="2026-08-01" to="2026-08-18" onChange={onChange} />
+    )
+
+    expect(screen.getByRole("button", { name: /Clear date filter/i })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "All time" }))
+    expect(onChange).toHaveBeenCalledWith("", "")
+
+    rerender(<DateRangePicker from="" to="" onChange={onChange} />)
+    expect(screen.queryByRole("button", { name: /Clear date filter/i })).not.toBeInTheDocument()
+  })
+
+  it("constrains from max and to min to keep the range valid", () => {
+    render(<DateRangePicker from="2026-08-01" to="2026-08-18" onChange={onChange} />)
+
+    expect(screen.getByLabelText("From")).toHaveAttribute("max", "2026-08-18")
+    expect(screen.getByLabelText("To")).toHaveAttribute("min", "2026-08-01")
+  })
+})

--- a/frontend/app/api/pools/[id]/activity/export/route.ts
+++ b/frontend/app/api/pools/[id]/activity/export/route.ts
@@ -58,10 +58,7 @@ export async function GET(req: NextRequest, ctx: { params: Promise<{ id: string 
   }
 
   try {
-    let q = getAdminClient()
-      .from("pool_activity")
-      .select(ACTIVITY_SELECT_COLUMNS)
-      .eq("pool_id", id)
+    let q = getAdminClient().from("pool_activity").select(ACTIVITY_SELECT_COLUMNS).eq("pool_id", id)
 
     if (query.search) {
       const orClause = buildSearchOrClause(query.search)

--- a/frontend/app/api/pools/[id]/activity/export/route.ts
+++ b/frontend/app/api/pools/[id]/activity/export/route.ts
@@ -1,0 +1,106 @@
+/**
+ * GET /api/pools/[id]/activity/export — downloadable export of a pool's
+ * activity history (issue #210).
+ *
+ * Accepts the same filter params as /activity (search, date_from, date_to,
+ * activity_type, sort — page is ignored) plus `format=csv|json` (default csv)
+ * and a required `wallet` param. Rate limited to EXPORT_RATE_LIMIT (5) exports
+ * per hour per wallet.
+ */
+
+import { NextRequest, NextResponse } from "next/server"
+import { getAdminClient } from "@/lib/supabase-admin"
+import { exportLimiter } from "@/lib/rate-limit"
+import { ACTIVITY_EXPORT_MAX_ROWS } from "@/lib/constants"
+import {
+  ACTIVITY_CSV_HEADERS,
+  ACTIVITY_SELECT_COLUMNS,
+  activityToCsvRow,
+  buildSearchOrClause,
+  exportFilename,
+  isActivityQueryError,
+  parseActivityQuery,
+  type ActivityExportRow,
+} from "@/lib/activity-query"
+import { buildCsv } from "@/lib/csv-export"
+
+export async function GET(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const sp = req.nextUrl.searchParams
+
+  // Wallet first: the limiter keys off it, so an anonymous caller must not be
+  // able to consume (or dodge) another key's export budget.
+  const wallet = sp.get("wallet")
+  if (!wallet) {
+    return NextResponse.json({ error: "wallet required" }, { status: 400 })
+  }
+
+  const limited = exportLimiter(req)
+  if (limited) return limited
+
+  const { id } = await ctx.params
+
+  const format = sp.get("format") ?? "csv"
+  if (format !== "csv" && format !== "json") {
+    return NextResponse.json({ error: "format must be 'csv' or 'json'" }, { status: 400 })
+  }
+
+  const query = parseActivityQuery({
+    search: sp.get("search"),
+    date_from: sp.get("date_from"),
+    date_to: sp.get("date_to"),
+    activity_type: sp.get("activity_type"),
+    sort: sp.get("sort"),
+    // Exports always cover all matching records, not a page.
+    page: null,
+  })
+  if (isActivityQueryError(query)) {
+    return NextResponse.json({ error: query.error }, { status: 400 })
+  }
+
+  try {
+    let q = getAdminClient()
+      .from("pool_activity")
+      .select(ACTIVITY_SELECT_COLUMNS)
+      .eq("pool_id", id)
+
+    if (query.search) {
+      const orClause = buildSearchOrClause(query.search)
+      if (orClause) q = q.or(orClause)
+    }
+    if (query.activityType) q = q.eq("activity_type", query.activityType)
+    if (query.dateFromIso) q = q.gte("created_at", query.dateFromIso)
+    if (query.dateToExclusiveIso) q = q.lt("created_at", query.dateToExclusiveIso)
+
+    const { data, error } = await q
+      .order("created_at", { ascending: query.ascending })
+      .limit(ACTIVITY_EXPORT_MAX_ROWS)
+
+    if (error) throw error
+
+    const rows = (data ?? []) as unknown as ActivityExportRow[]
+    const filename = exportFilename(id, format, new Date())
+
+    if (format === "json") {
+      return new NextResponse(JSON.stringify(rows, null, 2), {
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Content-Disposition": `attachment; filename="${filename}"`,
+        },
+      })
+    }
+
+    const csv = buildCsv(ACTIVITY_CSV_HEADERS, rows.map(activityToCsvRow))
+    return new NextResponse(csv, {
+      headers: {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+      },
+    })
+  } catch (error) {
+    console.error("Activity export error:", error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to export activity" },
+      { status: 500 }
+    )
+  }
+}

--- a/frontend/app/api/pools/[id]/activity/route.ts
+++ b/frontend/app/api/pools/[id]/activity/route.ts
@@ -65,9 +65,7 @@ export async function GET(req: NextRequest, ctx: { params: Promise<{ id: string 
     if (query.dateToExclusiveIso) q = q.lt("created_at", query.dateToExclusiveIso)
 
     const [activityRes, indexLogRes] = await Promise.all([
-      q
-        .order("created_at", { ascending: query.ascending })
-        .range(query.rangeFrom, query.rangeTo),
+      q.order("created_at", { ascending: query.ascending }).range(query.rangeFrom, query.rangeTo),
       admin
         .from("event_index_log")
         .select("last_indexed_ledger, indexed_at")

--- a/frontend/app/api/pools/[id]/activity/route.ts
+++ b/frontend/app/api/pools/[id]/activity/route.ts
@@ -1,0 +1,106 @@
+/**
+ * GET /api/pools/[id]/activity — filterable, paginated pool activity feed
+ * (issue #210).
+ *
+ * Query params:
+ *   search        — case-insensitive match over activity_type, description,
+ *                   user_address, tx_hash
+ *   date_from     — YYYY-MM-DD, inclusive
+ *   date_to       — YYYY-MM-DD, inclusive of the whole day
+ *   activity_type — one of ACTIVITY_TYPES
+ *   sort          — "newest" (default) | "oldest"
+ *   page          — 1-based, ACTIVITY_PAGE_SIZE rows per page
+ *
+ * Rows are public reads (same as the pool_activity SELECT RLS policy and the
+ * embedded feed in GET /api/pools?id=). The response also carries the pool's
+ * indexing state from event_index_log so the UI can show "Last indexed".
+ */
+
+import { NextRequest, NextResponse } from "next/server"
+import { getAdminClient } from "@/lib/supabase-admin"
+import { readLimiter } from "@/lib/rate-limit"
+import { ACTIVITY_PAGE_SIZE } from "@/lib/constants"
+import {
+  ACTIVITY_SELECT_COLUMNS,
+  buildSearchOrClause,
+  isActivityQueryError,
+  parseActivityQuery,
+} from "@/lib/activity-query"
+
+/** Supabase error code for a .range() that starts past the last row. */
+const PGRST_RANGE_NOT_SATISFIABLE = "PGRST103"
+
+export async function GET(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const limited = readLimiter(req)
+  if (limited) return limited
+
+  const { id } = await ctx.params
+  const sp = req.nextUrl.searchParams
+  const query = parseActivityQuery({
+    search: sp.get("search"),
+    date_from: sp.get("date_from"),
+    date_to: sp.get("date_to"),
+    activity_type: sp.get("activity_type"),
+    sort: sp.get("sort"),
+    page: sp.get("page"),
+  })
+  if (isActivityQueryError(query)) {
+    return NextResponse.json({ error: query.error }, { status: 400 })
+  }
+
+  try {
+    const admin = getAdminClient()
+
+    let q = admin
+      .from("pool_activity")
+      .select(ACTIVITY_SELECT_COLUMNS, { count: "exact" })
+      .eq("pool_id", id)
+
+    if (query.search) {
+      const orClause = buildSearchOrClause(query.search)
+      if (orClause) q = q.or(orClause)
+    }
+    if (query.activityType) q = q.eq("activity_type", query.activityType)
+    if (query.dateFromIso) q = q.gte("created_at", query.dateFromIso)
+    if (query.dateToExclusiveIso) q = q.lt("created_at", query.dateToExclusiveIso)
+
+    const [activityRes, indexLogRes] = await Promise.all([
+      q
+        .order("created_at", { ascending: query.ascending })
+        .range(query.rangeFrom, query.rangeTo),
+      admin
+        .from("event_index_log")
+        .select("last_indexed_ledger, indexed_at")
+        .eq("pool_id", id)
+        .maybeSingle(),
+    ])
+
+    // A page past the end of the result set is an empty page, not an error.
+    if (activityRes.error && activityRes.error.code !== PGRST_RANGE_NOT_SATISFIABLE) {
+      throw activityRes.error
+    }
+
+    const total = activityRes.count ?? 0
+    const activities = activityRes.data ?? []
+
+    return NextResponse.json({
+      activities,
+      page: query.page,
+      pageSize: ACTIVITY_PAGE_SIZE,
+      total,
+      hasMore: query.rangeFrom + activities.length < total,
+      lastIndexed: indexLogRes.data
+        ? {
+            ledger: indexLogRes.data.last_indexed_ledger,
+            indexedAt: indexLogRes.data.indexed_at,
+          }
+        : null,
+    })
+  } catch (error) {
+    console.error("Activity fetch error:", error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to load activity" },
+      { status: 500 }
+    )
+  }
+}

--- a/frontend/app/api/pools/[id]/index-events/route.ts
+++ b/frontend/app/api/pools/[id]/index-events/route.ts
@@ -1,0 +1,202 @@
+/**
+ * POST /api/pools/[id]/index-events — on-chain event indexing (issue #210).
+ *
+ * Body: { wallet_address } — any pool member can trigger a run.
+ *
+ * Reads contract events from Soroban RPC since the pool's last indexed ledger,
+ * enriches matching pool_activity rows with tx_hash / on_chain_timestamp /
+ * block_number / fee_charged (block time and fee from Horizon), inserts rows
+ * for on-chain events the database never recorded, backfills older rows that
+ * have a tx_hash but no on-chain data yet, and advances event_index_log.
+ *
+ * Idempotent: re-running updates the same rows to the same values, and the
+ * unique(pool_id) upsert keeps a single log row per pool.
+ */
+
+import { NextRequest, NextResponse } from "next/server"
+import { getAdminClient } from "@/lib/supabase-admin"
+import { writeLimiter } from "@/lib/rate-limit"
+import { fetchEventsSince, fetchHorizonTxBatch } from "@/lib/server/stellar-events"
+
+/** How many un-enriched historical rows to backfill from Horizon per run. */
+const BACKFILL_BATCH_SIZE = 25
+
+async function isMember(poolId: string, wallet: string): Promise<boolean> {
+  const { data } = await getAdminClient()
+    .from("pool_members")
+    .select("id")
+    .eq("pool_id", poolId)
+    .eq("member_address", wallet.toLowerCase())
+    .maybeSingle()
+  return data !== null
+}
+
+export async function POST(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const limited = writeLimiter(req)
+  if (limited) return limited
+
+  const { id } = await ctx.params
+
+  let wallet: string
+  try {
+    const body = await req.json()
+    wallet = typeof body?.wallet_address === "string" ? body.wallet_address.trim() : ""
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+  }
+  if (!wallet) {
+    return NextResponse.json({ error: "wallet_address required" }, { status: 400 })
+  }
+
+  try {
+    const admin = getAdminClient()
+
+    // Any member may trigger indexing (server-enforced, mirrors pool chat).
+    const member = await isMember(id, wallet)
+    if (!member) {
+      return NextResponse.json({ error: "Not a member of this pool" }, { status: 403 })
+    }
+
+    const { data: pool, error: poolErr } = await admin
+      .from("pools")
+      .select("id, contract_address")
+      .eq("id", id)
+      .maybeSingle()
+    if (poolErr) throw poolErr
+    if (!pool) {
+      return NextResponse.json({ error: "Pool not found" }, { status: 404 })
+    }
+    const contractAddress = (pool as { contract_address?: string }).contract_address ?? ""
+    if (!contractAddress || contractAddress === "pending_deployment") {
+      return NextResponse.json({ error: "Pool contract not deployed yet" }, { status: 422 })
+    }
+
+    const { data: indexLog } = await admin
+      .from("event_index_log")
+      .select("last_indexed_ledger")
+      .eq("pool_id", id)
+      .maybeSingle()
+    const startLedger = (indexLog?.last_indexed_ledger ?? 0) + 1
+
+    // ── 1. Pull new events from the RPC and enrich via Horizon ───────────────
+    const { events, latestLedger, warning } = await fetchEventsSince(
+      contractAddress,
+      startLedger
+    )
+    const horizonByHash = await fetchHorizonTxBatch(events.map((ev) => ev.tx_hash))
+
+    let updated = 0
+    let inserted = 0
+
+    for (const ev of events) {
+      const horizon = horizonByHash.get(ev.tx_hash) ?? null
+      const enrichment = {
+        on_chain_timestamp: horizon?.createdAt ?? ev.ledgerClosedAt,
+        block_number: horizon?.ledger ?? ev.ledger,
+        fee_charged: horizon?.feeCharged ?? null,
+      }
+
+      // Match the off-chain row logged for the same transaction. activity_type
+      // disambiguates txs that emit several tracked events; fall back to
+      // hash-only when the logged type doesn't line up with the topic map.
+      const { data: byType } = await admin
+        .from("pool_activity")
+        .select("id")
+        .eq("pool_id", id)
+        .eq("tx_hash", ev.tx_hash)
+        .eq("activity_type", ev.activity_type)
+      let matches = byType ?? []
+      if (matches.length === 0) {
+        const { data: byHash } = await admin
+          .from("pool_activity")
+          .select("id")
+          .eq("pool_id", id)
+          .eq("tx_hash", ev.tx_hash)
+        matches = byHash ?? []
+      }
+
+      if (matches.length > 0) {
+        const { error: updErr } = await admin
+          .from("pool_activity")
+          .update(enrichment)
+          .in(
+            "id",
+            matches.map((m) => m.id)
+          )
+        if (updErr) throw updErr
+        updated += matches.length
+      } else {
+        const { error: insErr } = await admin.from("pool_activity").insert([
+          {
+            pool_id: id,
+            activity_type: ev.activity_type,
+            user_address: ev.user_address?.toLowerCase() ?? null,
+            amount: ev.amount,
+            description: `${ev.activity_type} (indexed from chain)`,
+            tx_hash: ev.tx_hash,
+            ...enrichment,
+          },
+        ])
+        if (insErr) throw insErr
+        inserted++
+      }
+    }
+
+    // ── 2. Backfill older rows that have a tx_hash but no on-chain data ─────
+    const { data: pending } = await admin
+      .from("pool_activity")
+      .select("id, tx_hash")
+      .eq("pool_id", id)
+      .not("tx_hash", "is", null)
+      .is("on_chain_timestamp", null)
+      .order("created_at", { ascending: false })
+      .limit(BACKFILL_BATCH_SIZE)
+
+    let backfilled = 0
+    const pendingRows = (pending ?? []).filter((r) => r.tx_hash)
+    const backfillInfo = await fetchHorizonTxBatch(pendingRows.map((r) => r.tx_hash as string))
+    for (const row of pendingRows) {
+      const info = backfillInfo.get(row.tx_hash as string)
+      if (!info) continue // pruned/lagging history — retried on the next run
+      const { error: bfErr } = await admin
+        .from("pool_activity")
+        .update({
+          on_chain_timestamp: info.createdAt,
+          block_number: info.ledger,
+          fee_charged: info.feeCharged,
+        })
+        .eq("id", row.id)
+      if (bfErr) throw bfErr
+      backfilled++
+    }
+
+    // ── 3. Advance the index log ─────────────────────────────────────────────
+    const indexedAt = new Date().toISOString()
+    const newLastLedger = Math.max(latestLedger, indexLog?.last_indexed_ledger ?? 0)
+    const { error: logErr } = await admin.from("event_index_log").upsert(
+      {
+        pool_id: id,
+        last_indexed_ledger: newLastLedger,
+        indexed_at: indexedAt,
+      },
+      { onConflict: "pool_id" }
+    )
+    if (logErr) throw logErr
+
+    return NextResponse.json({
+      eventsFound: events.length,
+      updated,
+      inserted,
+      backfilled,
+      lastIndexedLedger: newLastLedger,
+      indexedAt,
+      ...(warning ? { warning } : {}),
+    })
+  } catch (error) {
+    console.error("Event indexing error:", error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to index events" },
+      { status: 500 }
+    )
+  }
+}

--- a/frontend/app/api/pools/[id]/index-events/route.ts
+++ b/frontend/app/api/pools/[id]/index-events/route.ts
@@ -79,10 +79,7 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ id: string
     const startLedger = (indexLog?.last_indexed_ledger ?? 0) + 1
 
     // ── 1. Pull new events from the RPC and enrich via Horizon ───────────────
-    const { events, latestLedger, warning } = await fetchEventsSince(
-      contractAddress,
-      startLedger
-    )
+    const { events, latestLedger, warning } = await fetchEventsSince(contractAddress, startLedger)
     const horizonByHash = await fetchHorizonTxBatch(events.map((ev) => ev.tx_hash))
 
     let updated = 0

--- a/frontend/components/group/group-activity.tsx
+++ b/frontend/components/group/group-activity.tsx
@@ -28,6 +28,7 @@ import {
   X,
 } from "lucide-react"
 import { useStellar } from "@/components/web3-provider"
+import { usePoolData } from "@/lib/data-layer/PoolDataProvider"
 import { useDebouncedValue } from "@/hooks/use-debounced-value"
 import { DateRangePicker } from "@/components/shared/date-range-picker"
 import { ACTIVITY_TYPES } from "@/lib/activity-query"
@@ -82,6 +83,13 @@ interface GroupActivityProps {
 
 export function GroupActivity({ groupId, contractAddress }: GroupActivityProps) {
   const { address } = useStellar()
+
+  // The refresh action must also refresh the shared pool cache (balances and
+  // on-chain state shown elsewhere on the page), as it did before the feed
+  // moved to the server-side activity API.
+  const cacheKey =
+    contractAddress && contractAddress !== "pending_deployment" ? contractAddress : groupId
+  const { refetch: refetchPoolCache } = usePoolData(cacheKey)
 
   // Filters
   const [search, setSearch] = useState("")
@@ -158,6 +166,10 @@ export function GroupActivity({ groupId, contractAddress }: GroupActivityProps) 
   useEffect(() => {
     fetchPage(1, false)
   }, [fetchPage])
+
+  const handleRefresh = useCallback(async () => {
+    await Promise.all([refetchPoolCache?.(), fetchPage(1, false)])
+  }, [refetchPoolCache, fetchPage])
 
   const handleReindex = async () => {
     if (!address || !contractAddress || contractAddress === "pending_deployment") return
@@ -257,7 +269,7 @@ export function GroupActivity({ groupId, contractAddress }: GroupActivityProps) 
         <Button
           variant="ghost"
           size="sm"
-          onClick={() => fetchPage(1, false)}
+          onClick={handleRefresh}
           disabled={loading}
           className="h-8 w-8 p-0"
           aria-label="Refresh activity"

--- a/frontend/components/group/group-activity.tsx
+++ b/frontend/components/group/group-activity.tsx
@@ -1,149 +1,246 @@
 "use client"
 
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect, useCallback, useRef } from "react"
 import { Card } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip"
 import { formatRelativeTime, formatExactDateTime } from "@/lib/utils"
 import {
   ArrowUpRight,
   ArrowDownLeft,
+  ArrowUpDown,
+  Download,
   UserPlus,
   Settings,
+  Search,
   Loader2,
   ExternalLink,
   RefreshCw,
   X,
 } from "lucide-react"
-import { usePoolData } from "@/lib/data-layer/PoolDataProvider"
-import { fetchContractEvents, ActivityEvent } from "@/hooks/useJointSaveContracts"
+import { useStellar } from "@/components/web3-provider"
+import { useDebouncedValue } from "@/hooks/use-debounced-value"
+import { DateRangePicker } from "@/components/shared/date-range-picker"
+import { ACTIVITY_TYPES } from "@/lib/activity-query"
 
-const PAGE_SIZE = 20
+const ACTIVITY_TYPE_LABELS: Record<string, string> = {
+  deposit: "Deposit",
+  payout: "Payout",
+  withdraw: "Withdraw",
+  complete: "Pool Complete",
+  member_joined: "Member Joined",
+  member_added: "Member Added",
+  member_removed: "Member Removed",
+  pool_created: "Pool Created",
+  yield: "Yield Distributed",
+}
 
-interface SupabaseActivity {
+interface Activity {
   id: string
   activity_type: string
   user_address: string | null
   amount: number | null
+  token_amount: number | null
   description: string | null
-  created_at: string
   tx_hash: string | null
+  on_chain_timestamp: string | null
+  block_number: number | null
+  fee_charged: number | null
+  created_at: string
+}
+
+interface LastIndexed {
+  ledger: number
+  indexedAt: string
+}
+
+interface ActivityResponse {
+  activities: Activity[]
+  page: number
+  pageSize: number
+  total: number
+  hasMore: boolean
+  lastIndexed: LastIndexed | null
 }
 
 interface GroupActivityProps {
   groupId: string
-  /** Contract address when known — used as the shared cache key */
+  /** Contract address when known — enables the Re-index action. */
   contractAddress?: string
+  /** Kept for call-site compatibility; indexing now tracks its own ledger. */
   startLedger?: number
 }
 
-type Activity = ActivityEvent
+export function GroupActivity({ groupId, contractAddress }: GroupActivityProps) {
+  const { address } = useStellar()
 
-function toActivity(a: SupabaseActivity): Activity {
-  return { ...a, source: "offchain" as const }
-}
-
-function mergeAndDedupe(onchain: Activity[], offchain: Activity[]): Activity[] {
-  const seen = new Set<string>()
-  const merged: Activity[] = []
-  for (const a of [...onchain, ...offchain]) {
-    const key = a.tx_hash ?? a.id
-    if (seen.has(key)) continue
-    seen.add(key)
-    merged.push(a)
-  }
-  return merged.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
-}
-
-/**
- * Filter activities to those whose created_at falls within [from, to].
- * If both are empty the full list is returned unchanged.
- */
-function applyDateFilter(activities: Activity[], from: string, to: string): Activity[] {
-  if (!from && !to) return activities
-
-  const fromMs = from ? new Date(from).setHours(0, 0, 0, 0) : -Infinity
-  // Use end-of-day for the "to" bound so the selected date is fully included.
-  const toMs = to ? new Date(to).setHours(23, 59, 59, 999) : Infinity
-
-  return activities.filter((a) => {
-    const ts = new Date(a.created_at).getTime()
-    return ts >= fromMs && ts <= toMs
-  })
-}
-
-export function GroupActivity({ groupId, contractAddress, startLedger = 0 }: GroupActivityProps) {
-  const cacheKey =
-    contractAddress && contractAddress !== "pending_deployment" ? contractAddress : groupId
-
-  const { data, isLoading, refetch: refetchCache } = usePoolData(cacheKey)
-  const [onchainActivities, setOnchainActivities] = useState<Activity[]>([])
-  const [loadingOnchain, setLoadingOnchain] = useState(false)
-  const [page, setPage] = useState(1)
-
-  // Date-range filter state
+  // Filters
+  const [search, setSearch] = useState("")
+  const debouncedSearch = useDebouncedValue(search, 300)
   const [fromDate, setFromDate] = useState("")
   const [toDate, setToDate] = useState("")
+  const [activityType, setActivityType] = useState("all")
+  const [sort, setSort] = useState<"newest" | "oldest">("newest")
 
-  const fetchOnchain = useCallback(async () => {
-    if (!contractAddress || contractAddress === "pending_deployment") return
-    try {
-      setLoadingOnchain(true)
-      const events = await fetchContractEvents(contractAddress, startLedger)
-      setOnchainActivities(events)
-    } catch (err) {
-      console.error("Failed to fetch onchain events:", err)
-    } finally {
-      setLoadingOnchain(false)
-    }
-  }, [contractAddress, startLedger])
+  // Data
+  const [activities, setActivities] = useState<Activity[]>([])
+  const [page, setPage] = useState(1)
+  const [hasMore, setHasMore] = useState(false)
+  const [total, setTotal] = useState(0)
+  const [lastIndexed, setLastIndexed] = useState<LastIndexed | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [indexing, setIndexing] = useState(false)
+  const [exporting, setExporting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
 
+  // Guards against out-of-order responses when filters change quickly.
+  const requestSeq = useRef(0)
+
+  const buildParams = useCallback(
+    (targetPage: number) => {
+      const params = new URLSearchParams()
+      if (debouncedSearch.trim()) params.set("search", debouncedSearch.trim())
+      if (fromDate) params.set("date_from", fromDate)
+      if (toDate) params.set("date_to", toDate)
+      if (activityType !== "all") params.set("activity_type", activityType)
+      if (sort !== "newest") params.set("sort", sort)
+      if (targetPage > 1) params.set("page", String(targetPage))
+      return params
+    },
+    [debouncedSearch, fromDate, toDate, activityType, sort]
+  )
+
+  const fetchPage = useCallback(
+    async (targetPage: number, append: boolean) => {
+      const seq = ++requestSeq.current
+      if (append) setLoadingMore(true)
+      else setLoading(true)
+      try {
+        const res = await fetch(`/api/pools/${groupId}/activity?${buildParams(targetPage)}`)
+        if (!res.ok) {
+          const body = await res.json().catch(() => null)
+          throw new Error(body?.error || "Failed to load activity")
+        }
+        const data = (await res.json()) as Partial<ActivityResponse> | null
+        if (seq !== requestSeq.current) return // stale response
+        const rows = Array.isArray(data?.activities) ? data.activities : []
+        setActivities((prev) => (append ? [...prev, ...rows] : rows))
+        setPage(data?.page ?? targetPage)
+        setHasMore(data?.hasMore ?? false)
+        setTotal(data?.total ?? rows.length)
+        setLastIndexed(data?.lastIndexed ?? null)
+        setError(null)
+      } catch (err) {
+        if (seq !== requestSeq.current) return
+        setError((err as Error)?.message || "Failed to load activity")
+      } finally {
+        if (seq === requestSeq.current) {
+          setLoading(false)
+          setLoadingMore(false)
+        }
+      }
+    },
+    [groupId, buildParams]
+  )
+
+  // Refetch from page 1 whenever a filter changes (search is debounced).
   useEffect(() => {
-    fetchOnchain()
-  }, [fetchOnchain])
+    fetchPage(1, false)
+  }, [fetchPage])
 
-  const refetch = useCallback(async () => {
-    await Promise.all([refetchCache(), fetchOnchain()])
-  }, [refetchCache, fetchOnchain])
-
-  // Reset pagination whenever the date filter changes so the user always
-  // sees from the first page of the newly-filtered result set.
-  const handleFromChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFromDate(e.target.value)
-    setPage(1)
+  const handleReindex = async () => {
+    if (!address || !contractAddress || contractAddress === "pending_deployment") return
+    setIndexing(true)
+    setNotice(null)
+    try {
+      const res = await fetch(`/api/pools/${groupId}/index-events`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-wallet-address": address,
+        },
+        body: JSON.stringify({ wallet_address: address }),
+      })
+      const body = await res.json().catch(() => null)
+      if (res.status === 403) {
+        setNotice("Only pool members can re-index.")
+        return
+      }
+      if (!res.ok) {
+        setNotice(body?.error || "Indexing failed. Please try again.")
+        return
+      }
+      if (body?.warning) setNotice(body.warning)
+      await fetchPage(1, false)
+    } catch {
+      setNotice("Indexing failed. Please try again.")
+    } finally {
+      setIndexing(false)
+    }
   }
 
-  const handleToChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setToDate(e.target.value)
-    setPage(1)
+  const handleExport = async () => {
+    if (!address) return
+    setExporting(true)
+    setNotice(null)
+    try {
+      const params = buildParams(1)
+      params.delete("page")
+      params.set("wallet", address)
+      const res = await fetch(`/api/pools/${groupId}/activity/export?${params}`)
+      if (res.status === 429) {
+        const body = await res.json().catch(() => null)
+        const wait = body?.retryAfterSec
+        setNotice(
+          wait
+            ? `Export limit reached (5 per hour). Try again in ${Math.ceil(wait / 60)} min.`
+            : "Export limit reached (5 per hour). Please try again later."
+        )
+        return
+      }
+      if (!res.ok) {
+        const body = await res.json().catch(() => null)
+        setNotice(body?.error || "Export failed. Please try again.")
+        return
+      }
+      const blob = await res.blob()
+      const disposition = res.headers.get("Content-Disposition") || ""
+      const filename =
+        disposition.match(/filename="([^"]+)"/)?.[1] ?? `pool-activity-${groupId.slice(0, 8)}.csv`
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement("a")
+      a.href = url
+      a.download = filename
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch {
+      setNotice("Export failed. Please try again.")
+    } finally {
+      setExporting(false)
+    }
   }
 
-  const clearFilter = () => {
-    setFromDate("")
-    setToDate("")
-    setPage(1)
+  const formatAddress = (addr: string | null) => {
+    if (!addr) return "System"
+    return `${addr.slice(0, 6)}...${addr.slice(-4)}`
   }
 
-  const isFiltered = fromDate !== "" || toDate !== ""
+  const isFiltered =
+    debouncedSearch.trim() !== "" || fromDate !== "" || toDate !== "" || activityType !== "all"
+  const canReindex = !!address && !!contractAddress && contractAddress !== "pending_deployment"
 
-  const dbActivities = (data?.db?.pool_activity ?? []).map(toActivity)
-  const allActivities = mergeAndDedupe(onchainActivities, dbActivities)
-
-  // Apply date-range filter before pagination
-  const filteredActivities = applyDateFilter(allActivities, fromDate, toDate)
-
-  const formatAddress = (address: string | null) => {
-    if (!address) return "System"
-    return `${address.slice(0, 6)}...${address.slice(-4)}`
-  }
-
-  const visible = filteredActivities.slice(0, page * PAGE_SIZE)
-  const hasMore = visible.length < filteredActivities.length
-
-  if (isLoading && allActivities.length === 0) {
+  if (loading && activities.length === 0 && !error) {
     return (
       <Card className="p-6">
         <div className="flex items-center justify-center py-8">
@@ -155,175 +252,253 @@ export function GroupActivity({ groupId, contractAddress, startLedger = 0 }: Gro
 
   return (
     <Card className="p-6">
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex items-center justify-between mb-1">
         <h3 className="text-lg font-semibold">Recent Activity</h3>
         <Button
           variant="ghost"
           size="sm"
-          onClick={refetch}
-          disabled={isLoading || loadingOnchain}
-          className="h-8 w-8 p0"
+          onClick={() => fetchPage(1, false)}
+          disabled={loading}
+          className="h-8 w-8 p-0"
+          aria-label="Refresh activity"
         >
-          <RefreshCw className={`h-4 w-4 ${isLoading || loadingOnchain ? "animate-spin" : ""}`} />
+          <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
         </Button>
       </div>
 
-      {/* ── Date-range filter ───────────────────────────────────────────── */}
-      <div className="flex flex-wrap items-end gap-3 mb-4">
-        <div className="flex flex-col gap-1">
-          <Label htmlFor="activity-from" className="text-xs text-muted-foreground">
-            From
-          </Label>
-          <Input
-            id="activity-from"
-            type="date"
-            value={fromDate}
-            onChange={handleFromChange}
-            max={toDate || undefined}
-            className="h-8 text-sm w-36"
-          />
-        </div>
-        <div className="flex flex-col gap-1">
-          <Label htmlFor="activity-to" className="text-xs text-muted-foreground">
-            To
-          </Label>
-          <Input
-            id="activity-to"
-            type="date"
-            value={toDate}
-            onChange={handleToChange}
-            min={fromDate || undefined}
-            className="h-8 text-sm w-36"
-          />
-        </div>
-        {isFiltered && (
+      {/* ── Indexing status ────────────────────────────────────────────────── */}
+      <div className="flex items-center gap-2 mb-4 flex-wrap">
+        <p className="text-xs text-muted-foreground">
+          {lastIndexed ? (
+            <>
+              Last indexed:{" "}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <time dateTime={lastIndexed.indexedAt} className="cursor-default" tabIndex={0}>
+                    {formatRelativeTime(lastIndexed.indexedAt)}
+                  </time>
+                </TooltipTrigger>
+                <TooltipContent>{formatExactDateTime(lastIndexed.indexedAt)}</TooltipContent>
+              </Tooltip>
+            </>
+          ) : (
+            "Never indexed"
+          )}
+        </p>
+        {canReindex && (
           <Button
-            variant="ghost"
+            variant="outline"
             size="sm"
-            onClick={clearFilter}
-            className="h-8 gap-1 text-xs"
-            aria-label="Clear date filter"
+            className="h-6 gap-1 text-xs px-2"
+            onClick={handleReindex}
+            disabled={indexing}
           >
-            <X className="h-3 w-3" />
-            Clear
+            <RefreshCw className={`h-3 w-3 ${indexing ? "animate-spin" : ""}`} />
+            {indexing ? "Indexing…" : "Re-index"}
           </Button>
         )}
       </div>
-      {/* ─────────────────────────────────────────────────────────────────── */}
 
-      {filteredActivities.length === 0 ? (
+      {/* ── Search + filters ───────────────────────────────────────────────── */}
+      <div className="space-y-3 mb-4">
+        <div className="relative">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            type="text"
+            placeholder="Search activity…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="h-8 pl-8 pr-8 text-sm"
+            aria-label="Search activity"
+          />
+          {search && (
+            <button
+              type="button"
+              onClick={() => setSearch("")}
+              className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              aria-label="Clear search"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-end gap-3">
+          <DateRangePicker
+            from={fromDate}
+            to={toDate}
+            onChange={(from, to) => {
+              setFromDate(from)
+              setToDate(to)
+            }}
+            idPrefix="activity"
+          />
+          <Select value={activityType} onValueChange={setActivityType}>
+            <SelectTrigger className="h-8 w-40 text-sm" aria-label="Filter by activity type">
+              <SelectValue placeholder="All types" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All types</SelectItem>
+              {ACTIVITY_TYPES.map((type) => (
+                <SelectItem key={type} value={type}>
+                  {ACTIVITY_TYPE_LABELS[type] ?? type}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1 text-xs"
+            onClick={() => setSort((s) => (s === "newest" ? "oldest" : "newest"))}
+            aria-label="Toggle sort order"
+          >
+            <ArrowUpDown className="h-3 w-3" />
+            {sort === "newest" ? "Newest first" : "Oldest first"}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1 text-xs"
+            onClick={handleExport}
+            disabled={exporting || !address || total === 0}
+            title={!address ? "Connect a wallet to export" : undefined}
+          >
+            {exporting ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <Download className="h-3 w-3" />
+            )}
+            Export
+          </Button>
+        </div>
+      </div>
+      {/* ───────────────────────────────────────────────────────────────────── */}
+
+      {notice && (
+        <p className="text-xs text-amber-600 dark:text-amber-500 mb-3" role="status">
+          {notice}
+        </p>
+      )}
+      {error && (
+        <p className="text-sm text-destructive text-center py-4" role="alert">
+          {error}
+        </p>
+      )}
+
+      {!error && activities.length === 0 ? (
         <p className="text-sm text-muted-foreground text-center py-4">
-          {isFiltered ? "No activity found in the selected date range." : "No activity yet"}
+          {isFiltered ? "No activity matches your filters." : "No activity yet"}
         </p>
       ) : (
-        <>
-          <div className="space-y-4">
-            {visible.map((activity: Activity) => (
-              <div
-                key={activity.id}
-                className="flex items-start gap-4 pb-4 border-b border-border last:border-0 last:pb-0"
-              >
+        !error && (
+          <>
+            <div className="space-y-4">
+              {activities.map((activity) => (
                 <div
-                  className={`flex h-10 w-10 items-center justify-center rounded-lg flex-shrink-0 ${
-                    activity.activity_type === "deposit"
-                      ? "bg-primary/10"
-                      : activity.activity_type === "payout"
-                        ? "bg-accent/10"
-                        : "bg-muted"
-                  }`}
+                  key={activity.id}
+                  className="flex items-start gap-4 pb-4 border-b border-border last:border-0 last:pb-0"
                 >
-                  {activity.activity_type === "deposit" && (
-                    <ArrowUpRight className="h-5 w-5 text-primary" />
-                  )}
-                  {activity.activity_type === "payout" && (
-                    <ArrowDownLeft className="h-5 w-5 text-accent" />
-                  )}
-                  {activity.activity_type === "member_joined" && (
-                    <UserPlus className="h-5 w-5 text-muted-foreground" />
-                  )}
-                  {!["deposit", "payout", "member_joined"].includes(activity.activity_type) && (
-                    <Settings className="h-5 w-5 text-muted-foreground" />
-                  )}
-                </div>
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 mb-1 flex-wrap">
-                    <p className="font-medium text-sm capitalize">
-                      {(
-                        {
-                          deposit: "Deposit",
-                          payout: "Payout",
-                          withdraw: "Withdraw",
-                          complete: "Pool Complete",
-                          member_joined: "Member Joined",
-                          pool_created: "Pool Created",
-                          yield: "Yield Distributed",
-                        } as Record<string, string>
-                      )[activity.activity_type] ?? activity.activity_type}
-                    </p>
-                    {activity.amount != null && (
-                      <Badge variant="secondary">{activity.amount.toFixed(2)} XLM</Badge>
+                  <div
+                    className={`flex h-10 w-10 items-center justify-center rounded-lg flex-shrink-0 ${
+                      activity.activity_type === "deposit"
+                        ? "bg-primary/10"
+                        : activity.activity_type === "payout"
+                          ? "bg-accent/10"
+                          : "bg-muted"
+                    }`}
+                  >
+                    {activity.activity_type === "deposit" && (
+                      <ArrowUpRight className="h-5 w-5 text-primary" />
                     )}
-                    <Badge
-                      variant="outline"
-                      className={`text-xs ${
-                        activity.source === "onchain"
-                          ? "border-blue-400 text-blue-600"
-                          : "border-gray-300 text-gray-500"
-                      }`}
-                    >
-                      {activity.source === "onchain" ? "🔗 on-chain" : "📝 off-chain"}
-                    </Badge>
+                    {activity.activity_type === "payout" && (
+                      <ArrowDownLeft className="h-5 w-5 text-accent" />
+                    )}
+                    {activity.activity_type === "member_joined" && (
+                      <UserPlus className="h-5 w-5 text-muted-foreground" />
+                    )}
+                    {!["deposit", "payout", "member_joined"].includes(activity.activity_type) && (
+                      <Settings className="h-5 w-5 text-muted-foreground" />
+                    )}
                   </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1 flex-wrap">
+                      <p className="font-medium text-sm capitalize">
+                        {ACTIVITY_TYPE_LABELS[activity.activity_type] ?? activity.activity_type}
+                      </p>
+                      {activity.amount != null && (
+                        <Badge variant="secondary">{activity.amount.toFixed(2)} XLM</Badge>
+                      )}
+                      <Badge
+                        variant="outline"
+                        className={`text-xs ${
+                          activity.on_chain_timestamp
+                            ? "border-blue-400 text-blue-600"
+                            : "border-gray-300 text-gray-500"
+                        }`}
+                      >
+                        {activity.on_chain_timestamp ? "🔗 on-chain" : "📝 off-chain"}
+                      </Badge>
+                    </div>
 
-                  <p className="text-xs text-muted-foreground">
-                    {formatAddress(activity.user_address)} •{" "}
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <time
-                          dateTime={activity.created_at}
-                          className="cursor-default"
-                          tabIndex={0}
-                        >
-                          {formatRelativeTime(activity.created_at)}
-                        </time>
-                      </TooltipTrigger>
-                      <TooltipContent>{formatExactDateTime(activity.created_at)}</TooltipContent>
-                    </Tooltip>
-                  </p>
+                    <p className="text-xs text-muted-foreground">
+                      {formatAddress(activity.user_address)} •{" "}
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <time
+                            dateTime={activity.on_chain_timestamp ?? activity.created_at}
+                            className="cursor-default"
+                            tabIndex={0}
+                          >
+                            {formatRelativeTime(activity.on_chain_timestamp ?? activity.created_at)}
+                          </time>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          {formatExactDateTime(activity.on_chain_timestamp ?? activity.created_at)}
+                        </TooltipContent>
+                      </Tooltip>
+                      {activity.block_number != null && <> • Ledger {activity.block_number}</>}
+                    </p>
 
-                  {activity.description && (
-                    <p className="text-xs text-muted-foreground mt-1">{activity.description}</p>
-                  )}
+                    {activity.description && (
+                      <p className="text-xs text-muted-foreground mt-1">{activity.description}</p>
+                    )}
 
-                  {activity.tx_hash ? (
-                    <a
-                      href={`https://stellar.expert/explorer/testnet/tx/${activity.tx_hash}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1 text-xs text-primary hover:underline mt-1"
-                    >
-                      {activity.tx_hash.slice(0, 8)}…{activity.tx_hash.slice(-6)}
-                      <ExternalLink className="h-3 w-3" />
-                    </a>
-                  ) : (
-                    <p className="text-xs text-muted-foreground mt-1">No tx hash</p>
-                  )}
+                    {activity.tx_hash ? (
+                      <a
+                        href={`https://stellar.expert/explorer/testnet/tx/${activity.tx_hash}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-xs text-primary hover:underline mt-1"
+                      >
+                        {activity.tx_hash.slice(0, 8)}…{activity.tx_hash.slice(-6)}
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                    ) : (
+                      <p className="text-xs text-muted-foreground mt-1">No tx hash</p>
+                    )}
+                  </div>
                 </div>
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
 
-          {hasMore && (
-            <Button
-              variant="outline"
-              size="sm"
-              className="w-full mt-4"
-              onClick={() => setPage((p: number) => p + 1)}
-            >
-              Load more
-            </Button>
-          )}
-        </>
+            {hasMore && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full mt-4"
+                onClick={() => fetchPage(page + 1, true)}
+                disabled={loadingMore}
+              >
+                {loadingMore ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  `Load more (${activities.length} of ${total})`
+                )}
+              </Button>
+            )}
+          </>
+        )
       )}
     </Card>
   )

--- a/frontend/components/shared/date-range-picker.tsx
+++ b/frontend/components/shared/date-range-picker.tsx
@@ -1,0 +1,115 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { format, subDays } from "date-fns"
+import { X } from "lucide-react"
+
+export interface DateRangePickerProps {
+  /** "YYYY-MM-DD" or "" for unbounded. */
+  from: string
+  /** "YYYY-MM-DD" or "" for unbounded. */
+  to: string
+  onChange: (from: string, to: string) => void
+  /** Optional id prefix so multiple pickers can coexist on one page. */
+  idPrefix?: string
+}
+
+const PRESETS = [
+  { label: "Last 7 days", days: 7 },
+  { label: "Last 30 days", days: 30 },
+  { label: "Last 90 days", days: 90 },
+] as const
+
+function presetRange(days: number): { from: string; to: string } {
+  const today = new Date()
+  return {
+    from: format(subDays(today, days), "yyyy-MM-dd"),
+    to: format(today, "yyyy-MM-dd"),
+  }
+}
+
+/**
+ * Simple two-field date range selector with quick presets.
+ * Fully controlled: the parent owns the from/to strings.
+ */
+export function DateRangePicker({ from, to, onChange, idPrefix = "date-range" }: DateRangePickerProps) {
+  const isFiltered = from !== "" || to !== ""
+
+  const isPresetActive = (days: number) => {
+    const range = presetRange(days)
+    return from === range.from && to === range.to
+  }
+
+  return (
+    <div className="flex flex-wrap items-end gap-3">
+      <div className="flex flex-col gap-1">
+        <Label htmlFor={`${idPrefix}-from`} className="text-xs text-muted-foreground">
+          From
+        </Label>
+        <Input
+          id={`${idPrefix}-from`}
+          type="date"
+          value={from}
+          onChange={(e) => onChange(e.target.value, to)}
+          max={to || undefined}
+          className="h-8 text-sm w-36"
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <Label htmlFor={`${idPrefix}-to`} className="text-xs text-muted-foreground">
+          To
+        </Label>
+        <Input
+          id={`${idPrefix}-to`}
+          type="date"
+          value={to}
+          onChange={(e) => onChange(from, e.target.value)}
+          min={from || undefined}
+          className="h-8 text-sm w-36"
+        />
+      </div>
+
+      <div className="flex flex-wrap items-center gap-1">
+        {PRESETS.map((preset) => (
+          <Button
+            key={preset.days}
+            type="button"
+            variant={isPresetActive(preset.days) ? "secondary" : "ghost"}
+            size="sm"
+            className="h-8 text-xs"
+            onClick={() => {
+              const range = presetRange(preset.days)
+              onChange(range.from, range.to)
+            }}
+          >
+            {preset.label}
+          </Button>
+        ))}
+        <Button
+          type="button"
+          variant={!isFiltered ? "secondary" : "ghost"}
+          size="sm"
+          className="h-8 text-xs"
+          onClick={() => onChange("", "")}
+        >
+          All time
+        </Button>
+        {isFiltered && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => onChange("", "")}
+            className="h-8 gap-1 text-xs"
+            aria-label="Clear date filter"
+          >
+            <X className="h-3 w-3" />
+            Clear
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/shared/date-range-picker.tsx
+++ b/frontend/components/shared/date-range-picker.tsx
@@ -34,7 +34,12 @@ function presetRange(days: number): { from: string; to: string } {
  * Simple two-field date range selector with quick presets.
  * Fully controlled: the parent owns the from/to strings.
  */
-export function DateRangePicker({ from, to, onChange, idPrefix = "date-range" }: DateRangePickerProps) {
+export function DateRangePicker({
+  from,
+  to,
+  onChange,
+  idPrefix = "date-range",
+}: DateRangePickerProps) {
   const isFiltered = from !== "" || to !== ""
 
   const isPresetActive = (days: number) => {

--- a/frontend/e2e/fixtures/mock-pools.ts
+++ b/frontend/e2e/fixtures/mock-pools.ts
@@ -94,7 +94,9 @@ export async function mockPoolsApi(page: Page, seed: MockPool[] = []): Promise<P
     // /api/pools/:id/activity, /api/pools/:id/activity/export,
     // /api/pools/:id/index-events — must be handled before the query-param
     // branches because the **/api/pools** glob captures them too.
-    const nested = url.pathname.match(/\/api\/pools\/([^/]+)\/(activity\/export|activity|index-events)$/)
+    const nested = url.pathname.match(
+      /\/api\/pools\/([^/]+)\/(activity\/export|activity|index-events)$/
+    )
     if (nested) {
       const [, poolId, endpoint] = nested
       const pool = pools.find((p) => p.id === poolId || p.contract_address === poolId)

--- a/frontend/e2e/fixtures/mock-pools.ts
+++ b/frontend/e2e/fixtures/mock-pools.ts
@@ -90,6 +90,77 @@ export async function mockPoolsApi(page: Page, seed: MockPool[] = []): Promise<P
     const url = new URL(req.url())
     const method = req.method()
 
+    // ── Nested per-pool routes (issue #210) ──────────────────────────────────
+    // /api/pools/:id/activity, /api/pools/:id/activity/export,
+    // /api/pools/:id/index-events — must be handled before the query-param
+    // branches because the **/api/pools** glob captures them too.
+    const nested = url.pathname.match(/\/api\/pools\/([^/]+)\/(activity\/export|activity|index-events)$/)
+    if (nested) {
+      const [, poolId, endpoint] = nested
+      const pool = pools.find((p) => p.id === poolId || p.contract_address === poolId)
+      if (!pool) return json(route, { error: "Pool not found" }, 404)
+
+      if (endpoint === "index-events" && method === "POST") {
+        return json(route, {
+          eventsFound: 0,
+          updated: 0,
+          inserted: 0,
+          backfilled: 0,
+          lastIndexedLedger: 0,
+          indexedAt: new Date().toISOString(),
+        })
+      }
+
+      if (method === "GET") {
+        // Shared filter handling for activity + export
+        const search = (url.searchParams.get("search") ?? "").toLowerCase()
+        const type = url.searchParams.get("activity_type")
+        const sort = url.searchParams.get("sort") ?? "newest"
+        const pageNum = Math.max(1, parseInt(url.searchParams.get("page") ?? "1", 10) || 1)
+        const pageSize = 50
+
+        let rows = [...pool.pool_activity]
+        if (search) {
+          rows = rows.filter((a) =>
+            [a.activity_type, a.description, a.user_address, a.tx_hash]
+              .filter(Boolean)
+              .some((v: string) => v.toLowerCase().includes(search))
+          )
+        }
+        if (type) rows = rows.filter((a) => a.activity_type === type)
+        rows.sort((a, b) => {
+          const diff = new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+          return sort === "oldest" ? diff : -diff
+        })
+
+        if (endpoint === "activity/export") {
+          const csv = [
+            "ID,Activity Type,Amount,Transaction Hash,Created At",
+            ...rows.map((a) =>
+              [a.id, a.activity_type, a.amount ?? "", a.tx_hash ?? "", a.created_at].join(",")
+            ),
+          ].join("\n")
+          return route.fulfill({
+            status: 200,
+            contentType: "text/csv; charset=utf-8",
+            headers: { "Content-Disposition": `attachment; filename="pool-activity-e2e.csv"` },
+            body: csv,
+          })
+        }
+
+        const start = (pageNum - 1) * pageSize
+        const paged = rows.slice(start, start + pageSize)
+        return json(route, {
+          activities: paged,
+          page: pageNum,
+          pageSize,
+          total: rows.length,
+          hasMore: start + paged.length < rows.length,
+          lastIndexed: null,
+        })
+      }
+    }
+
     if (method === "GET") {
       const id = url.searchParams.get("id")
       const contract = url.searchParams.get("contract")

--- a/frontend/hooks/useJointSaveContracts.ts
+++ b/frontend/hooks/useJointSaveContracts.ts
@@ -22,6 +22,7 @@ import {
   type PendingTransactionType,
 } from "@/lib/pending-transactions"
 import { TX_TIMEOUT } from "@/lib/constants"
+import { mapSorobanEvent } from "@/lib/soroban-event-mapping"
 import { isContractVersionUnknown } from "@/lib/contract-version"
 export { isContractVersionUnknown }
 
@@ -1093,56 +1094,19 @@ export async function fetchContractEvents(
   const events: ActivityEvent[] = []
 
   for (const ev of response.events) {
-    const topics = ev.topic
-    if (!topics.length) continue
-
-    // First topic is always the event name symbol
-    const topicName = topics[0].switch().name === "scvSymbol" ? topics[0].sym().toString() : null
-    if (!topicName) continue
-
-    // Second topic (optional) is the address
-    let userAddress: string | null = null
-    if (topics[1]?.switch().name === "scvAddress") {
-      try {
-        userAddress = Address.fromScVal(topics[1]).toString()
-      } catch {}
-    }
-
-    // Value is the amount (i128) for deposit/payout/withdraw
-    let amount: number | null = null
-    try {
-      const val = ev.value
-      const sw = val.switch().name
-      if (sw === "scvI128" || sw === "scvU128" || sw === "scvU64" || sw === "scvI64") {
-        amount = Number(scValToBigInt(val)) / 10_000_000
-      }
-    } catch {}
-
-    const typeMap: Record<string, string> = {
-      deposit: "deposit",
-      payout: "payout",
-      withdraw: "withdraw",
-      complete: "complete",
-      unlocked: "complete",
-      refunded: "withdraw",
-      yield: "yield",
-    }
-
-    const activity_type = typeMap[topicName]
-    if (!activity_type) continue
-
-    // Derive a stable id from txHash + topic
-    const id = `${ev.txHash}-${topicName}`
+    const mapped = mapSorobanEvent(ev)
+    if (!mapped) continue
 
     events.push({
-      id,
-      activity_type,
-      user_address: userAddress,
-      amount,
+      // Derive a stable id from txHash + activity type
+      id: `${mapped.tx_hash}-${mapped.activity_type}`,
+      activity_type: mapped.activity_type,
+      user_address: mapped.user_address,
+      amount: mapped.amount,
       description: null,
       // Soroban events don't carry a timestamp; use ledger close time if available
-      created_at: ev.ledgerClosedAt ?? new Date(0).toISOString(),
-      tx_hash: ev.txHash,
+      created_at: mapped.ledgerClosedAt ?? new Date(0).toISOString(),
+      tx_hash: mapped.tx_hash,
       source: "onchain",
     })
   }

--- a/frontend/lib/activity-query.test.ts
+++ b/frontend/lib/activity-query.test.ts
@@ -1,0 +1,139 @@
+// Unit tests for the pool activity query helpers (issue #210)
+import { test } from "node:test"
+import assert from "node:assert"
+import {
+  ACTIVITY_CSV_HEADERS,
+  activityToCsvRow,
+  buildSearchOrClause,
+  exportFilename,
+  isActivityQueryError,
+  parseActivityQuery,
+  sanitizeSearchTerm,
+  type ActivityQuery,
+} from "./activity-query"
+import { ACTIVITY_PAGE_SIZE } from "./constants"
+
+function parseOk(params: Parameters<typeof parseActivityQuery>[0]): ActivityQuery {
+  const q = parseActivityQuery(params)
+  assert.ok(!isActivityQueryError(q), `expected valid query, got error: ${JSON.stringify(q)}`)
+  return q
+}
+
+test("parseActivityQuery - defaults with no params", () => {
+  const q = parseOk({})
+  assert.strictEqual(q.search, null)
+  assert.strictEqual(q.dateFromIso, null)
+  assert.strictEqual(q.dateToExclusiveIso, null)
+  assert.strictEqual(q.activityType, null)
+  assert.strictEqual(q.ascending, false) // newest first
+  assert.strictEqual(q.page, 1)
+  assert.strictEqual(q.rangeFrom, 0)
+  assert.strictEqual(q.rangeTo, ACTIVITY_PAGE_SIZE - 1)
+})
+
+test("parseActivityQuery - page maps to 50-row ranges", () => {
+  const q = parseOk({ page: "3" })
+  assert.strictEqual(q.rangeFrom, 2 * ACTIVITY_PAGE_SIZE)
+  assert.strictEqual(q.rangeTo, 3 * ACTIVITY_PAGE_SIZE - 1)
+})
+
+test("parseActivityQuery - rejects bad page values", () => {
+  for (const page of ["0", "-1", "1.5", "abc"]) {
+    const q = parseActivityQuery({ page })
+    assert.ok(isActivityQueryError(q), `page=${page} should be rejected`)
+  }
+})
+
+test("parseActivityQuery - sort oldest flips ascending, bad sort rejected", () => {
+  assert.strictEqual(parseOk({ sort: "oldest" }).ascending, true)
+  assert.strictEqual(parseOk({ sort: "newest" }).ascending, false)
+  assert.ok(isActivityQueryError(parseActivityQuery({ sort: "sideways" })))
+})
+
+test("parseActivityQuery - activity_type whitelist", () => {
+  assert.strictEqual(parseOk({ activity_type: "deposit" }).activityType, "deposit")
+  assert.ok(isActivityQueryError(parseActivityQuery({ activity_type: "hack" })))
+})
+
+test("parseActivityQuery - date_to is inclusive of the whole day", () => {
+  const q = parseOk({ date_from: "2026-08-01", date_to: "2026-08-15" })
+  assert.strictEqual(q.dateFromIso, "2026-08-01T00:00:00.000Z")
+  // Exclusive upper bound at the following midnight
+  assert.strictEqual(q.dateToExclusiveIso, "2026-08-16T00:00:00.000Z")
+})
+
+test("parseActivityQuery - rejects malformed and inverted dates", () => {
+  assert.ok(isActivityQueryError(parseActivityQuery({ date_from: "01-08-2026" })))
+  assert.ok(isActivityQueryError(parseActivityQuery({ date_to: "2026-13-40" })))
+  assert.ok(
+    isActivityQueryError(parseActivityQuery({ date_from: "2026-08-20", date_to: "2026-08-01" }))
+  )
+})
+
+test("parseActivityQuery - caps search length", () => {
+  assert.ok(isActivityQueryError(parseActivityQuery({ search: "x".repeat(101) })))
+  assert.strictEqual(parseOk({ search: "x".repeat(100) })?.search, "x".repeat(100))
+})
+
+test("sanitizeSearchTerm - strips PostgREST metacharacters", () => {
+  assert.strictEqual(sanitizeSearchTerm("x),description.ilike.(y"), "x description.ilike. y")
+  assert.strictEqual(sanitizeSearchTerm("50%_off\\*"), "50 off")
+  assert.strictEqual(sanitizeSearchTerm("deposit"), "deposit")
+  assert.strictEqual(sanitizeSearchTerm(",,(())"), "")
+})
+
+test("buildSearchOrClause - covers searchable columns, null when term is all metachars", () => {
+  const clause = buildSearchOrClause("deposit")
+  assert.ok(clause?.includes("activity_type.ilike.%deposit%"))
+  assert.ok(clause?.includes("description.ilike.%deposit%"))
+  assert.ok(clause?.includes("user_address.ilike.%deposit%"))
+  assert.ok(clause?.includes("tx_hash.ilike.%deposit%"))
+  assert.strictEqual(buildSearchOrClause("(),%"), null)
+})
+
+test("buildSearchOrClause - injection attempt cannot introduce extra clauses", () => {
+  const clause = buildSearchOrClause("a,id.eq.1")
+  // Commas were stripped, so the malicious fragment is part of the pattern,
+  // not a new filter condition.
+  assert.strictEqual(clause?.split(",").length, 4)
+})
+
+test("activityToCsvRow - maps all columns and blanks nulls", () => {
+  const row = activityToCsvRow({
+    id: "act-1",
+    activity_type: "deposit",
+    user_address: null,
+    amount: 12.5,
+    token_amount: null,
+    description: "deposit transaction",
+    tx_hash: "abc123",
+    block_number: 55_000,
+    fee_charged: 100,
+    on_chain_timestamp: "2026-08-18T10:00:00Z",
+    created_at: "2026-08-18T09:59:58Z",
+  })
+  assert.strictEqual(row.length, ACTIVITY_CSV_HEADERS.length)
+  assert.deepStrictEqual(row, [
+    "act-1",
+    "deposit",
+    "",
+    12.5,
+    "",
+    "deposit transaction",
+    "abc123",
+    55_000,
+    100,
+    "2026-08-18T10:00:00Z",
+    "2026-08-18T09:59:58Z",
+  ])
+})
+
+test("exportFilename - short id, date stamp, extension", () => {
+  const name = exportFilename(
+    "123e4567-e89b-12d3-a456-426614174000",
+    "csv",
+    new Date("2026-08-18T12:00:00Z")
+  )
+  assert.strictEqual(name, "pool-activity-123e4567-2026-08-18.csv")
+  assert.ok(exportFilename("", "json", new Date("2026-08-18T12:00:00Z")).endsWith(".json"))
+})

--- a/frontend/lib/activity-query.ts
+++ b/frontend/lib/activity-query.ts
@@ -65,7 +65,10 @@ export function isActivityQueryError(
  * alias.
  */
 export function sanitizeSearchTerm(term: string): string {
-  return term.replace(/[,()%_\\*]/g, " ").replace(/\s+/g, " ").trim()
+  return term
+    .replace(/[,()%_\\*]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
 }
 
 /**

--- a/frontend/lib/activity-query.ts
+++ b/frontend/lib/activity-query.ts
@@ -1,0 +1,218 @@
+/**
+ * Pure helpers for the pool activity API (issue #210).
+ *
+ * Query-string parsing/validation, PostgREST search-clause construction, and
+ * CSV row mapping live here — free of next/server and Supabase imports — so
+ * the route handlers stay thin and this logic runs under `tsx --test`.
+ */
+
+import { ACTIVITY_PAGE_SIZE } from "./constants"
+
+/**
+ * Every activity_type the platform writes today: the contract event map in
+ * useJointSaveContracts, the PATCH /api/pools activity logger, and the
+ * pool-creation logger.
+ */
+export const ACTIVITY_TYPES = [
+  "deposit",
+  "payout",
+  "withdraw",
+  "complete",
+  "member_joined",
+  "member_added",
+  "member_removed",
+  "pool_created",
+  "yield",
+] as const
+
+export type ActivityType = (typeof ACTIVITY_TYPES)[number]
+
+const MAX_SEARCH_LENGTH = 100
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
+
+export interface ActivityQuery {
+  /** Sanitized search term, or null when absent/empty. */
+  search: string | null
+  /** Inclusive lower bound for created_at (ISO), or null. */
+  dateFromIso: string | null
+  /** EXCLUSIVE upper bound for created_at (ISO) — midnight after date_to. */
+  dateToExclusiveIso: string | null
+  activityType: ActivityType | null
+  /** true = oldest first. */
+  ascending: boolean
+  /** 1-based page number. */
+  page: number
+  /** Supabase .range() bounds (0-based, inclusive). */
+  rangeFrom: number
+  rangeTo: number
+}
+
+export interface ActivityQueryError {
+  error: string
+}
+
+export function isActivityQueryError(
+  q: ActivityQuery | ActivityQueryError
+): q is ActivityQueryError {
+  return "error" in q
+}
+
+/**
+ * Strip characters that carry meaning inside a PostgREST `or=(...)` filter
+ * string or an `ilike` pattern. Raw commas/parens would corrupt the filter
+ * expression (letting callers break or inject clauses); `%`/`_` are pattern
+ * wildcards; `\` is the escape character; `*` is PostgREST's own wildcard
+ * alias.
+ */
+export function sanitizeSearchTerm(term: string): string {
+  return term.replace(/[,()%_\\*]/g, " ").replace(/\s+/g, " ").trim()
+}
+
+/**
+ * Build the argument for Supabase's `.or(...)` covering every text column a
+ * user would reasonably search. Returns null when the sanitized term is empty.
+ */
+export function buildSearchOrClause(term: string): string | null {
+  const clean = sanitizeSearchTerm(term)
+  if (!clean) return null
+  const pattern = `%${clean}%`
+  return [
+    `activity_type.ilike.${pattern}`,
+    `description.ilike.${pattern}`,
+    `user_address.ilike.${pattern}`,
+    `tx_hash.ilike.${pattern}`,
+  ].join(",")
+}
+
+function parseDateParam(value: string): Date | null {
+  if (!DATE_RE.test(value)) return null
+  const d = new Date(`${value}T00:00:00.000Z`)
+  return Number.isNaN(d.getTime()) ? null : d
+}
+
+/**
+ * Validate and normalize the activity endpoint's query params.
+ * Returns `{ error }` (route responds 400) on any invalid input.
+ */
+export function parseActivityQuery(params: {
+  search?: string | null
+  date_from?: string | null
+  date_to?: string | null
+  activity_type?: string | null
+  sort?: string | null
+  page?: string | null
+}): ActivityQuery | ActivityQueryError {
+  const rawSearch = (params.search ?? "").trim()
+  if (rawSearch.length > MAX_SEARCH_LENGTH) {
+    return { error: `search must be at most ${MAX_SEARCH_LENGTH} characters` }
+  }
+  const search = rawSearch ? sanitizeSearchTerm(rawSearch) || null : null
+
+  let dateFromIso: string | null = null
+  if (params.date_from) {
+    const d = parseDateParam(params.date_from)
+    if (!d) return { error: "date_from must be a valid YYYY-MM-DD date" }
+    dateFromIso = d.toISOString()
+  }
+
+  let dateToExclusiveIso: string | null = null
+  if (params.date_to) {
+    const d = parseDateParam(params.date_to)
+    if (!d) return { error: "date_to must be a valid YYYY-MM-DD date" }
+    // Exclusive bound at the following midnight so date_to itself is included.
+    d.setUTCDate(d.getUTCDate() + 1)
+    dateToExclusiveIso = d.toISOString()
+  }
+
+  if (dateFromIso && dateToExclusiveIso && dateFromIso >= dateToExclusiveIso) {
+    return { error: "date_from must not be after date_to" }
+  }
+
+  let activityType: ActivityType | null = null
+  if (params.activity_type) {
+    if (!(ACTIVITY_TYPES as readonly string[]).includes(params.activity_type)) {
+      return { error: `activity_type must be one of: ${ACTIVITY_TYPES.join(", ")}` }
+    }
+    activityType = params.activity_type as ActivityType
+  }
+
+  const sort = params.sort ?? "newest"
+  if (sort !== "newest" && sort !== "oldest") {
+    return { error: "sort must be 'newest' or 'oldest'" }
+  }
+
+  let page = 1
+  if (params.page != null && params.page !== "") {
+    page = Number(params.page)
+    if (!Number.isInteger(page) || page < 1) {
+      return { error: "page must be a positive integer" }
+    }
+  }
+
+  const rangeFrom = (page - 1) * ACTIVITY_PAGE_SIZE
+  return {
+    search,
+    dateFromIso,
+    dateToExclusiveIso,
+    activityType,
+    ascending: sort === "oldest",
+    page,
+    rangeFrom,
+    rangeTo: rangeFrom + ACTIVITY_PAGE_SIZE - 1,
+  }
+}
+
+/** Columns returned by the activity + export endpoints. */
+export const ACTIVITY_SELECT_COLUMNS =
+  "id, activity_type, user_address, amount, token_amount, description, tx_hash, on_chain_timestamp, block_number, fee_charged, created_at"
+
+// ── Export mapping ────────────────────────────────────────────────────────────
+
+export interface ActivityExportRow {
+  id: string
+  activity_type: string
+  user_address: string | null
+  amount: number | null
+  token_amount: number | null
+  description: string | null
+  tx_hash: string | null
+  block_number: number | null
+  fee_charged: number | null
+  on_chain_timestamp: string | null
+  created_at: string
+}
+
+export const ACTIVITY_CSV_HEADERS = [
+  "ID",
+  "Activity Type",
+  "User Address",
+  "Amount",
+  "Token Amount",
+  "Description",
+  "Transaction Hash",
+  "Ledger",
+  "Fee (stroops)",
+  "On-chain Timestamp",
+  "Created At",
+]
+
+export function activityToCsvRow(row: ActivityExportRow): unknown[] {
+  return [
+    row.id,
+    row.activity_type,
+    row.user_address ?? "",
+    row.amount ?? "",
+    row.token_amount ?? "",
+    row.description ?? "",
+    row.tx_hash ?? "",
+    row.block_number ?? "",
+    row.fee_charged ?? "",
+    row.on_chain_timestamp ?? "",
+    row.created_at,
+  ]
+}
+
+export function exportFilename(poolId: string, format: "csv" | "json", now: Date): string {
+  const shortId = poolId.replace(/[^a-zA-Z0-9]/g, "").slice(0, 8) || "pool"
+  return `pool-activity-${shortId}-${now.toISOString().slice(0, 10)}.${format}`
+}

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -94,6 +94,31 @@ export const READ_RATE_LIMIT = 30 as const
  */
 export const WRITE_RATE_LIMIT = 10 as const
 
+/**
+ * Maximum number of activity exports allowed per key per export window.
+ */
+export const EXPORT_RATE_LIMIT = 5 as const
+
+/**
+ * Sliding-window size for the export rate limiter.
+ * Unit: **milliseconds** (1 hour).
+ */
+export const EXPORT_RATE_LIMIT_WINDOW_MS = 3_600_000 as const
+
+// ── Activity feed ─────────────────────────────────────────────────────────────
+
+/**
+ * Number of pool activity rows returned per page by
+ * GET /api/pools/[id]/activity.
+ */
+export const ACTIVITY_PAGE_SIZE = 50 as const
+
+/**
+ * Hard cap on rows returned by GET /api/pools/[id]/activity/export so a single
+ * export can never buffer an unbounded result set.
+ */
+export const ACTIVITY_EXPORT_MAX_ROWS = 5_000 as const
+
 // ── UI ────────────────────────────────────────────────────────────────────────
 
 /**

--- a/frontend/lib/rate-limit.ts
+++ b/frontend/lib/rate-limit.ts
@@ -12,7 +12,13 @@
  */
 
 import { NextRequest, NextResponse } from "next/server"
-import { RATE_LIMIT_WINDOW_MS, READ_RATE_LIMIT, WRITE_RATE_LIMIT } from "@/lib/constants"
+import {
+  EXPORT_RATE_LIMIT,
+  EXPORT_RATE_LIMIT_WINDOW_MS,
+  RATE_LIMIT_WINDOW_MS,
+  READ_RATE_LIMIT,
+  WRITE_RATE_LIMIT,
+} from "@/lib/constants"
 
 interface WindowEntry {
   timestamps: number[]
@@ -117,4 +123,17 @@ export function readLimiter(req: NextRequest): NextResponse | null {
  */
 export function writeLimiter(req: NextRequest): NextResponse | null {
   return applyLimit(req, "write", WRITE_RATE_LIMIT, WINDOW_MS)
+}
+
+/**
+ * Export limiter — 5 requests per hour per key.
+ * For GET /api/pools/[id]/activity/export.
+ *
+ * Reasoning: an export is a full-history dump, far heavier than a page read.
+ * A member re-exporting after new activity a handful of times an hour is
+ * normal; anything more is scripted scraping. Callers must supply a `wallet`
+ * query param so the limit is keyed per wallet, not per IP.
+ */
+export function exportLimiter(req: NextRequest): NextResponse | null {
+  return applyLimit(req, "export", EXPORT_RATE_LIMIT, EXPORT_RATE_LIMIT_WINDOW_MS)
 }

--- a/frontend/lib/server/stellar-events.ts
+++ b/frontend/lib/server/stellar-events.ts
@@ -1,0 +1,222 @@
+/**
+ * Server-only Stellar helpers for the on-chain event indexer
+ * (POST /api/pools/[id]/index-events, issue #210).
+ *
+ * Lives under lib/server/ because it must never be imported from client code —
+ * the client equivalents in hooks/useJointSaveContracts.ts drag in wallet-kit
+ * and React, which cannot load in a route handler.
+ */
+
+import { rpc } from "@stellar/stellar-sdk"
+import { mapSorobanEvent, type MappedSorobanEvent } from "@/lib/soroban-event-mapping"
+
+const RPC_URL = process.env.NEXT_PUBLIC_STELLAR_RPC_URL
+const HORIZON_URL = process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL
+
+/** How many events to request per getEvents page (RPC max is 10000, be modest). */
+const EVENTS_PAGE_LIMIT = 100
+/** Safety valve: never pull more than this many pages in one indexing run. */
+const MAX_EVENT_PAGES = 20
+/**
+ * Fallback clamp when the requested startLedger predates the RPC's retention
+ * window and the error message doesn't tell us the oldest available ledger.
+ * ~100k ledgers ≈ 7 days at ~6s per ledger, matching typical RPC retention.
+ */
+const RETENTION_FALLBACK_LEDGERS = 100_000
+
+export function getServerRpc(): rpc.Server {
+  if (!RPC_URL) throw new Error("NEXT_PUBLIC_STELLAR_RPC_URL is not configured")
+  return new rpc.Server(RPC_URL, { allowHttp: RPC_URL.startsWith("http://") })
+}
+
+export interface FetchEventsResult {
+  events: MappedSorobanEvent[]
+  /** Latest ledger known to the RPC — becomes the new last_indexed_ledger. */
+  latestLedger: number
+  /** Set when the requested range was clamped or could not be read. */
+  warning?: string
+}
+
+interface GetEventsPage {
+  events: unknown[]
+  latestLedger: number
+  cursor?: string
+}
+
+async function getEventsPage(
+  server: rpc.Server,
+  contractId: string,
+  startLedger: number | undefined,
+  cursor: string | undefined
+): Promise<GetEventsPage> {
+  const response = await server.getEvents({
+    // getEvents takes either startLedger or cursor, never both.
+    ...(cursor ? { cursor } : { startLedger: startLedger ?? 1 }),
+    filters: [{ type: "contract", contractIds: [contractId] }],
+    limit: EVENTS_PAGE_LIMIT,
+  } as Parameters<rpc.Server["getEvents"]>[0])
+  return {
+    events: response.events,
+    latestLedger: response.latestLedger,
+    cursor: (response as unknown as { cursor?: string }).cursor,
+  }
+}
+
+/**
+ * Read every trackable contract event for `contractId` from `startLedger`
+ * onward, cursor-paginating past the per-request event cap.
+ *
+ * Never throws for range problems: when `startLedger` predates the RPC's
+ * retention window the range is clamped (parsed from the error when possible)
+ * and retried once; if events still can't be read, an empty result with a
+ * `warning` is returned so one flaky RPC call doesn't fail the whole indexing
+ * request.
+ */
+export async function fetchEventsSince(
+  contractId: string,
+  startLedger: number
+): Promise<FetchEventsResult> {
+  const server = getServerRpc()
+  const events: MappedSorobanEvent[] = []
+  let latestLedger = 0
+  let warning: string | undefined
+  let cursor: string | undefined
+  let start: number | undefined = Math.max(1, startLedger)
+
+  for (let page = 0; page < MAX_EVENT_PAGES; page++) {
+    let result: GetEventsPage
+    try {
+      result = await getEventsPage(server, contractId, start, cursor)
+    } catch (err) {
+      if (page > 0) {
+        // Mid-pagination failure: keep what we have.
+        warning = `Event pagination stopped early: ${(err as Error)?.message ?? "unknown error"}`
+        break
+      }
+      // First request failed — likely a startLedger outside the retention
+      // window. Clamp and retry once.
+      const clamped = await clampStartLedger(server, err, start ?? 1)
+      if (clamped === null) {
+        return {
+          events: [],
+          latestLedger: await safeLatestLedger(server),
+          warning: `Could not read events: ${(err as Error)?.message ?? "unknown error"}`,
+        }
+      }
+      warning = `Requested ledger range was outside the RPC retention window; indexed from ledger ${clamped} instead`
+      try {
+        result = await getEventsPage(server, contractId, clamped, undefined)
+      } catch (retryErr) {
+        return {
+          events: [],
+          latestLedger: await safeLatestLedger(server),
+          warning: `Could not read events: ${(retryErr as Error)?.message ?? "unknown error"}`,
+        }
+      }
+    }
+
+    latestLedger = result.latestLedger || latestLedger
+    for (const ev of result.events) {
+      const mapped = mapSorobanEvent(ev as Parameters<typeof mapSorobanEvent>[0])
+      if (mapped) events.push(mapped)
+    }
+
+    if (result.events.length < EVENTS_PAGE_LIMIT || !result.cursor) break
+    cursor = result.cursor
+    start = undefined
+  }
+
+  return { events, latestLedger, warning }
+}
+
+/**
+ * Work out a usable startLedger after a range error. RPC errors of the form
+ * "startLedger must be within the ledger range: 123456 - 223456" carry the
+ * oldest retained ledger — use it when present, otherwise back off to
+ * latest - RETENTION_FALLBACK_LEDGERS. Returns null when no clamp would help
+ * (e.g. network failure).
+ */
+async function clampStartLedger(
+  server: rpc.Server,
+  err: unknown,
+  requested: number
+): Promise<number | null> {
+  const message = (err as Error)?.message ?? ""
+  const rangeMatch = message.match(/(\d{2,})\s*-\s*(\d{2,})/)
+  if (rangeMatch) {
+    const oldest = parseInt(rangeMatch[1], 10)
+    if (Number.isFinite(oldest) && oldest > requested) return oldest
+  }
+  if (!/ledger|range/i.test(message)) return null
+  try {
+    const latest = await server.getLatestLedger()
+    return Math.max(1, latest.sequence - RETENTION_FALLBACK_LEDGERS)
+  } catch {
+    return null
+  }
+}
+
+async function safeLatestLedger(server: rpc.Server): Promise<number> {
+  try {
+    return (await server.getLatestLedger()).sequence
+  } catch {
+    return 0
+  }
+}
+
+// ── Horizon enrichment ────────────────────────────────────────────────────────
+
+export interface HorizonTxInfo {
+  /** Ledger sequence the transaction was included in. */
+  ledger: number
+  /** Ledger close time (ISO). */
+  createdAt: string
+  /** Fee actually charged, in stroops. */
+  feeCharged: number
+}
+
+/**
+ * Fetch a transaction's on-chain details from Horizon.
+ * Returns null on 404 or any failure — Horizon history can lag or be pruned,
+ * and a missing transaction must never abort an indexing run.
+ */
+export async function fetchHorizonTx(txHash: string): Promise<HorizonTxInfo | null> {
+  if (!HORIZON_URL) return null
+  try {
+    const res = await fetch(`${HORIZON_URL.replace(/\/$/, "")}/transactions/${txHash}`, {
+      headers: { Accept: "application/json" },
+      cache: "no-store",
+    })
+    if (!res.ok) return null
+    const tx = (await res.json()) as {
+      ledger?: number
+      created_at?: string
+      fee_charged?: string | number
+    }
+    if (tx.ledger == null || !tx.created_at) return null
+    return {
+      ledger: tx.ledger,
+      createdAt: tx.created_at,
+      feeCharged: Number(tx.fee_charged ?? 0),
+    }
+  } catch {
+    return null
+  }
+}
+
+/** Enrich many tx hashes with small parallelism so Horizon isn't hammered. */
+export async function fetchHorizonTxBatch(
+  txHashes: string[],
+  chunkSize = 5
+): Promise<Map<string, HorizonTxInfo>> {
+  const out = new Map<string, HorizonTxInfo>()
+  const unique = Array.from(new Set(txHashes))
+  for (let i = 0; i < unique.length; i += chunkSize) {
+    const chunk = unique.slice(i, i + chunkSize)
+    const results = await Promise.all(chunk.map((h) => fetchHorizonTx(h)))
+    results.forEach((info, idx) => {
+      if (info) out.set(chunk[idx], info)
+    })
+  }
+  return out
+}

--- a/frontend/lib/soroban-event-mapping.test.ts
+++ b/frontend/lib/soroban-event-mapping.test.ts
@@ -1,0 +1,83 @@
+// Unit tests for the shared Soroban event mapper (issue #210)
+import { test } from "node:test"
+import assert from "node:assert"
+import { Address, nativeToScVal, xdr } from "@stellar/stellar-sdk"
+import {
+  mapSorobanEvent,
+  mapTopicToActivityType,
+  type RawSorobanEvent,
+} from "./soroban-event-mapping"
+
+const USER = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7"
+
+function makeEvent(
+  topic: string,
+  opts: { user?: string; amountStroops?: bigint; value?: xdr.ScVal } = {}
+): RawSorobanEvent {
+  const topics = [nativeToScVal(topic, { type: "symbol" })]
+  if (opts.user) topics.push(new Address(opts.user).toScVal())
+  return {
+    topic: topics,
+    value:
+      opts.value ??
+      (opts.amountStroops != null
+        ? nativeToScVal(opts.amountStroops, { type: "i128" })
+        : nativeToScVal(undefined)),
+    txHash: "abc123",
+    ledger: 55_000,
+    ledgerClosedAt: "2026-08-18T10:00:00Z",
+  }
+}
+
+test("mapTopicToActivityType - known topics translate, unknown return null", () => {
+  assert.strictEqual(mapTopicToActivityType("deposit"), "deposit")
+  assert.strictEqual(mapTopicToActivityType("payout"), "payout")
+  assert.strictEqual(mapTopicToActivityType("withdraw"), "withdraw")
+  assert.strictEqual(mapTopicToActivityType("complete"), "complete")
+  assert.strictEqual(mapTopicToActivityType("unlocked"), "complete")
+  assert.strictEqual(mapTopicToActivityType("refunded"), "withdraw")
+  assert.strictEqual(mapTopicToActivityType("yield"), "yield")
+  assert.strictEqual(mapTopicToActivityType("transfer"), null)
+})
+
+test("mapSorobanEvent - full deposit event maps address, amount, ledger fields", () => {
+  const mapped = mapSorobanEvent(makeEvent("deposit", { user: USER, amountStroops: 125_000_000n }))
+  assert.ok(mapped)
+  assert.strictEqual(mapped.activity_type, "deposit")
+  assert.strictEqual(mapped.user_address, USER)
+  assert.strictEqual(mapped.amount, 12.5)
+  assert.strictEqual(mapped.tx_hash, "abc123")
+  assert.strictEqual(mapped.ledger, 55_000)
+  assert.strictEqual(mapped.ledgerClosedAt, "2026-08-18T10:00:00Z")
+})
+
+test("mapSorobanEvent - unlocked/refunded remap to complete/withdraw", () => {
+  assert.strictEqual(mapSorobanEvent(makeEvent("unlocked"))?.activity_type, "complete")
+  assert.strictEqual(mapSorobanEvent(makeEvent("refunded"))?.activity_type, "withdraw")
+})
+
+test("mapSorobanEvent - untracked topic and empty topics return null", () => {
+  assert.strictEqual(mapSorobanEvent(makeEvent("transfer")), null)
+  assert.strictEqual(
+    mapSorobanEvent({
+      topic: [],
+      value: nativeToScVal(undefined),
+      txHash: "x",
+      ledger: 1,
+    }),
+    null
+  )
+})
+
+test("mapSorobanEvent - non-numeric value yields null amount, missing close time yields null", () => {
+  const mapped = mapSorobanEvent({
+    topic: [nativeToScVal("payout", { type: "symbol" })],
+    value: nativeToScVal("not-a-number"),
+    txHash: "abc",
+    ledger: 2,
+  })
+  assert.ok(mapped)
+  assert.strictEqual(mapped.amount, null)
+  assert.strictEqual(mapped.user_address, null)
+  assert.strictEqual(mapped.ledgerClosedAt, null)
+})

--- a/frontend/lib/soroban-event-mapping.ts
+++ b/frontend/lib/soroban-event-mapping.ts
@@ -1,0 +1,104 @@
+/**
+ * Pure mapping from raw Soroban contract events to the platform's activity
+ * vocabulary. Shared by the client activity hook (fetchContractEvents in
+ * hooks/useJointSaveContracts.ts) and the server-side indexer
+ * (POST /api/pools/[id]/index-events) — it only touches @stellar/stellar-sdk
+ * value types, so it is safe to import from either side.
+ */
+
+import { Address, xdr } from "@stellar/stellar-sdk"
+
+function scValToBigInt(val: xdr.ScVal): bigint {
+  // i128 / u128 are stored as hi+lo parts
+  if (val.switch().name === "scvI128") {
+    const parts = val.i128()
+    return (BigInt(parts.hi().toString()) << 64n) | BigInt(parts.lo().toString())
+  }
+  if (val.switch().name === "scvU128") {
+    const parts = val.u128()
+    return (BigInt(parts.hi().toString()) << 64n) | BigInt(parts.lo().toString())
+  }
+  if (val.switch().name === "scvU64") return BigInt(val.u64().toString())
+  if (val.switch().name === "scvI64") return BigInt(val.i64().toString())
+  return 0n
+}
+
+/**
+ * Contract event topic → pool_activity.activity_type.
+ * Topics emitted by contracts: "deposit", "payout", "withdraw", "complete",
+ * "unlocked", "refunded", "yield".
+ */
+const EVENT_TYPE_MAP: Record<string, string> = {
+  deposit: "deposit",
+  payout: "payout",
+  withdraw: "withdraw",
+  complete: "complete",
+  unlocked: "complete",
+  refunded: "withdraw",
+  yield: "yield",
+}
+
+/** Translate a raw event topic symbol to an activity_type, or null if unknown. */
+export function mapTopicToActivityType(topic: string): string | null {
+  return EVENT_TYPE_MAP[topic] ?? null
+}
+
+/** The subset of rpc.Api.EventResponse the mapper reads. */
+export interface RawSorobanEvent {
+  topic: xdr.ScVal[]
+  value: xdr.ScVal
+  txHash: string
+  ledger: number
+  ledgerClosedAt?: string
+}
+
+export interface MappedSorobanEvent {
+  activity_type: string
+  user_address: string | null
+  amount: number | null
+  tx_hash: string
+  ledger: number
+  ledgerClosedAt: string | null
+}
+
+/**
+ * Map one raw contract event to activity fields, or null when the event is not
+ * one the activity feed tracks. First topic is the event name symbol; second
+ * (optional) topic is the acting address; the value is the amount (i128, in
+ * stroops) for deposit/payout/withdraw-style events.
+ */
+export function mapSorobanEvent(ev: RawSorobanEvent): MappedSorobanEvent | null {
+  const topics = ev.topic
+  if (!topics.length) return null
+
+  const topicName = topics[0].switch().name === "scvSymbol" ? topics[0].sym().toString() : null
+  if (!topicName) return null
+
+  const activity_type = mapTopicToActivityType(topicName)
+  if (!activity_type) return null
+
+  let user_address: string | null = null
+  if (topics[1]?.switch().name === "scvAddress") {
+    try {
+      user_address = Address.fromScVal(topics[1]).toString()
+    } catch {}
+  }
+
+  let amount: number | null = null
+  try {
+    const val = ev.value
+    const sw = val.switch().name
+    if (sw === "scvI128" || sw === "scvU128" || sw === "scvU64" || sw === "scvI64") {
+      amount = Number(scValToBigInt(val)) / 10_000_000
+    }
+  } catch {}
+
+  return {
+    activity_type,
+    user_address,
+    amount,
+    tx_hash: ev.txHash,
+    ledger: ev.ledger,
+    ledgerClosedAt: ev.ledgerClosedAt ?? null,
+  }
+}

--- a/frontend/lib/supabase.ts
+++ b/frontend/lib/supabase.ts
@@ -95,6 +95,7 @@ export type Database = {
           withdrawal_fee?: number | null
           yield_enabled?: boolean
         }
+        Relationships: []
       }
       pool_members: {
         Row: {
@@ -117,6 +118,7 @@ export type Database = {
           contribution_amount?: number
           status?: "pending" | "paid" | "late"
         }
+        Relationships: []
       }
       pool_activity: {
         Row: {
@@ -148,6 +150,7 @@ export type Database = {
           description?: string | null
           tx_hash?: string | null
         }
+        Relationships: []
       }
       pool_daily_metrics: {
         Row: {
@@ -180,6 +183,7 @@ export type Database = {
           active_members_count?: number
           created_at?: string
         }
+        Relationships: []
       }
       join_requests: {
         Row: {
@@ -201,6 +205,7 @@ export type Database = {
           responded_at?: string | null
           responder_id?: string | null
         }
+        Relationships: []
       }
       pool_health_scores: {
         Row: {
@@ -227,6 +232,7 @@ export type Database = {
           risk_indicator?: string
           last_calculated_at?: string
         }
+        Relationships: []
       }
       user_profiles: {
         Row: {
@@ -266,6 +272,7 @@ export type Database = {
           }
           updated_at?: string
         }
+        Relationships: []
       }
       deposit_reminders: {
         Row: {
@@ -288,6 +295,7 @@ export type Database = {
           round_deadline?: string
           created_at?: string
         }
+        Relationships: []
       }
       notifications: {
         Row: {
@@ -311,6 +319,7 @@ export type Database = {
         Update: {
           read?: boolean
         }
+        Relationships: []
       }
       admin_actions: {
         Row: {
@@ -342,6 +351,7 @@ export type Database = {
           tx_hash?: string | null
           created_at?: string
         }
+        Relationships: []
       }
       cron_job_logs: {
         Row: {
@@ -376,8 +386,13 @@ export type Database = {
           next_retry_at?: string | null
           created_at?: string
         }
+        Relationships: []
       }
     }
+    // supabase-js v2 requires these keys on the schema type; without them the
+    // client can't match GenericSchema and every table degrades to `never`.
+    Views: Record<string, never>
+    Functions: Record<string, never>
   }
 }
 

--- a/frontend/lib/supabase.ts
+++ b/frontend/lib/supabase.ts
@@ -130,6 +130,9 @@ export type Database = {
           token_amount: number | null
           description: string | null
           tx_hash: string | null
+          on_chain_timestamp: string | null
+          block_number: number | null
+          fee_charged: number | null
           created_at: string
         }
         Insert: {
@@ -140,6 +143,9 @@ export type Database = {
           token_amount?: number | null
           description?: string | null
           tx_hash?: string | null
+          on_chain_timestamp?: string | null
+          block_number?: number | null
+          fee_charged?: number | null
         }
         Update: {
           pool_id?: string
@@ -149,6 +155,9 @@ export type Database = {
           token_amount?: number | null
           description?: string | null
           tx_hash?: string | null
+          on_chain_timestamp?: string | null
+          block_number?: number | null
+          fee_charged?: number | null
         }
         Relationships: []
       }
@@ -385,6 +394,25 @@ export type Database = {
           retry_count?: number
           next_retry_at?: string | null
           created_at?: string
+        }
+        Relationships: []
+      }
+      event_index_log: {
+        Row: {
+          id: number
+          pool_id: string
+          last_indexed_ledger: number
+          indexed_at: string
+        }
+        Insert: {
+          pool_id: string
+          last_indexed_ledger: number
+          indexed_at?: string
+        }
+        Update: {
+          pool_id?: string
+          last_indexed_ledger?: number
+          indexed_at?: string
         }
         Relationships: []
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "start": "next start",
-    "test:unit": "tsx --test lib/csv-export.test.ts lib/activity-query.test.ts lib/analytics.test.ts lib/pool-health.test.ts lib/form-validation.test.ts lib/member-filters.test.ts lib/contract-version.test.ts lib/error-reporting.test.ts lib/pending-transactions.test.ts hooks/use-keyboard-shortcuts.test.ts app/api/admin/audit-log/route.test.ts app/api/admin/actions/route.test.ts app/api/errors/route.test.ts components/error-boundary.test.ts app/api/notifications/route.test.ts app/api/user-profile/route.test.ts app/api/portfolio/summary/route.test.ts",
+    "test:unit": "tsx --test lib/csv-export.test.ts lib/activity-query.test.ts lib/soroban-event-mapping.test.ts lib/analytics.test.ts lib/pool-health.test.ts lib/form-validation.test.ts lib/member-filters.test.ts lib/contract-version.test.ts lib/error-reporting.test.ts lib/pending-transactions.test.ts hooks/use-keyboard-shortcuts.test.ts app/api/admin/audit-log/route.test.ts app/api/admin/actions/route.test.ts app/api/errors/route.test.ts components/error-boundary.test.ts app/api/notifications/route.test.ts app/api/user-profile/route.test.ts app/api/portfolio/summary/route.test.ts",
     "test:components": "vitest run",
     "test:components:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "start": "next start",
-    "test:unit": "tsx --test lib/csv-export.test.ts lib/analytics.test.ts lib/pool-health.test.ts lib/form-validation.test.ts lib/member-filters.test.ts lib/contract-version.test.ts lib/error-reporting.test.ts lib/pending-transactions.test.ts hooks/use-keyboard-shortcuts.test.ts app/api/admin/audit-log/route.test.ts app/api/admin/actions/route.test.ts app/api/errors/route.test.ts components/error-boundary.test.ts app/api/notifications/route.test.ts app/api/user-profile/route.test.ts app/api/portfolio/summary/route.test.ts",
+    "test:unit": "tsx --test lib/csv-export.test.ts lib/activity-query.test.ts lib/analytics.test.ts lib/pool-health.test.ts lib/form-validation.test.ts lib/member-filters.test.ts lib/contract-version.test.ts lib/error-reporting.test.ts lib/pending-transactions.test.ts hooks/use-keyboard-shortcuts.test.ts app/api/admin/audit-log/route.test.ts app/api/admin/actions/route.test.ts app/api/errors/route.test.ts components/error-boundary.test.ts app/api/notifications/route.test.ts app/api/user-profile/route.test.ts app/api/portfolio/summary/route.test.ts",
     "test:components": "vitest run",
     "test:components:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",

--- a/supabase/migrations/20260818000000_activity_event_indexing.sql
+++ b/supabase/migrations/20260818000000_activity_event_indexing.sql
@@ -1,0 +1,48 @@
+-- On-chain event indexing (issue #210): enrich pool_activity rows with the
+-- on-chain data needed to verify a transaction on Stellar Explorer, and track
+-- indexing progress per pool so re-index runs never re-read old ledgers.
+--
+-- `pool_activity.tx_hash` already exists (see ARCHITECTURE.md schema), so only
+-- the enrichment columns are added here. Backfill note: SQL cannot call
+-- Horizon, so historical rows are enriched lazily by the first
+-- POST /api/pools/[id]/index-events run for each pool (it fills
+-- on_chain_timestamp / block_number / fee_charged for any row that already has
+-- a tx_hash).
+
+alter table public.pool_activity
+  add column if not exists on_chain_timestamp timestamptz;
+
+alter table public.pool_activity
+  add column if not exists block_number bigint;
+
+-- Fee in stroops as reported by Horizon's fee_charged.
+alter table public.pool_activity
+  add column if not exists fee_charged bigint;
+
+-- Indexes for the new per-pool filter/sort query patterns.
+create index if not exists idx_pool_activity_pool_created
+  on public.pool_activity (pool_id, created_at desc);
+
+create index if not exists idx_pool_activity_pool_type
+  on public.pool_activity (pool_id, activity_type);
+
+-- One row per pool recording how far indexing has progressed.
+-- (The issue sketch uses `pool_id text`; a uuid FK is used instead so rows are
+-- cleaned up with their pool and cannot reference a nonexistent one.)
+create table if not exists public.event_index_log (
+  id bigserial primary key,
+  pool_id uuid not null unique references public.pools(id) on delete cascade,
+  last_indexed_ledger bigint not null default 0,
+  indexed_at timestamptz not null default now()
+);
+
+-- RLS: public read (the activity feed shows "Last indexed"), writes via the
+-- service-role key only — same model as pool_activity in
+-- 20260624000000_rls_lockdown.sql.
+alter table public.event_index_log enable row level security;
+
+create policy "event_index_log_select_public"
+  on public.event_index_log for select
+  using (true);
+
+-- No INSERT/UPDATE/DELETE policy = anon callers cannot forge indexing state.


### PR DESCRIPTION
Closes #210

## Summary

Adds a comprehensive transaction indexing system: `pool_activity` rows are enriched with on-chain data (tx hash, ledger, block time, fee), the activity feed gains server-side full-text search / date-range / type filtering with pagination, and full history can be exported per pool.

### Database
- Migration `supabase/migrations/20260818000000_activity_event_indexing.sql`:
  - `pool_activity` gains `on_chain_timestamp` (timestamptz), `block_number` (bigint), `fee_charged` (bigint, stroops). `tx_hash` already existed.
  - New `event_index_log` table tracking the last indexed ledger per pool (RLS: public read, service-role writes — same model as `pool_activity`).
  - Composite indexes for the per-pool filter/sort query patterns.

### API
- `GET /api/pools/[id]/activity` — search (activity type, description, address, tx hash), `date_from`/`date_to` (end date inclusive), `activity_type`, `sort=newest|oldest`, `page` (50/page). Response includes the pool's indexing state for the "Last indexed" display.
- `GET /api/pools/[id]/activity/export` — same filters, `format=csv|json`, downloadable attachment, rate limited to 5 exports/hour per wallet.
- `POST /api/pools/[id]/index-events` — any pool member can trigger; reads contract events from Soroban RPC since `last_indexed_ledger` (cursor-paginated, clamped to the RPC retention window instead of failing), enriches matching rows via Horizon, inserts rows for on-chain events the DB never recorded, backfills older rows that have a `tx_hash` but no on-chain data, and advances `event_index_log`.

### Frontend
- `group-activity.tsx` reworked to consume the new API: debounced search (300ms), shared date range picker with 7/30/90-day presets, activity-type dropdown, newest/oldest toggle, Export CSV button (surfaces the rate-limit message), "Last indexed: X ago" with a member-only Re-index button, 50-per-page Load More. Existing rendering (icons, amount badge, on-chain badge, relative-time tooltips, stellar.expert links) preserved; the on-chain badge now derives from the persisted `on_chain_timestamp`.
- New shared component `frontend/components/shared/date-range-picker.tsx`.

## Design notes / deviations from the issue sketch
- `event_index_log.pool_id` is a **uuid FK** to `pools(id)` (with `unique` for upserts) rather than `text` — referential integrity and automatic cleanup with the pool.
- Horizon backfill cannot run inside a SQL migration; it happens lazily on each `index-events` run (bounded batch per run, retried until enriched).
- The export limiter reuses the existing in-memory sliding-window limiter (`lib/rate-limit.ts`), consistent with the repo's read/write limiters.
- Includes a standalone fix aligning the `Database` type with supabase-js v2's schema shape (`Relationships`/`Views`/`Functions`) — this removed 21 pre-existing "type never" TS errors across existing routes.

## For reviewers: applying the migration
`npx supabase db push` (or run the migration file in the SQL editor). The app works without it, but the new columns/table must exist for the activity endpoints and indexer.

## Testing
- Unit (`npm run test:unit`): 154/154 pass (includes new suites for query parsing/sanitization and the Soroban event mapper — the search sanitizer is unit-tested against PostgREST `or()` filter injection).
- Component (`npx vitest run`): 101/101 pass (includes new DateRangePicker tests).
- E2E (Playwright): deposit-flow, navigation, responsive, wallet-connection pass. `create-pool.spec.ts` fails, but it fails identically on `main` (verified in a clean worktree) — pre-existing and unrelated.
- Manual walkthrough (search/filters/sort/pagination, CSV export incl. the 429 path, re-indexing against testnet) is in progress — requires the migration applied to a live Supabase project.


<img width="1862" height="966" alt="image" src="https://github.com/user-attachments/assets/7c1b64fd-6492-4aaa-809d-a5bd7c448546" />

<img width="1862" height="966" alt="image" src="https://github.com/user-attachments/assets/8978bf1a-d0fe-4cb1-8b3c-a254f9973e95" />
