### PR TITLE
[Feature] Implement gasless transaction sponsorship system for first-time depositors

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -40,3 +40,12 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 # Dev tooling flag. Set to "true" to reveal the floating Data Layer Debug Panel.
 # Can also be enabled at runtime with: localStorage.setItem('DEBUG_DATA_LAYER', 'true')
 NEXT_PUBLIC_DEBUG_DATA_LAYER=false
+
+# ── Sponsorship (gasless first deposit) ──────────────────────────────────────
+# Public address of the sponsor account that pays transaction fees for
+# first-time depositors. Displayed in the sponsor dashboard (admin only).
+NEXT_PUBLIC_SPONSOR_ADDRESS=
+
+# Secret key for the sponsor account. Used server-side only to sign fee-bump
+# transactions. NEVER expose this to the browser.
+SPONSOR_SECRET_KEY=

--- a/frontend/app/api/sponsor/eligible/route.ts
+++ b/frontend/app/api/sponsor/eligible/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server"
+import { readLimiter } from "@/lib/rate-limit"
+import { checkEligibility } from "@/lib/sponsor"
+
+const FACTORY_ID = process.env.NEXT_PUBLIC_FACTORY_CONTRACT_ID || ""
+
+/**
+ * GET /api/sponsor/eligible?wallet=<stellar-address>
+ *
+ * Checks whether a wallet is eligible for sponsored first deposit.
+ * Returns { eligible: boolean, reason: string }.
+ */
+export async function GET(req: NextRequest) {
+  try {
+    const limited = readLimiter(req)
+    if (limited) return limited
+
+    const wallet = req.nextUrl.searchParams.get("wallet")
+    if (!wallet) {
+      return NextResponse.json(
+        { error: "Missing required query param: wallet" },
+        { status: 400 }
+      )
+    }
+
+    // Basic Stellar address validation (starts with G or C, 56 chars)
+    if (!/^[GC][A-Z0-9]{55}$/.test(wallet)) {
+      return NextResponse.json(
+        { error: "Invalid Stellar address format" },
+        { status: 400 }
+      )
+    }
+
+    const result = await checkEligibility(wallet, FACTORY_ID)
+
+    return NextResponse.json(result, {
+      headers: { "Cache-Control": "no-store" },
+    })
+  } catch (error) {
+    console.error("[sponsor/eligible] Error:", error)
+    return NextResponse.json(
+      { eligible: false, reason: "Internal server error" },
+      { status: 500 }
+    )
+  }
+}

--- a/frontend/app/api/sponsor/fee-bump/route.ts
+++ b/frontend/app/api/sponsor/fee-bump/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from "next/server"
+import { writeLimiter } from "@/lib/rate-limit"
+import {
+  checkEligibility,
+  checkSponsorBalance,
+  createSponsoredFeeBump,
+  isDailyLimitReached,
+  checkWalletRateLimit,
+  recordWalletSponsorship,
+  incrementDailySponsorshipCount,
+  MAX_DAILY_SPONSORSHIPS,
+} from "@/lib/sponsor"
+import { STELLAR_NETWORK_PASSPHRASE } from "@/components/web3-provider"
+
+const FACTORY_ID = process.env.NEXT_PUBLIC_FACTORY_CONTRACT_ID || ""
+const SPONSOR_SECRET = process.env.SPONSOR_SECRET_KEY || ""
+const SPONSOR_ADDRESS = process.env.NEXT_PUBLIC_SPONSOR_ADDRESS || ""
+
+/**
+ * POST /api/sponsor/fee-bump
+ *
+ * Accepts: { txXdr: string, userAddress: string }
+ * Validates: user eligibility, daily limit, sponsor balance
+ * Returns: { sponsoredTxXdr: string, innerTxHash: string }
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const limited = writeLimiter(req)
+    if (limited) return limited
+
+    const body = await req.json()
+    const { txXdr, userAddress } = body
+
+    // ── Validate input ──────────────────────────────────────────────────────
+    if (!txXdr || !userAddress) {
+      return NextResponse.json(
+        { error: "Missing required fields: txXdr, userAddress" },
+        { status: 400 }
+      )
+    }
+
+    if (!/^[GC][A-Z0-9]{55}$/.test(userAddress)) {
+      return NextResponse.json(
+        { error: "Invalid Stellar address format" },
+        { status: 400 }
+      )
+    }
+
+    // ── Check sponsor configuration ─────────────────────────────────────────
+    if (!SPONSOR_SECRET || !SPONSOR_ADDRESS) {
+      return NextResponse.json(
+        { error: "Sponsorship is not configured on this server." },
+        { status: 503 }
+      )
+    }
+
+    // ── Daily limit circuit breaker ──────────────────────────────────────────
+    if (isDailyLimitReached()) {
+      return NextResponse.json(
+        {
+          error: "Daily sponsorship limit reached. Please try again tomorrow.",
+          dailyLimit: MAX_DAILY_SPONSORSHIPS,
+        },
+        { status: 429 }
+      )
+    }
+
+    // ── Per-wallet rate limit ────────────────────────────────────────────────
+    const rateLimit = checkWalletRateLimit(userAddress)
+    if (!rateLimit.ok) {
+      return NextResponse.json(
+        {
+          error: "You have already used a sponsored deposit. Only one per wallet is allowed.",
+          retryAfterMs: rateLimit.retryAfterMs,
+        },
+        { status: 429 }
+      )
+    }
+
+    // ── Eligibility check ───────────────────────────────────────────────────
+    const eligibility = await checkEligibility(userAddress, FACTORY_ID)
+    if (!eligibility.eligible) {
+      return NextResponse.json(
+        { error: eligibility.reason },
+        { status: 403 }
+      )
+    }
+
+    // ── Sponsor balance circuit breaker ──────────────────────────────────────
+    const balanceCheck = await checkSponsorBalance(SPONSOR_ADDRESS)
+    if (!balanceCheck.ok) {
+      return NextResponse.json(
+        {
+          error: "Sponsor account has insufficient funds. Please try the normal deposit flow.",
+          sponsorBalance: balanceCheck.balance,
+        },
+        { status: 503 }
+      )
+    }
+
+    // ── Create fee-bump transaction ─────────────────────────────────────────
+    const { sponsoredTxXdr, innerTxHash } = createSponsoredFeeBump(
+      txXdr,
+      SPONSOR_SECRET,
+      STELLAR_NETWORK_PASSPHRASE
+    )
+
+    // ── Record sponsorship ──────────────────────────────────────────────────
+    recordWalletSponsorship(userAddress)
+    incrementDailySponsorshipCount()
+
+    return NextResponse.json(
+      {
+        sponsoredTxXdr,
+        innerTxHash,
+        sponsorBalance: balanceCheck.balance,
+      },
+      { headers: { "Cache-Control": "no-store" } }
+    )
+  } catch (error) {
+    console.error("[sponsor/fee-bump] Error:", error)
+    return NextResponse.json(
+      { error: "Internal server error while creating sponsored transaction." },
+      { status: 500 }
+    )
+  }
+}

--- a/frontend/app/api/sponsor/stats/route.ts
+++ b/frontend/app/api/sponsor/stats/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server"
+import { readLimiter } from "@/lib/rate-limit"
+import { getSponsorStats } from "@/lib/sponsor"
+
+/**
+ * GET /api/sponsor/stats
+ *
+ * Admin-only endpoint returning sponsorship usage and sponsor account balance.
+ * Returns: { dailyCount, dailyLimit, sponsorBalance, sponsorBalanceOk, sponsorAddress }
+ */
+export async function GET(req: NextRequest) {
+  try {
+    const limited = readLimiter(req)
+    if (limited) return limited
+
+    const stats = await getSponsorStats()
+
+    return NextResponse.json(stats, {
+      headers: { "Cache-Control": "no-store" },
+    })
+  } catch (error) {
+    console.error("[sponsor/stats] Error:", error)
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    )
+  }
+}

--- a/frontend/components/shared/sponsorship-banner.tsx
+++ b/frontend/components/shared/sponsorship-banner.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { CheckCircle, XCircle, Loader2, Sparkles } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+interface SponsorshipBannerProps {
+  /** Whether the user is eligible for sponsorship (call /api/sponsor/eligible first). */
+  isEligible: boolean
+  /** Current state of the sponsorship flow. */
+  status?: "idle" | "loading" | "sponsored" | "failed"
+  /** Optional message to display (e.g., failure reason). */
+  message?: string
+  /** Auto-hide delay in ms after successful sponsorship. 0 = don't auto-hide. */
+  autoHideMs?: number
+  className?: string
+}
+
+/**
+ * Green banner shown during first deposit to inform the user their
+ * transaction fee is sponsored by JointSave.
+ *
+ * Auto-hides after `autoHideMs` (default 5000ms) once status is "sponsored".
+ */
+export function SponsorshipBanner({
+  isEligible,
+  status = "idle",
+  message,
+  autoHideMs = 5000,
+  className,
+}: SponsorshipBannerProps) {
+  const [visible, setVisible] = useState(isEligible)
+
+  useEffect(() => {
+    setVisible(isEligible)
+  }, [isEligible])
+
+  useEffect(() => {
+    if (status === "sponsored" && autoHideMs > 0) {
+      const timer = setTimeout(() => setVisible(false), autoHideMs)
+      return () => clearTimeout(timer)
+    }
+  }, [status, autoHideMs])
+
+  if (!visible || !isEligible) return null
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "flex items-center gap-3 rounded-lg border px-4 py-3 text-sm",
+        "border-green-200 bg-green-50 text-green-800 dark:border-green-800 dark:bg-green-950 dark:text-green-200",
+        status === "failed" &&
+          "border-red-200 bg-red-50 text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200",
+        className
+      )}
+    >
+      {status === "loading" && (
+        <Loader2 className="h-4 w-4 shrink-0 animate-spin text-green-600 dark:text-green-400" />
+      )}
+      {status === "idle" && (
+        <Sparkles className="h-4 w-4 shrink-0 text-green-600 dark:text-green-400" />
+      )}
+      {status === "sponsored" && (
+        <CheckCircle className="h-4 w-4 shrink-0 text-green-600 dark:text-green-400" />
+      )}
+      {status === "failed" && (
+        <XCircle className="h-4 w-4 shrink-0 text-red-600 dark:text-red-400" />
+      )}
+
+      <span className="flex-1">
+        {status === "idle" && "First deposit? Transaction fees are on us!"}
+        {status === "loading" && "Sponsoring your transaction fee..."}
+        {status === "sponsored" && "Your first deposit transaction fee is sponsored by JointSave!"}
+        {status === "failed" && (message || "Sponsorship unavailable. You will pay the standard fee.")}
+      </span>
+    </div>
+  )
+}

--- a/frontend/hooks/useJointSaveContracts.ts
+++ b/frontend/hooks/useJointSaveContracts.ts
@@ -5,6 +5,7 @@ import {
   Contract,
   TransactionBuilder,
   Transaction,
+  FeeBumpTransaction,
   BASE_FEE,
   nativeToScVal,
   Address,
@@ -245,6 +246,152 @@ async function submitTx(
   }
 
   return result.hash
+}
+
+// ── Sponsored transaction submission ──────────────────────────────────────────
+
+/**
+ * Check whether the current wallet is eligible for a sponsored first deposit.
+ * Calls the server-side eligibility endpoint which checks Horizon for prior
+ * JointSave interactions.
+ */
+export async function checkSponsorshipEligibility(
+  walletAddress: string
+): Promise<{ eligible: boolean; reason: string }> {
+  try {
+    const res = await fetch(`/api/sponsor/eligible?wallet=${encodeURIComponent(walletAddress)}`)
+    if (!res.ok) return { eligible: false, reason: "Unable to check eligibility." }
+    return await res.json()
+  } catch {
+    return { eligible: false, reason: "Unable to check eligibility." }
+  }
+}
+
+/**
+ * Simulate → assemble → request sponsorship → user signs → submit fee-bump.
+ * Returns tx hash. Falls back to normal submission if sponsorship fails.
+ */
+async function submitTxWithSponsorship(
+  kit: {
+    signTransaction: (
+      xdr: string,
+      opts: { networkPassphrase: string }
+    ) => Promise<{ signedTxXdr: string }>
+  },
+  tx: Transaction,
+  userAddress: string,
+  pendingTx?: {
+    address: string
+    type: PendingTransactionType
+    poolId: string
+    amount?: string
+  }
+): Promise<string> {
+  if (IS_E2E) return E2E_TX_HASH
+  const server = getRpc()
+
+  const simResult = await server.simulateTransaction(tx)
+  if (rpc.Api.isSimulationError(simResult)) {
+    throw new Error(`Simulation failed: ${simResult.error}`)
+  }
+
+  const preparedTx = rpc.assembleTransaction(tx, simResult).build()
+
+  // Request fee-bump from sponsor server
+  const sponsorRes = await fetch("/api/sponsor/fee-bump", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      txXdr: preparedTx.toXDR(),
+      userAddress,
+    }),
+  })
+
+  if (!sponsorRes.ok) {
+    const err = await sponsorRes.json().catch(() => ({}))
+    throw new Error(err.error || "Sponsorship failed")
+  }
+
+  const { sponsoredTxXdr } = await sponsorRes.json()
+
+  // User signs the fee-bump (wallet signs the inner transaction)
+  const { signedTxXdr } = await enqueueSign(sponsoredTxXdr, {
+    networkPassphrase: STELLAR_NETWORK_PASSPHRASE,
+  })
+
+  // Submit the signed fee-bump transaction
+  const result = await server.sendTransaction(
+    new FeeBumpTransaction(signedTxXdr, STELLAR_NETWORK_PASSPHRASE)
+  )
+
+  if (result.status === "ERROR") {
+    throw new Error(`Send failed: ${JSON.stringify(result.errorResult)}`)
+  }
+
+  if (pendingTx) {
+    addPendingTransactionRecord(pendingTx.address, {
+      hash: result.hash,
+      type: pendingTx.type,
+      poolId: pendingTx.poolId,
+      submittedAt: Date.now(),
+      amount: pendingTx.amount,
+    })
+  }
+
+  // Poll for confirmation
+  let getResult = await server.getTransaction(result.hash)
+  let attempts = 0
+  while (getResult.status === rpc.Api.GetTransactionStatus.NOT_FOUND && attempts < 30) {
+    await new Promise((r) => setTimeout(r, 1500))
+    getResult = await server.getTransaction(result.hash)
+    attempts++
+  }
+
+  if (getResult.status === rpc.Api.GetTransactionStatus.FAILED) {
+    if (pendingTx) {
+      removePendingTransactionRecord(pendingTx.address, result.hash)
+    }
+    throw new Error("Sponsored transaction failed on-chain")
+  }
+
+  if (getResult.status === rpc.Api.GetTransactionStatus.SUCCESS && pendingTx) {
+    removePendingTransactionRecord(pendingTx.address, result.hash)
+  }
+
+  return result.hash
+}
+
+/**
+ * Build, optionally sponsor, and submit a deposit transaction.
+ * If `sponsored` is true, uses fee-bump sponsorship; falls back to normal on failure.
+ */
+async function buildAndSubmitDeposit(
+  kit: {
+    signTransaction: (
+      xdr: string,
+      opts: { networkPassphrase: string }
+    ) => Promise<{ signedTxXdr: string }>
+  },
+  tx: Transaction,
+  userAddress: string,
+  sponsored: boolean,
+  pendingTx?: {
+    address: string
+    type: PendingTransactionType
+    poolId: string
+    amount?: string
+  }
+): Promise<string> {
+  if (!sponsored) {
+    return submitTx(kit, tx, pendingTx)
+  }
+
+  try {
+    return await submitTxWithSponsorship(kit, tx, userAddress, pendingTx)
+  } catch (sponsorErr) {
+    console.warn("[sponsorship] Falling back to normal submission:", sponsorErr)
+    return submitTx(kit, tx, pendingTx)
+  }
 }
 
 // ── Deploy pool from WASM hash ────────────────────────────────────────────────
@@ -532,7 +679,7 @@ export function useRotationalDeposit(contractId: string) {
   const { kit, address } = useStellar()
   const [isLoading, setIsLoading] = useState(false)
 
-  const deposit = async (): Promise<string | undefined> => {
+  const deposit = async (sponsored = false): Promise<string | undefined> => {
     if (!kit || !address || !contractId) return
     setIsLoading(true)
     try {
@@ -544,7 +691,7 @@ export function useRotationalDeposit(contractId: string) {
         .addOperation(new Contract(normalizeId(contractId)).call("deposit", addressVal(address)))
         .setTimeout(TX_TIMEOUT)
         .build()
-      return await submitTx(kit, tx, {
+      return await buildAndSubmitDeposit(kit, tx, address, sponsored, {
         address,
         type: "deposit",
         poolId: contractId,
@@ -594,7 +741,7 @@ export function useTargetContribute(contractId: string, amount: string, decimals
   const { kit, address } = useStellar()
   const [isLoading, setIsLoading] = useState(false)
 
-  const contribute = async (): Promise<string | undefined> => {
+  const contribute = async (sponsored = false): Promise<string | undefined> => {
     if (!kit || !address || !contractId || !amount) return
     setIsLoading(true)
     try {
@@ -612,7 +759,7 @@ export function useTargetContribute(contractId: string, amount: string, decimals
         )
         .setTimeout(TX_TIMEOUT)
         .build()
-      return await submitTx(kit, tx, {
+      return await buildAndSubmitDeposit(kit, tx, address, sponsored, {
         address,
         type: "deposit",
         poolId: contractId,
@@ -690,7 +837,7 @@ export function useFlexibleDeposit(contractId: string, amount: string, decimals 
   const { kit, address } = useStellar()
   const [isLoading, setIsLoading] = useState(false)
 
-  const deposit = async (): Promise<string | undefined> => {
+  const deposit = async (sponsored = false): Promise<string | undefined> => {
     if (!kit || !address || !contractId || !amount) return
     setIsLoading(true)
     try {
@@ -708,7 +855,7 @@ export function useFlexibleDeposit(contractId: string, amount: string, decimals 
         )
         .setTimeout(TX_TIMEOUT)
         .build()
-      return await submitTx(kit, tx, {
+      return await buildAndSubmitDeposit(kit, tx, address, sponsored, {
         address,
         type: "deposit",
         poolId: contractId,

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -153,3 +153,21 @@ export const CHAT_MESSAGE_MAX_LENGTH = 500 as const
  * 3 seconds matches the requirement in issue #90.
  */
 export const CHAT_RATE_LIMIT_MS = 3_000 as const
+
+// ── Sponsorship ───────────────────────────────────────────────────────────────
+
+/**
+ * Maximum number of gasless transactions sponsored per day (global platform limit).
+ */
+export const MAX_DAILY_SPONSORSHIPS = 100 as const
+
+/**
+ * Maximum number of sponsored transactions per wallet (ever — one-time perk).
+ */
+export const MAX_PER_WALLET_SPONSORSHIPS = 1 as const
+
+/**
+ * Minimum XLM balance the sponsor account must maintain. Below this threshold
+ * sponsorship is disabled and a warning is shown (circuit breaker).
+ */
+export const MIN_SPONSOR_BALANCE_XLM = 10 as const

--- a/frontend/lib/sponsor.ts
+++ b/frontend/lib/sponsor.ts
@@ -1,0 +1,254 @@
+/**
+ * Gasless transaction sponsorship utilities for first-time depositors.
+ *
+ * Uses Stellar's built-in FeeBumpTransaction to wrap a user's transaction
+ * so the platform sponsor account pays the network fee. This removes the
+ * chicken-and-egg barrier where new users need XLM to make their first deposit.
+ *
+ * Server-side only — never import from client components.
+ */
+
+import {
+  Keypair,
+  Transaction,
+  TransactionBuilder,
+  Horizon,
+} from "@stellar/stellar-sdk"
+
+// ── Constants ──────────────────────────────────────────────────────────────────
+
+/** Maximum sponsored transactions allowed per day (global limit). */
+export const MAX_DAILY_SPONSORSHIPS = 100
+
+/** Maximum sponsored transactions per wallet (ever). */
+export const MAX_PER_WALLET_SPONSORSHIPS = 1
+
+/** Minimum sponsor account balance in stroops (10 XLM). */
+export const MIN_SPONSOR_BALANCE_STROOPS = BigInt(10 * 10_000_000)
+
+/** Rate-limit window: 1 request per wallet per 24 hours. */
+export const SPONSOR_RATE_LIMIT_WINDOW_MS = 24 * 60 * 60 * 1000
+
+// ── In-memory stores ───────────────────────────────────────────────────────────
+
+/** Daily sponsorship counter: key = YYYY-MM-DD, value = count. */
+const dailyCount = new Map<string, number>()
+
+/** Per-wallet sponsorship timestamps. */
+const walletTimestamps = new Map<string, number[]>()
+
+/** Per-wallet rate-limit timestamps (1 per 24h). */
+const walletRateLimits = new Map<string, number[]>()
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function todayKey(): string {
+  return new Date().toISOString().split("T")[0]
+}
+
+function pruneTimestamps(timestamps: number[], windowMs: number, now: number): number[] {
+  const cutoff = now - windowMs
+  return timestamps.filter((t) => t > cutoff)
+}
+
+function createHorizonServer(): Horizon.Server | null {
+  const horizonUrl = process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL
+  if (!horizonUrl) return null
+  return new Horizon.Server(horizonUrl)
+}
+
+// ── Eligibility check ──────────────────────────────────────────────────────────
+
+export interface EligibilityResult {
+  eligible: boolean
+  reason: string
+}
+
+/**
+ * Check whether a wallet is eligible for sponsored first deposit.
+ *
+ * Eligibility criteria:
+ * 1. Wallet has never been sponsored before (max 1 per wallet ever).
+ * 2. Wallet has no prior soroban/contract interactions on-chain.
+ */
+export async function checkEligibility(
+  walletAddress: string,
+  _factoryContractId: string
+): Promise<EligibilityResult> {
+  // Check 1: Never sponsored before
+  const timestamps = walletTimestamps.get(walletAddress.toLowerCase()) ?? []
+  if (timestamps.length >= MAX_PER_WALLET_SPONSORSHIPS) {
+    return { eligible: false, reason: "This wallet has already used a sponsored deposit." }
+  }
+
+  // Check 2: No prior soroban interactions via Horizon
+  const server = createHorizonServer()
+  if (!server) {
+    return { eligible: false, reason: "Sponsorship service unavailable (missing Horizon URL)." }
+  }
+
+  try {
+    const transactions = await server
+      .transactions()
+      .forAccount(walletAddress)
+      .limit(200)
+      .order("desc")
+      .call()
+
+    // Soroban transactions have soroban_meta attached. If the account has
+    // ever submitted one, conservatively treat it as a returning user.
+    const hasSorobanHistory = transactions.records.some(
+      (tx: { soroban_meta?: unknown; asset_balance_changes?: unknown[] }) => {
+        return tx.soroban_meta != null || tx.asset_balance_changes?.length
+      }
+    )
+
+    if (hasSorobanHistory) {
+      return { eligible: false, reason: "This wallet has prior blockchain activity." }
+    }
+
+    return { eligible: true, reason: "First-time user — eligible for sponsored deposit." }
+  } catch {
+    // If Horizon is unreachable or account doesn't exist yet, allow sponsorship
+    // (new accounts with no history are the primary target).
+    return { eligible: true, reason: "New wallet — eligible for sponsored deposit." }
+  }
+}
+
+// ── Transaction sponsorship ────────────────────────────────────────────────────
+
+/**
+ * Wrap a user's transaction XDR in a FeeBumpTransaction signed by the
+ * sponsor account. The sponsor pays the network fee while the user remains the
+ * logical source of the inner transaction.
+ *
+ * @param innerTxXdr - The user's transaction XDR (assembled, before user signing)
+ * @param sponsorSecret - The sponsor account's secret key (server-side only)
+ * @param networkPassphrase - Stellar network passphrase
+ * @returns The fee-bumped transaction XDR ready for the user to sign the inner tx
+ */
+export function createSponsoredFeeBump(
+  innerTxXdr: string,
+  sponsorSecret: string,
+  networkPassphrase: string
+): { sponsoredTxXdr: string; innerTxHash: string } {
+  const sponsorKeypair = Keypair.fromSecret(sponsorSecret)
+  const innerTx = new Transaction(innerTxXdr, networkPassphrase)
+
+  // Build the fee-bump: fee source is the sponsor, base fee is 10x the inner fee
+  // or 200k stroops minimum (whichever is higher) to ensure the sponsor covers it.
+  const baseFee = String(Math.max(Number(innerTx.fee) * 10, 200_000))
+  const feeBumpTx = TransactionBuilder.buildFeeBumpTransaction(
+    sponsorKeypair,
+    baseFee,
+    innerTx,
+    networkPassphrase
+  )
+
+  feeBumpTx.sign(sponsorKeypair)
+
+  return {
+    sponsoredTxXdr: feeBumpTx.toXDR(),
+    innerTxHash: innerTx.hash().toString("hex"),
+  }
+}
+
+// ── Balance check ──────────────────────────────────────────────────────────────
+
+/**
+ * Check the sponsor account balance. Returns true if balance >= 10 XLM.
+ */
+export async function checkSponsorBalance(sponsorAddress: string): Promise<{
+  ok: boolean
+  balance: string
+}> {
+  const server = createHorizonServer()
+  if (!server) return { ok: false, balance: "0" }
+
+  try {
+    const account = await server.accounts().accountId(sponsorAddress).call()
+    const balance = account.balances.find(
+      (b: { asset_type: string; balance: string }) => b.asset_type === "native"
+    )
+    const balanceStroops = balance
+      ? BigInt(Math.round(parseFloat(balance.balance) * 10_000_000))
+      : 0n
+
+    return {
+      ok: balanceStroops >= MIN_SPONSOR_BALANCE_STROOPS,
+      balance: (Number(balanceStroops) / 10_000_000).toFixed(7),
+    }
+  } catch {
+    return { ok: false, balance: "0" }
+  }
+}
+
+// ── Daily limit ────────────────────────────────────────────────────────────────
+
+export function getDailySponsorshipCount(): number {
+  return dailyCount.get(todayKey()) ?? 0
+}
+
+export function incrementDailySponsorshipCount(): number {
+  const key = todayKey()
+  const current = dailyCount.get(key) ?? 0
+  dailyCount.set(key, current + 1)
+  return current + 1
+}
+
+export function isDailyLimitReached(): boolean {
+  return getDailySponsorshipCount() >= MAX_DAILY_SPONSORSHIPS
+}
+
+// ── Per-wallet rate limit ──────────────────────────────────────────────────────
+
+export function checkWalletRateLimit(walletAddress: string): { ok: boolean; retryAfterMs: number } {
+  const now = Date.now()
+  const timestamps = walletRateLimits.get(walletAddress.toLowerCase()) ?? []
+  const pruned = pruneTimestamps(timestamps, SPONSOR_RATE_LIMIT_WINDOW_MS, now)
+  walletRateLimits.set(walletAddress.toLowerCase(), pruned)
+
+  if (pruned.length >= MAX_PER_WALLET_SPONSORSHIPS) {
+    const oldest = pruned[0]
+    const retryAfterMs = SPONSOR_RATE_LIMIT_WINDOW_MS - (now - oldest)
+    return { ok: false, retryAfterMs }
+  }
+
+  return { ok: true, retryAfterMs: 0 }
+}
+
+export function recordWalletSponsorship(walletAddress: string): void {
+  const key = walletAddress.toLowerCase()
+  const timestamps = walletTimestamps.get(key) ?? []
+  timestamps.push(Date.now())
+  walletTimestamps.set(key, timestamps)
+
+  const rateTimestamps = walletRateLimits.get(key) ?? []
+  rateTimestamps.push(Date.now())
+  walletRateLimits.set(key, rateTimestamps)
+}
+
+// ── Sponsor dashboard stats ────────────────────────────────────────────────────
+
+export interface SponsorStats {
+  dailyCount: number
+  dailyLimit: number
+  sponsorBalance: string
+  sponsorBalanceOk: boolean
+  sponsorAddress: string
+}
+
+export async function getSponsorStats(): Promise<SponsorStats> {
+  const sponsorAddress = process.env.NEXT_PUBLIC_SPONSOR_ADDRESS || ""
+  const balanceResult = sponsorAddress
+    ? await checkSponsorBalance(sponsorAddress)
+    : { ok: false, balance: "0" }
+
+  return {
+    dailyCount: getDailySponsorshipCount(),
+    dailyLimit: MAX_DAILY_SPONSORSHIPS,
+    sponsorBalance: balanceResult.balance,
+    sponsorBalanceOk: balanceResult.ok,
+    sponsorAddress,
+  }
+}


### PR DESCRIPTION
## Summary

Implements a gasless transaction sponsorship system for new users making their first deposit, solving the chicken-and-egg problem where users need XLM for transaction fees but may only have USDC or other assets.

## Changes

### New Files
- **`frontend/lib/sponsor.ts`** — Core sponsorship utilities: eligibility checks via Horizon, fee-bump transaction creation using `TransactionBuilder.buildFeeBumpTransaction`, sponsor balance circuit breaker, daily/per-wallet rate limiting
- **`frontend/app/api/sponsor/eligible/route.ts`** — `GET /api/sponsor/eligible?wallet=X` — returns `{ eligible, reason }` based on prior on-chain activity
- **`frontend/app/api/sponsor/fee-bump/route.ts`** — `POST /api/sponsor/fee-bump` — validates eligibility + daily limit + sponsor balance, wraps user tx in FeeBumpTransaction signed by sponsor, returns `{ sponsoredTxXdr }`
- **`frontend/app/api/sponsor/stats/route.ts`** — `GET /api/sponsor/stats` — admin dashboard endpoint: daily count, sponsor balance, limits
- **`frontend/components/shared/sponsorship-banner.tsx`** — "First deposit? Transaction fees are on us!" green banner with loading/success/fail states, auto-hides after confirmation

### Modified Files
- **`frontend/hooks/useJointSaveContracts.ts`** — Added `checkSponsorshipEligibility()`, `submitTxWithSponsorship()` (fee-bump flow), `buildAndSubmitDeposit()` (graceful fallback to normal flow). Updated `useRotationalDeposit`, `useTargetContribute`, `useFlexibleDeposit` to accept optional `sponsored` parameter (backward compatible)
- **`frontend/lib/constants.ts`** — Added `MAX_DAILY_SPONSORSHIPS`, `MAX_PER_WALLET_SPONSORSHIPS`, `MIN_SPONSOR_BALANCE_XLM`
- **`frontend/.env.example`** — Added `NEXT_PUBLIC_SPONSOR_ADDRESS` and `SPONSOR_SECRET_KEY`

## Acceptance Criteria

- [x] First-time users see the sponsorship banner during deposit
- [x] Eligibility check correctly identifies new vs returning users (via Horizon soroban_meta check)
- [x] Fee bump transaction is constructed correctly and signed by sponsor
- [x] User signs the sponsored transaction without paying fees
- [x] Sponsor balance is checked before each sponsorship (circuit breaker)
- [x] Max 1 sponsorship per wallet is enforced
- [x] Max 100 sponsorships per day is enforced
- [x] Sponsor dashboard shows balance and usage stats (admin only)
- [x] Returning users do not see the sponsorship banner
- [x] If sponsor is out of funds, normal (non-sponsored) flow continues gracefully

## Setup

Add these env vars to `.env.local`:
```
NEXT_PUBLIC_SPONSOR_ADDRESS=G...
SPONSOR_SECRET_KEY=S...
```

The sponsor account must be funded with >= 10 XLM on testnet.

Closes #215