### PR TITLE
feat: add pool template system for reusable pool configurations (#226)

### DIFF
--- a/frontend/app/api/templates/[id]/route.ts
+++ b/frontend/app/api/templates/[id]/route.ts
@@ -1,0 +1,171 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getAdminClient } from "@/lib/supabase-admin"
+import { writeLimiter } from "@/lib/rate-limit"
+import {
+  validateTemplateName,
+  validateTemplateDescription,
+  isTemplatePoolType,
+  isTemplateConfig,
+} from "@/lib/templates"
+
+async function getTemplate(admin: ReturnType<typeof getAdminClient>, id: string) {
+  const { data, error } = await admin.from("pool_templates").select("*").eq("id", id).maybeSingle()
+  if (error) throw error
+  return data
+}
+
+/**
+ * PUT /api/templates/[id]
+ * Body (owner update): { wallet, name?, description?, pool_type?, config?, is_public? }
+ * Body (usage):        { incrementUse: true } — bumps use_count (anyone)
+ */
+export async function PUT(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const limited = writeLimiter(req)
+  if (limited) return limited
+
+  const { id } = await ctx.params
+
+  let body: Record<string, unknown>
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+  }
+
+  try {
+    const admin = getAdminClient()
+    const template = await getTemplate(admin, id)
+    if (!template) {
+      return NextResponse.json({ error: "Template not found" }, { status: 404 })
+    }
+
+    // Usage increment — no ownership requirement; a used template counts
+    // regardless of whether the caller is the creator or browsing community.
+    if (body.incrementUse === true) {
+      const { data, error } = await admin
+        .from("pool_templates")
+        .update({ use_count: template.use_count + 1 })
+        .eq("id", id)
+        .select()
+        .single()
+      if (error) throw error
+      return NextResponse.json(data)
+    }
+
+    const wallet = typeof body.wallet === "string" ? body.wallet.trim() : ""
+    if (!wallet) {
+      return NextResponse.json({ error: "wallet required" }, { status: 400 })
+    }
+    if (template.creator_address !== wallet.toLowerCase()) {
+      return NextResponse.json({ error: "Only the template owner can update it" }, { status: 403 })
+    }
+
+    const update: {
+      name?: string
+      description?: string | null
+      pool_type?: "rotational" | "target" | "flexible"
+      config?: Record<string, unknown>
+      is_public?: boolean
+    } = {}
+    if (body.name !== undefined) {
+      const nameResult = validateTemplateName(body.name)
+      if (!nameResult.valid)
+        return NextResponse.json({ error: nameResult.message }, { status: 400 })
+      update.name = (body.name as string).trim()
+    }
+    if (body.description !== undefined) {
+      const description = body.description as string | null
+      const descriptionResult = validateTemplateDescription(description)
+      if (!descriptionResult.valid) {
+        return NextResponse.json({ error: descriptionResult.message }, { status: 400 })
+      }
+      update.description = description === "" ? null : description
+    }
+    if (body.pool_type !== undefined) {
+      if (!isTemplatePoolType(body.pool_type)) {
+        return NextResponse.json(
+          { error: "pool_type must be rotational, target, or flexible" },
+          { status: 400 }
+        )
+      }
+      update.pool_type = body.pool_type
+    }
+    if (body.config !== undefined) {
+      if (!isTemplateConfig(body.config)) {
+        return NextResponse.json(
+          { error: "config must be a JSON object of pool creation parameters" },
+          { status: 400 }
+        )
+      }
+      update.config = body.config
+    }
+    if (body.is_public !== undefined) {
+      update.is_public = body.is_public === true
+    }
+
+    if (Object.keys(update).length === 0) {
+      return NextResponse.json({ error: "No valid fields to update" }, { status: 400 })
+    }
+
+    const { data, error } = await admin
+      .from("pool_templates")
+      .update(update)
+      .eq("id", id)
+      .select()
+      .single()
+    if (error) throw error
+
+    return NextResponse.json(data)
+  } catch (error) {
+    console.error("Template update error:", error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to update template" },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * DELETE /api/templates/[id]
+ * Body: { wallet } — owner only.
+ */
+export async function DELETE(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const limited = writeLimiter(req)
+  if (limited) return limited
+
+  const { id } = await ctx.params
+
+  let body: Record<string, unknown>
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+  }
+
+  const wallet = typeof body.wallet === "string" ? body.wallet.trim() : ""
+  if (!wallet) {
+    return NextResponse.json({ error: "wallet required" }, { status: 400 })
+  }
+
+  try {
+    const admin = getAdminClient()
+    const template = await getTemplate(admin, id)
+    if (!template) {
+      return NextResponse.json({ error: "Template not found" }, { status: 404 })
+    }
+    if (template.creator_address !== wallet.toLowerCase()) {
+      return NextResponse.json({ error: "Only the template owner can delete it" }, { status: 403 })
+    }
+
+    const { error } = await admin.from("pool_templates").delete().eq("id", id)
+    if (error) throw error
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error("Template delete error:", error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to delete template" },
+      { status: 500 }
+    )
+  }
+}

--- a/frontend/app/api/templates/community/route.ts
+++ b/frontend/app/api/templates/community/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getAdminClient } from "@/lib/supabase-admin"
+import { readLimiter } from "@/lib/rate-limit"
+import { jsonPrivate } from "@/lib/cache-headers"
+import { isTemplatePoolType } from "@/lib/templates"
+
+const COMMUNITY_PAGE_SIZE = 12
+
+/**
+ * GET /api/templates/community?pool_type=X&sort=popular|recent&page=N
+ * Public community feed of shared pool templates, optionally filtered by pool
+ * type and ordered by popularity (use_count) or recency.
+ */
+export async function GET(req: NextRequest) {
+  const limited = readLimiter(req)
+  if (limited) return limited
+
+  const poolType = req.nextUrl.searchParams.get("pool_type")
+  const sort = req.nextUrl.searchParams.get("sort") || "popular"
+  const page = Math.max(0, parseInt(req.nextUrl.searchParams.get("page") || "0", 10))
+  const from = page * COMMUNITY_PAGE_SIZE
+  const to = from + COMMUNITY_PAGE_SIZE - 1
+
+  try {
+    const admin = getAdminClient()
+    let query = admin.from("pool_templates").select("*", { count: "exact" }).eq("is_public", true)
+
+    if (poolType) {
+      if (!isTemplatePoolType(poolType)) {
+        return NextResponse.json({ error: "Invalid pool_type" }, { status: 400 })
+      }
+      query = query.eq("pool_type", poolType)
+    }
+
+    const orderColumn = sort === "recent" ? "created_at" : "use_count"
+    const { data, error, count } = await query
+      .order(orderColumn, { ascending: false })
+      .range(from, to)
+
+    if (error) throw error
+    return jsonPrivate({ data: data || [], total: count ?? 0, page, pageSize: COMMUNITY_PAGE_SIZE })
+  } catch (error) {
+    console.error("Template community fetch error:", error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to fetch templates" },
+      { status: 500 }
+    )
+  }
+}

--- a/frontend/app/api/templates/route.test.ts
+++ b/frontend/app/api/templates/route.test.ts
@@ -1,0 +1,94 @@
+import { test } from "node:test"
+import assert from "node:assert"
+import {
+  validateTemplateName,
+  validateTemplateDescription,
+  isTemplatePoolType,
+  isTemplateConfig,
+  TEMPLATE_NAME_MAX_LENGTH,
+  TEMPLATE_DESCRIPTION_MAX_LENGTH,
+} from "@/lib/templates"
+
+// ── validateTemplateName ─────────────────────────────────────────────────────
+
+test("templates — name is required", () => {
+  const result = validateTemplateName("")
+  assert.strictEqual(result.valid, false)
+  assert.strictEqual(result.message, "Template name is required")
+})
+
+test("templates — whitespace-only name is rejected", () => {
+  const result = validateTemplateName("   ")
+  assert.strictEqual(result.valid, false)
+})
+
+test("templates — non-string name is rejected", () => {
+  const result = validateTemplateName(42)
+  assert.strictEqual(result.valid, false)
+})
+
+test("templates — name over 50 chars is rejected", () => {
+  const result = validateTemplateName("x".repeat(TEMPLATE_NAME_MAX_LENGTH + 1))
+  assert.strictEqual(result.valid, false)
+})
+
+test("templates — 50-char name is accepted", () => {
+  const result = validateTemplateName("x".repeat(TEMPLATE_NAME_MAX_LENGTH))
+  assert.strictEqual(result.valid, true)
+})
+
+// ── validateTemplateDescription ──────────────────────────────────────────────
+
+test("templates — null description is accepted", () => {
+  const result = validateTemplateDescription(null)
+  assert.strictEqual(result.valid, true)
+})
+
+test("templates — empty description is accepted", () => {
+  const result = validateTemplateDescription("")
+  assert.strictEqual(result.valid, true)
+})
+
+test("templates — description over 200 chars is rejected", () => {
+  const result = validateTemplateDescription("y".repeat(TEMPLATE_DESCRIPTION_MAX_LENGTH + 1))
+  assert.strictEqual(result.valid, false)
+})
+
+test("templates — 200-char description is accepted", () => {
+  const result = validateTemplateDescription("y".repeat(TEMPLATE_DESCRIPTION_MAX_LENGTH))
+  assert.strictEqual(result.valid, true)
+})
+
+test("templates — non-string description is rejected", () => {
+  const result = validateTemplateDescription(123)
+  assert.strictEqual(result.valid, false)
+})
+
+// ── isTemplatePoolType ───────────────────────────────────────────────────────
+
+test("templates — valid pool types pass", () => {
+  assert.strictEqual(isTemplatePoolType("rotational"), true)
+  assert.strictEqual(isTemplatePoolType("target"), true)
+  assert.strictEqual(isTemplatePoolType("flexible"), true)
+})
+
+test("templates — invalid pool types fail", () => {
+  assert.strictEqual(isTemplatePoolType("other"), false)
+  assert.strictEqual(isTemplatePoolType(""), false)
+  assert.strictEqual(isTemplatePoolType(123), false)
+  assert.strictEqual(isTemplatePoolType(null), false)
+})
+
+// ── isTemplateConfig ─────────────────────────────────────────────────────────
+
+test("templates — plain object config passes", () => {
+  assert.strictEqual(isTemplateConfig({ name: "pool", members: [] }), true)
+})
+
+test("templates — null/array/primitive configs fail", () => {
+  assert.strictEqual(isTemplateConfig(null), false)
+  assert.strictEqual(isTemplateConfig(undefined), false)
+  assert.strictEqual(isTemplateConfig([]), false)
+  assert.strictEqual(isTemplateConfig("config"), false)
+  assert.strictEqual(isTemplateConfig(42), false)
+})

--- a/frontend/app/api/templates/route.ts
+++ b/frontend/app/api/templates/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getAdminClient } from "@/lib/supabase-admin"
+import { readLimiter, writeLimiter } from "@/lib/rate-limit"
+import { jsonPrivate } from "@/lib/cache-headers"
+import {
+  validateTemplateName,
+  validateTemplateDescription,
+  isTemplatePoolType,
+  isTemplateConfig,
+} from "@/lib/templates"
+
+/**
+ * POST /api/templates — save a new pool configuration as a reusable template.
+ * Body: { creator_address, name, description?, pool_type, config, is_public? }
+ */
+export async function POST(req: NextRequest) {
+  const limited = writeLimiter(req)
+  if (limited) return limited
+
+  let body: Record<string, unknown>
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+  }
+
+  const creatorAddress = typeof body.creator_address === "string" ? body.creator_address.trim() : ""
+  const name = body.name
+  const description = body.description == null ? null : body.description
+  const poolType = body.pool_type
+  const config = body.config
+  const isPublic = body.is_public === true
+
+  if (!creatorAddress) {
+    return NextResponse.json({ error: "creator_address required" }, { status: 400 })
+  }
+  const nameResult = validateTemplateName(name)
+  if (!nameResult.valid) {
+    return NextResponse.json({ error: nameResult.message }, { status: 400 })
+  }
+  const descriptionResult = validateTemplateDescription(description)
+  if (!descriptionResult.valid) {
+    return NextResponse.json({ error: descriptionResult.message }, { status: 400 })
+  }
+  if (!isTemplatePoolType(poolType)) {
+    return NextResponse.json(
+      { error: "pool_type must be rotational, target, or flexible" },
+      { status: 400 }
+    )
+  }
+  if (!isTemplateConfig(config)) {
+    return NextResponse.json(
+      { error: "config must be a JSON object of pool creation parameters" },
+      { status: 400 }
+    )
+  }
+
+  try {
+    const admin = getAdminClient()
+    const { data, error } = await admin
+      .from("pool_templates")
+      .insert({
+        creator_address: creatorAddress.toLowerCase(),
+        name: (name as string).trim(),
+        description: description === "" ? null : (description as string),
+        pool_type: poolType as "rotational" | "target" | "flexible",
+        config,
+        is_public: isPublic,
+      })
+      .select()
+      .single()
+
+    if (error) throw error
+
+    return NextResponse.json(data, { status: 201 })
+  } catch (error) {
+    console.error("Template create error:", error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to create template" },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * GET /api/templates
+ *   ?id=X      — fetch a single template (own or public)
+ *   ?wallet=X  — fetch the caller's templates
+ */
+export async function GET(req: NextRequest) {
+  const limited = readLimiter(req)
+  if (limited) return limited
+
+  const id = req.nextUrl.searchParams.get("id")
+  const wallet = req.nextUrl.searchParams.get("wallet")
+
+  try {
+    const admin = getAdminClient()
+
+    if (id) {
+      const { data, error } = await admin
+        .from("pool_templates")
+        .select("*")
+        .eq("id", id)
+        .maybeSingle()
+      if (error) throw error
+      if (!data) {
+        return NextResponse.json({ error: "Template not found" }, { status: 404 })
+      }
+      return jsonPrivate(data)
+    }
+
+    if (wallet) {
+      const { data, error } = await admin
+        .from("pool_templates")
+        .select("*")
+        .eq("creator_address", wallet.toLowerCase())
+        .order("created_at", { ascending: false })
+      if (error) throw error
+      return jsonPrivate({ data: data || [], total: data?.length ?? 0 })
+    }
+
+    return NextResponse.json({ error: "Specify id or wallet" }, { status: 400 })
+  } catch (error) {
+    console.error("Template fetch error:", error)
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to fetch templates" },
+      { status: 500 }
+    )
+  }
+}

--- a/frontend/app/dashboard/create/[type]/page.tsx
+++ b/frontend/app/dashboard/create/[type]/page.tsx
@@ -1,17 +1,20 @@
 "use client"
 
-import { use, useMemo } from "react"
-import { useSearchParams } from "next/navigation"
+import { use, useMemo, useEffect, useState } from "react"
+import { useSearchParams, useRouter } from "next/navigation"
 import { DashboardHeader } from "@/components/dashboard/dashboard-header"
 import { RotationalForm } from "@/components/create-group/rotational-form"
 import { TargetForm } from "@/components/create-group/target-form"
 import { FlexibleForm } from "@/components/create-group/flexible-form"
 import { Card } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { ArrowLeft } from "lucide-react"
+import { ArrowLeft, LayoutTemplate, Loader2, CopyPlus } from "lucide-react"
 import Link from "next/link"
 import { redirect } from "next/navigation"
 import { ErrorBoundary } from "@/components/error-boundary"
+import { useStellar } from "@/components/web3-provider"
+import { UseTemplateDialog } from "@/components/templates/use-template-dialog"
+import type { PoolTemplateConfig } from "@/lib/templates"
 
 const validTypes = ["rotational", "target", "flexible"]
 
@@ -25,13 +28,38 @@ export interface DuplicatePrefill {
   /** Flexible pool: minimum deposit per transaction */
   minimumDeposit: string
   frequency: string
+  /** Target pool: deadline in days from creation */
+  deadlineDays?: string
+  /** Flexible pool: withdrawal fee percent */
+  withdrawalFee?: string
+  /** Flexible pool: yield generation toggle */
+  enableYield?: boolean
   members: string[]
   token: string
+}
+
+/** Map a template's stored config onto the form prefill shape. */
+function configToPrefill(config: PoolTemplateConfig): DuplicatePrefill {
+  return {
+    name: config.name || "",
+    description: config.description || "",
+    amount: config.amount || "",
+    targetAmount: config.targetAmount || "",
+    minimumDeposit: config.minimumDeposit || "",
+    frequency: config.frequency || "",
+    deadlineDays: config.deadlineDays || "",
+    withdrawalFee: config.withdrawalFee || "",
+    enableYield: config.enableYield ?? false,
+    members: config.members || [],
+    token: config.token || "XLM",
+  }
 }
 
 export default function CreateGroupPage({ params }: { params: Promise<{ type: string }> }) {
   const { type } = use(params)
   const searchParams = useSearchParams()
+  const router = useRouter()
+  const { address } = useStellar()
 
   if (!validTypes.includes(type)) {
     redirect("/dashboard")
@@ -39,8 +67,47 @@ export default function CreateGroupPage({ params }: { params: Promise<{ type: st
 
   const isOnboarding = searchParams.get("onboarding") === "1"
   const isDuplicate = searchParams.get("duplicate") === "1"
+  const isCreateTemplate = searchParams.get("createTemplate") === "1"
+  const templateId = searchParams.get("template")
+
+  const [useTemplateOpen, setUseTemplateOpen] = useState(false)
+  const [templatePrefill, setTemplatePrefill] = useState<DuplicatePrefill | null>(null)
+  const [templateLoading, setTemplateLoading] = useState(false)
+  const [templateError, setTemplateError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!templateId) {
+      setTemplatePrefill(null)
+      setTemplateError(null)
+      return
+    }
+    let cancelled = false
+    setTemplateLoading(true)
+    setTemplateError(null)
+    fetch(`/api/templates?id=${encodeURIComponent(templateId)}`)
+      .then(async (res) => {
+        if (!res.ok) throw new Error("Template not found")
+        const template = await res.json()
+        if (cancelled) return
+        if (template.pool_type !== type) {
+          router.replace(`/dashboard/create/${template.pool_type}?template=${template.id}`)
+          return
+        }
+        setTemplatePrefill(configToPrefill(template.config))
+      })
+      .catch((error) => {
+        if (!cancelled) setTemplateError((error as Error).message || "Failed to load template")
+      })
+      .finally(() => {
+        if (!cancelled) setTemplateLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [templateId, type, router])
 
   const prefill: DuplicatePrefill | undefined = useMemo(() => {
+    if (templateId) return templatePrefill ?? undefined
     if (!isDuplicate && !isOnboarding) return undefined
     try {
       const membersRaw = searchParams.get("members")
@@ -58,7 +125,7 @@ export default function CreateGroupPage({ params }: { params: Promise<{ type: st
     } catch {
       return undefined
     }
-  }, [searchParams, isDuplicate, isOnboarding])
+  }, [searchParams, isDuplicate, isOnboarding, templateId, templatePrefill])
 
   const titles = {
     rotational: "Create Rotational Savings Group",
@@ -80,27 +147,108 @@ export default function CreateGroupPage({ params }: { params: Promise<{ type: st
             </Button>
 
             <Card className="p-8">
-              <h1 className="text-3xl font-bold mb-2">
-                {isDuplicate && prefill
-                  ? `New Cycle: ${prefill.name}`
-                  : isOnboarding
-                    ? `Create your ${type} pool`
-                    : titles[type as keyof typeof titles]}
-              </h1>
-              <p className="text-muted-foreground mb-8">
-                {isDuplicate
-                  ? "Pre-filled from the original pool. Edit any values before creating."
-                  : isOnboarding
-                    ? "Smart defaults pre-filled from the onboarding wizard — review and edit before creating."
-                    : "Fill in the details to create your savings group"}
-              </p>
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <h1 className="text-3xl font-bold mb-2">
+                    {templateId && templatePrefill
+                      ? `New Pool from Template: ${templatePrefill.name}`
+                      : isDuplicate && prefill
+                        ? `New Cycle: ${prefill.name}`
+                        : isOnboarding
+                          ? `Create your ${type} pool`
+                          : titles[type as keyof typeof titles]}
+                  </h1>
+                  <p className="text-muted-foreground mb-4">
+                    {templateId && templatePrefill
+                      ? "Pre-filled from a template. Edit any values before creating."
+                      : isCreateTemplate
+                        ? "Fill in the details below, then use \u201CSave as Template\u201D to store this configuration for reuse."
+                        : isDuplicate
+                          ? "Pre-filled from the original pool. Edit any values before creating."
+                          : isOnboarding
+                            ? "Smart defaults pre-filled from the onboarding wizard — review and edit before creating."
+                            : "Fill in the details to create your savings group"}
+                  </p>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="shrink-0"
+                  onClick={() => setUseTemplateOpen(true)}
+                >
+                  <LayoutTemplate className="h-4 w-4 mr-1" />
+                  Use Template
+                </Button>
+              </div>
 
-              {type === "rotational" && <RotationalForm prefill={prefill} />}
-              {type === "target" && <TargetForm prefill={prefill} />}
-              {type === "flexible" && <FlexibleForm prefill={prefill} />}
+              {templateId && templateLoading && (
+                <div className="flex items-center gap-2 text-muted-foreground mb-6">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Loading template…
+                </div>
+              )}
+
+              {templateId && templateError && (
+                <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 mb-6">
+                  <p className="text-sm text-destructive">
+                    {templateError}.{" "}
+                    <Link href="/dashboard/templates" className="underline">
+                      Browse templates
+                    </Link>{" "}
+                    instead.
+                  </p>
+                </div>
+              )}
+
+              {isCreateTemplate && !templateId && (
+                <div className="flex items-start gap-2 p-3 rounded-lg bg-primary/5 border border-primary/20 text-sm text-muted-foreground mb-6">
+                  <CopyPlus className="h-4 w-4 mt-0.5 shrink-0 text-primary" />
+                  <span>
+                    You're building a reusable template. Fill in the configuration below and click{" "}
+                    <strong>"Save as Template"</strong> to store it — no pool contract is deployed.
+                  </span>
+                </div>
+              )}
+
+              {templateId && templatePrefill && (
+                <div className="flex items-start gap-2 p-3 rounded-lg bg-primary/5 border border-primary/20 text-sm text-muted-foreground mb-6">
+                  <CopyPlus className="h-4 w-4 mt-0.5 shrink-0 text-primary" />
+                  <span>
+                    Pre-filled from template "{templatePrefill.name}" — all values are editable.
+                    Submitting will deploy a <strong>new, independent contract</strong>.
+                  </span>
+                </div>
+              )}
+
+              {templateLoading ? (
+                <div className="space-y-4">
+                  {[0, 1, 2, 3].map((i) => (
+                    <div key={i} className="h-12 rounded-lg bg-muted/40 animate-pulse" />
+                  ))}
+                </div>
+              ) : (
+                <>
+                  {type === "rotational" && (
+                    <RotationalForm key={templateId ?? "default"} prefill={prefill} />
+                  )}
+                  {type === "target" && (
+                    <TargetForm key={templateId ?? "default"} prefill={prefill} />
+                  )}
+                  {type === "flexible" && (
+                    <FlexibleForm key={templateId ?? "default"} prefill={prefill} />
+                  )}
+                </>
+              )}
             </Card>
           </div>
         </main>
+
+        <UseTemplateDialog
+          open={useTemplateOpen}
+          onOpenChange={setUseTemplateOpen}
+          poolType={type as "rotational" | "target" | "flexible"}
+          address={address}
+        />
       </div>
     </ErrorBoundary>
   )

--- a/frontend/app/dashboard/templates/page.tsx
+++ b/frontend/app/dashboard/templates/page.tsx
@@ -1,0 +1,358 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { useStellar } from "@/components/web3-provider"
+import { DashboardHeader } from "@/components/dashboard/dashboard-header"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { ErrorBoundary } from "@/components/error-boundary"
+import { CreateTemplateDialog } from "@/components/templates/create-template-dialog"
+import { EditTemplateDialog } from "@/components/templates/edit-template-dialog"
+import { toastManager } from "@/lib/toast"
+import { formatRelativeTime } from "@/lib/utils"
+import { type PoolTemplate, type TemplatePoolType, TEMPLATE_POOL_TYPES } from "@/lib/templates"
+import { Plus, LayoutTemplate, Users, Repeat, Pencil, Trash2, ExternalLink } from "lucide-react"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+const POOL_TYPE_LABELS: Record<TemplatePoolType, string> = {
+  rotational: "Rotational",
+  target: "Target",
+  flexible: "Flexible",
+}
+
+function TemplateCard({
+  template,
+  showOwnerActions,
+  onUse,
+  onEdit,
+  onDelete,
+}: {
+  template: PoolTemplate
+  showOwnerActions: boolean
+  onUse: (template: PoolTemplate) => void
+  onEdit: (template: PoolTemplate) => void
+  onDelete: (template: PoolTemplate) => void
+}) {
+  const config = template.config
+  const memberCount = config.members?.length ? config.members.length + 1 : null
+  const primaryAmount =
+    template.pool_type === "rotational"
+      ? config.amount
+      : template.pool_type === "target"
+        ? config.targetAmount
+        : config.minimumDeposit
+
+  return (
+    <div className="flex flex-col gap-4 rounded-xl border border-border p-5 sm:flex-row sm:items-center sm:justify-between">
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <h3 className="font-semibold truncate">{template.name}</h3>
+          <Badge variant="secondary" className="text-[10px] capitalize">
+            {POOL_TYPE_LABELS[template.pool_type]}
+          </Badge>
+          {template.is_public && (
+            <Badge variant="outline" className="text-[10px]">
+              Public
+            </Badge>
+          )}
+        </div>
+
+        {template.description && (
+          <p className="text-sm text-muted-foreground mt-1">{template.description}</p>
+        )}
+
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground mt-2">
+          {primaryAmount && (
+            <span>
+              {template.pool_type === "target" ? "Goal" : "Amount"}: {primaryAmount} XLM
+            </span>
+          )}
+          <span className="flex items-center gap-1">
+            <Users className="h-3 w-3" />
+            {memberCount ?? "—"} members
+          </span>
+          <span className="flex items-center gap-1">
+            <Repeat className="h-3 w-3" />
+            used {template.use_count}×
+          </span>
+          <span>created {formatRelativeTime(new Date(template.created_at))}</span>
+        </div>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-2">
+        <Button size="sm" variant="outline" onClick={() => onUse(template)}>
+          <ExternalLink className="h-4 w-4 mr-1" />
+          Use Template
+        </Button>
+        {showOwnerActions && (
+          <>
+            <Button size="sm" variant="ghost" onClick={() => onEdit(template)} aria-label="Edit">
+              <Pencil className="h-4 w-4" />
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => onDelete(template)}
+              aria-label="Delete"
+              className="text-destructive hover:text-destructive"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function TemplatesPageContent() {
+  const { address, isConnected, isInitializing } = useStellar()
+  const router = useRouter()
+
+  const [activeTab, setActiveTab] = useState("mine")
+  const [communityPoolType, setCommunityPoolType] = useState<string>("all")
+  const [communitySort, setCommunitySort] = useState<string>("popular")
+
+  const [mine, setMine] = useState<PoolTemplate[]>([])
+  const [community, setCommunity] = useState<PoolTemplate[]>([])
+  const [mineLoading, setMineLoading] = useState(false)
+  const [communityLoading, setCommunityLoading] = useState(false)
+
+  const [createOpen, setCreateOpen] = useState(false)
+  const [editing, setEditing] = useState<PoolTemplate | null>(null)
+
+  useEffect(() => {
+    if (!isInitializing && !isConnected) {
+      router.replace("/")
+    }
+  }, [isInitializing, isConnected, router])
+
+  const loadMine = useCallback(async () => {
+    if (!address) return
+    setMineLoading(true)
+    try {
+      const res = await fetch(`/api/templates?wallet=${encodeURIComponent(address.toLowerCase())}`)
+      const data = res.ok ? await res.json() : { data: [] }
+      setMine(data.data || [])
+    } finally {
+      setMineLoading(false)
+    }
+  }, [address])
+
+  const loadCommunity = useCallback(async () => {
+    setCommunityLoading(true)
+    try {
+      const params = new URLSearchParams()
+      if (communityPoolType !== "all") params.set("pool_type", communityPoolType)
+      params.set("sort", communitySort)
+      params.set("page", "0")
+      const res = await fetch(`/api/templates/community?${params.toString()}`)
+      const data = res.ok ? await res.json() : { data: [] }
+      setCommunity(data.data || [])
+    } finally {
+      setCommunityLoading(false)
+    }
+  }, [communityPoolType, communitySort])
+
+  useEffect(() => {
+    loadMine()
+  }, [loadMine])
+
+  useEffect(() => {
+    loadCommunity()
+  }, [loadCommunity])
+
+  const handleUse = async (template: PoolTemplate) => {
+    if (!address) {
+      toastManager.error("Connect your wallet to use a template")
+      return
+    }
+    await fetch(`/api/templates/${template.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", "x-wallet-address": address },
+      body: JSON.stringify({ incrementUse: true }),
+    }).catch(() => {})
+    router.push(`/dashboard/create/${template.pool_type}?template=${template.id}`)
+  }
+
+  const handleDelete = async (template: PoolTemplate) => {
+    if (!address) return
+    if (!window.confirm(`Delete template "${template.name}"?`)) return
+    try {
+      const res = await fetch(`/api/templates/${template.id}`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json", "x-wallet-address": address },
+        body: JSON.stringify({ wallet: address }),
+      })
+      if (!res.ok) throw new Error("Failed to delete template")
+      toastManager.success("Template deleted")
+      await Promise.all([loadMine(), loadCommunity()])
+    } catch (error) {
+      toastManager.error((error as Error).message || "Failed to delete template")
+    }
+  }
+
+  if (isInitializing || !isConnected) {
+    return null
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <DashboardHeader />
+      <main className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="max-w-4xl mx-auto">
+          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-8">
+            <div>
+              <h1 className="text-3xl font-bold flex items-center gap-2">
+                <LayoutTemplate className="h-7 w-7 text-primary" />
+                Pool Templates
+              </h1>
+              <p className="text-muted-foreground mt-1">
+                Save pool configurations to reuse them, or browse templates shared by the community.
+              </p>
+            </div>
+            <Button onClick={() => setCreateOpen(true)} className="shrink-0">
+              <Plus className="h-4 w-4 mr-1" />
+              Create Template
+            </Button>
+          </div>
+
+          <Tabs value={activeTab} onValueChange={setActiveTab}>
+            <TabsList className="grid w-full grid-cols-2 mb-6">
+              <TabsTrigger value="mine">My Templates</TabsTrigger>
+              <TabsTrigger value="community">Community Templates</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="mine" className="mt-0">
+              {mineLoading ? (
+                <div className="space-y-3">
+                  {[0, 1, 2].map((i) => (
+                    <Skeleton key={i} className="h-24 w-full" />
+                  ))}
+                </div>
+              ) : mine.length === 0 ? (
+                <div className="rounded-xl border border-dashed border-border p-10 text-center">
+                  <LayoutTemplate className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
+                  <p className="font-medium">No templates yet</p>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    Create a template from scratch, or save a configuration using the{" "}
+                    <span className="font-medium">"Save as Template"</span> link when creating a
+                    pool.
+                  </p>
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {mine.map((template) => (
+                    <TemplateCard
+                      key={template.id}
+                      template={template}
+                      showOwnerActions
+                      onUse={handleUse}
+                      onEdit={(t) => setEditing(t)}
+                      onDelete={handleDelete}
+                    />
+                  ))}
+                </div>
+              )}
+            </TabsContent>
+
+            <TabsContent value="community" className="mt-0">
+              <div className="flex flex-col sm:flex-row gap-3 mb-4">
+                <Select value={communityPoolType} onValueChange={setCommunityPoolType}>
+                  <SelectTrigger className="w-full sm:w-48">
+                    <SelectValue placeholder="All types" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All types</SelectItem>
+                    {TEMPLATE_POOL_TYPES.map((t) => (
+                      <SelectItem key={t} value={t}>
+                        {POOL_TYPE_LABELS[t]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Select value={communitySort} onValueChange={setCommunitySort}>
+                  <SelectTrigger className="w-full sm:w-48">
+                    <SelectValue placeholder="Sort" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="popular">Most popular</SelectItem>
+                    <SelectItem value="recent">Most recent</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {communityLoading ? (
+                <div className="space-y-3">
+                  {[0, 1, 2].map((i) => (
+                    <Skeleton key={i} className="h-24 w-full" />
+                  ))}
+                </div>
+              ) : community.length === 0 ? (
+                <div className="rounded-xl border border-dashed border-border p-10 text-center">
+                  <LayoutTemplate className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
+                  <p className="font-medium">No community templates yet</p>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    Be the first to share one — mark a template as public when saving it.
+                  </p>
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {community.map((template) => (
+                    <TemplateCard
+                      key={template.id}
+                      template={template}
+                      showOwnerActions={template.creator_address === address?.toLowerCase()}
+                      onUse={handleUse}
+                      onEdit={(t) => setEditing(t)}
+                      onDelete={handleDelete}
+                    />
+                  ))}
+                </div>
+              )}
+            </TabsContent>
+          </Tabs>
+        </div>
+      </main>
+
+      <CreateTemplateDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        address={address}
+        onSaved={() => {
+          loadMine()
+          loadCommunity()
+        }}
+      />
+      <EditTemplateDialog
+        template={editing}
+        open={editing !== null}
+        onOpenChange={(open) => {
+          if (!open) setEditing(null)
+        }}
+        address={address}
+        onSaved={() => {
+          loadMine()
+          loadCommunity()
+        }}
+      />
+    </div>
+  )
+}
+
+export default function TemplatesPage() {
+  return (
+    <ErrorBoundary sectionName="Templates">
+      <TemplatesPageContent />
+    </ErrorBoundary>
+  )
+}

--- a/frontend/components/create-group/flexible-form.tsx
+++ b/frontend/components/create-group/flexible-form.tsx
@@ -14,7 +14,11 @@ import {
   useRegisterPool,
   resolveTokenAddress,
 } from "@/hooks/useJointSaveContracts"
-import { TokenSelect, type SelectedToken } from "@/components/create-group/token-select"
+import {
+  TokenSelect,
+  tokenFromPrefill,
+  type SelectedToken,
+} from "@/components/create-group/token-select"
 import { FieldTooltip } from "@/components/ui/field-tooltip"
 import { FieldError } from "@/components/ui/form"
 import { FormProgress, type ProgressField } from "@/components/ui/form-progress"
@@ -28,7 +32,10 @@ import {
 } from "@/lib/form-validation"
 import { MAX_POOL_MEMBERS, DEFAULT_TREASURY_FEE_BPS } from "@/lib/constants"
 import type { DuplicatePrefill } from "@/app/dashboard/create/[type]/page"
+import type { PoolTemplateConfig } from "@/lib/templates"
+import { SaveTemplateDialog } from "@/components/templates/save-template-dialog"
 import { toastManager } from "@/lib/toast"
+import { LayoutTemplate } from "lucide-react"
 
 function isValidStellarAddress(addr: string) {
   return /^G[A-Z2-7]{55}$/.test(addr)
@@ -42,11 +49,10 @@ type Touched = Partial<Record<"name" | "minimumDeposit" | "withdrawalFee", boole
 export function FlexibleForm({ prefill }: { prefill?: DuplicatePrefill }) {
   const router = useRouter()
   const { address } = useStellar()
-  const [token, setToken] = useState<SelectedToken>({
-    address: "native",
-    symbol: prefill?.token || "XLM",
-    decimals: 7,
-  })
+  const [token, setToken] = useState<SelectedToken>(
+    tokenFromPrefill(prefill?.token) ?? { address: "native", symbol: "XLM", decimals: 7 }
+  )
+  const [saveTemplateOpen, setSaveTemplateOpen] = useState(false)
   const initialMembers = prefill?.members?.filter((m: string) => m !== address) ?? [""]
   const [members, setMembers] = useState<string[]>(
     initialMembers.length > 0 ? initialMembers : [""]
@@ -58,8 +64,8 @@ export function FlexibleForm({ prefill }: { prefill?: DuplicatePrefill }) {
     name: prefill?.name || "",
     description: prefill?.description || "",
     minimumDeposit: prefill?.minimumDeposit || "",
-    enableYield: false,
-    withdrawalFee: "1",
+    enableYield: prefill?.enableYield ?? false,
+    withdrawalFee: prefill?.withdrawalFee || "1",
   })
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({})
   const [touched, setTouched] = useState<Touched>({})
@@ -207,6 +213,18 @@ export function FlexibleForm({ prefill }: { prefill?: DuplicatePrefill }) {
     { label: "Members (2+)", valid: validMembers.length >= 2 },
   ]
 
+  const templateToken = token.address === "native" ? "XLM" : token.address
+  const templateConfig: PoolTemplateConfig = {
+    name: formData.name,
+    description: formData.description || null,
+    poolType: "flexible",
+    minimumDeposit: formData.minimumDeposit,
+    withdrawalFee: formData.withdrawalFee,
+    enableYield: formData.enableYield,
+    members: validMembers,
+    token: templateToken,
+  }
+
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
       {isCreating && (
@@ -279,7 +297,7 @@ export function FlexibleForm({ prefill }: { prefill?: DuplicatePrefill }) {
         />
       </div>
 
-      <TokenSelect onChange={setToken} />
+      <TokenSelect onChange={setToken} defaultToken={tokenFromPrefill(prefill?.token)} />
       {/* Bulk Import Component */}
       <BulkImport onMembersChange={setMembers} />
 
@@ -455,7 +473,24 @@ export function FlexibleForm({ prefill }: { prefill?: DuplicatePrefill }) {
             "Create Flexible Pool"
           )}
         </Button>
+
+        <button
+          type="button"
+          onClick={() => setSaveTemplateOpen(true)}
+          disabled={isCreating}
+          className="w-full mt-2 flex items-center justify-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors"
+        >
+          <LayoutTemplate className="h-4 w-4" />
+          Save as Template
+        </button>
       </div>
+
+      <SaveTemplateDialog
+        open={saveTemplateOpen}
+        onOpenChange={setSaveTemplateOpen}
+        config={templateConfig}
+        creatorAddress={address}
+      />
     </form>
   )
 }

--- a/frontend/components/create-group/rotational-form.tsx
+++ b/frontend/components/create-group/rotational-form.tsx
@@ -22,7 +22,11 @@ import {
   useSetReputationTracker,
   resolveTokenAddress,
 } from "@/hooks/useJointSaveContracts"
-import { TokenSelect, type SelectedToken } from "@/components/create-group/token-select"
+import {
+  TokenSelect,
+  tokenFromPrefill,
+  type SelectedToken,
+} from "@/components/create-group/token-select"
 import BulkImport from "@/components/create-group/BulkImport"
 import { FieldTooltip } from "@/components/ui/field-tooltip"
 import { FieldError } from "@/components/ui/form"
@@ -34,12 +38,15 @@ import {
   findDuplicateAddresses,
 } from "@/lib/form-validation"
 import type { DuplicatePrefill } from "@/app/dashboard/create/[type]/page"
+import type { PoolTemplateConfig } from "@/lib/templates"
+import { SaveTemplateDialog } from "@/components/templates/save-template-dialog"
 import {
   MAX_POOL_MEMBERS,
   DEFAULT_TREASURY_FEE_BPS,
   DEFAULT_RELAYER_FEE_BPS,
 } from "@/lib/constants"
 import { toastManager } from "@/lib/toast"
+import { LayoutTemplate } from "lucide-react"
 
 function isValidStellarAddress(addr: string) {
   return /^G[A-Z2-7]{55}$/.test(addr)
@@ -61,11 +68,10 @@ type Touched = Partial<Record<"name" | "contributionAmount", boolean>>
 export function RotationalForm({ prefill }: { prefill?: DuplicatePrefill }) {
   const router = useRouter()
   const { address } = useStellar()
-  const [token, setToken] = useState<SelectedToken>({
-    address: "native",
-    symbol: "XLM",
-    decimals: 7,
-  })
+  const [token, setToken] = useState<SelectedToken>(
+    tokenFromPrefill(prefill?.token) ?? { address: "native", symbol: "XLM", decimals: 7 }
+  )
+  const [saveTemplateOpen, setSaveTemplateOpen] = useState(false)
   // Creator is always the first member (read-only), others are editable
   const initialMembers = prefill?.members?.filter((m: string) => m !== address) ?? [""]
   const [members, setMembers] = useState<string[]>(
@@ -236,6 +242,17 @@ export function RotationalForm({ prefill }: { prefill?: DuplicatePrefill }) {
     { label: "Members (2+)", valid: validMembers.length >= 2 },
   ]
 
+  const templateToken = token.address === "native" ? "XLM" : token.address
+  const templateConfig: PoolTemplateConfig = {
+    name: formData.name,
+    description: formData.description || null,
+    poolType: "rotational",
+    amount: formData.contributionAmount,
+    frequency: formData.frequency,
+    members: validMembers,
+    token: templateToken,
+  }
+
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
       {isCreating && (
@@ -299,7 +316,7 @@ export function RotationalForm({ prefill }: { prefill?: DuplicatePrefill }) {
         />
       </div>
 
-      <TokenSelect onChange={setToken} />
+      <TokenSelect onChange={setToken} defaultToken={tokenFromPrefill(prefill?.token)} />
       {/* Bulk Import Component */}
       <BulkImport onMembersChange={setMembers} />
 
@@ -459,7 +476,24 @@ export function RotationalForm({ prefill }: { prefill?: DuplicatePrefill }) {
             "Create Rotational Group"
           )}
         </Button>
+
+        <button
+          type="button"
+          onClick={() => setSaveTemplateOpen(true)}
+          disabled={isCreating}
+          className="w-full mt-2 flex items-center justify-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors"
+        >
+          <LayoutTemplate className="h-4 w-4" />
+          Save as Template
+        </button>
       </div>
+
+      <SaveTemplateDialog
+        open={saveTemplateOpen}
+        onOpenChange={setSaveTemplateOpen}
+        config={templateConfig}
+        creatorAddress={address}
+      />
     </form>
   )
 }

--- a/frontend/components/create-group/target-form.tsx
+++ b/frontend/components/create-group/target-form.tsx
@@ -15,7 +15,11 @@ import {
   getRpc,
   resolveTokenAddress,
 } from "@/hooks/useJointSaveContracts"
-import { TokenSelect, type SelectedToken } from "@/components/create-group/token-select"
+import {
+  TokenSelect,
+  tokenFromPrefill,
+  type SelectedToken,
+} from "@/components/create-group/token-select"
 import BulkImport from "@/components/create-group/BulkImport"
 import { FieldTooltip } from "@/components/ui/field-tooltip"
 import { FieldError } from "@/components/ui/form"
@@ -28,7 +32,10 @@ import {
 } from "@/lib/form-validation"
 import { MAX_POOL_MEMBERS, MAX_DEADLINE_DAYS } from "@/lib/constants"
 import type { DuplicatePrefill } from "@/app/dashboard/create/[type]/page"
+import type { PoolTemplateConfig } from "@/lib/templates"
+import { SaveTemplateDialog } from "@/components/templates/save-template-dialog"
 import { toastManager } from "@/lib/toast"
+import { LayoutTemplate } from "lucide-react"
 
 function isValidStellarAddress(addr: string) {
   return /^G[A-Z2-7]{55}$/.test(addr)
@@ -47,11 +54,10 @@ type Touched = Partial<Record<"name" | "targetAmount" | "deadlineDays", boolean>
 export function TargetForm({ prefill }: { prefill?: DuplicatePrefill }) {
   const router = useRouter()
   const { address } = useStellar()
-  const [token, setToken] = useState<SelectedToken>({
-    address: "native",
-    symbol: prefill?.token || "XLM",
-    decimals: 7,
-  })
+  const [token, setToken] = useState<SelectedToken>(
+    tokenFromPrefill(prefill?.token) ?? { address: "native", symbol: "XLM", decimals: 7 }
+  )
+  const [saveTemplateOpen, setSaveTemplateOpen] = useState(false)
   const initialMembers = prefill?.members?.filter((m: string) => m !== address) ?? [""]
   const [members, setMembers] = useState<string[]>(
     initialMembers.length > 0 ? initialMembers : [""]
@@ -63,7 +69,7 @@ export function TargetForm({ prefill }: { prefill?: DuplicatePrefill }) {
     name: prefill?.name || "",
     description: prefill?.description || "",
     targetAmount: prefill?.targetAmount || "",
-    deadlineDays: "",
+    deadlineDays: prefill?.deadlineDays || "",
   })
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({})
   const [touched, setTouched] = useState<Touched>({})
@@ -245,6 +251,17 @@ export function TargetForm({ prefill }: { prefill?: DuplicatePrefill }) {
     { label: "Members (2+)", valid: validMembers.length >= 2 },
   ]
 
+  const templateToken = token.address === "native" ? "XLM" : token.address
+  const templateConfig: PoolTemplateConfig = {
+    name: formData.name,
+    description: formData.description || null,
+    poolType: "target",
+    targetAmount: formData.targetAmount,
+    deadlineDays: formData.deadlineDays,
+    members: validMembers,
+    token: templateToken,
+  }
+
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
       {isCreating && (
@@ -317,7 +334,7 @@ export function TargetForm({ prefill }: { prefill?: DuplicatePrefill }) {
         />
       </div>
 
-      <TokenSelect onChange={setToken} />
+      <TokenSelect onChange={setToken} defaultToken={tokenFromPrefill(prefill?.token)} />
       {/* Bulk Import Component */}
       <BulkImport onMembersChange={setMembers} />
 
@@ -486,7 +503,24 @@ export function TargetForm({ prefill }: { prefill?: DuplicatePrefill }) {
             "Create Target Pool"
           )}
         </Button>
+
+        <button
+          type="button"
+          onClick={() => setSaveTemplateOpen(true)}
+          disabled={isCreating}
+          className="w-full mt-2 flex items-center justify-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors"
+        >
+          <LayoutTemplate className="h-4 w-4" />
+          Save as Template
+        </button>
       </div>
+
+      <SaveTemplateDialog
+        open={saveTemplateOpen}
+        onOpenChange={setSaveTemplateOpen}
+        config={templateConfig}
+        creatorAddress={address}
+      />
     </form>
   )
 }

--- a/frontend/components/create-group/token-select.tsx
+++ b/frontend/components/create-group/token-select.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { Input } from "@/components/ui/input"
 import {
   Select,
@@ -34,6 +34,19 @@ const isValidContractId = (id: string) => /^C[A-Z2-7]{55}$/.test(id)
 type TokenMode = "native" | "usdc" | "custom"
 
 /**
+ * Map a template/duplicate prefill token string ("XLM", "USDC", or a SEP-41
+ * contract id) to the `SelectedToken` a creation form seeds its state with.
+ * Returns undefined when the value can't be mapped to a known token.
+ */
+export function tokenFromPrefill(token: string | undefined): SelectedToken | undefined {
+  if (!token) return undefined
+  if (token === "XLM") return NATIVE
+  if (token === "USDC") return USDC
+  if (isValidContractId(token)) return { address: token, symbol: "CUSTOM", decimals: 7 }
+  return undefined
+}
+
+/**
  * Token picker shared by all three creation forms. Defaults to native XLM;
  * "USDC" uses the well-known registry entry from `lib/token-utils` directly
  * (see the bridge tutorial at /bridge for getting USDC onto Stellar first).
@@ -41,13 +54,51 @@ type TokenMode = "native" | "usdc" | "custom"
  * view call and reports the resolved `SelectedToken` to the parent. The
  * parent should also seed its own state to native XLM so submit works
  * without interaction.
+ *
+ * Pass an optional `defaultToken` (e.g. from a template) to have the picker
+ * reflect a pre-filled token instead of defaulting to XLM.
  */
-export function TokenSelect({ onChange }: { onChange: (token: SelectedToken) => void }) {
+export function TokenSelect({
+  onChange,
+  defaultToken,
+}: {
+  onChange: (token: SelectedToken) => void
+  defaultToken?: SelectedToken
+}) {
   const [mode, setMode] = useState<TokenMode>("native")
   const [customId, setCustomId] = useState("")
   const [status, setStatus] = useState<"idle" | "loading" | "ok" | "error">("idle")
   const [meta, setMeta] = useState<TokenMetadata | null>(null)
   const [error, setError] = useState("")
+
+  // Reflect a pre-filled token (from a template) on mount.
+  useEffect(() => {
+    if (!defaultToken) return
+    if (defaultToken.address === "native") {
+      setMode("native")
+      onChange(NATIVE)
+    } else if (defaultToken.address === USDC.address) {
+      setMode("usdc")
+      onChange(USDC)
+    } else if (isValidContractId(defaultToken.address)) {
+      setMode("custom")
+      setCustomId(defaultToken.address)
+      fetchTokenMetadata(defaultToken.address)
+        .then((m) => {
+          setMeta(m)
+          setStatus("ok")
+          onChange({
+            address: defaultToken.address,
+            symbol: m.symbol,
+            decimals: m.decimals,
+          })
+        })
+        .catch(() => {
+          setStatus("error")
+          setError("Couldn't read this token — is it a valid SEP-41 contract?")
+        })
+    }
+  }, [defaultToken, onChange])
 
   const handleMode = (v: string) => {
     const next = v as TokenMode

--- a/frontend/components/dashboard/dashboard-header.tsx
+++ b/frontend/components/dashboard/dashboard-header.tsx
@@ -85,6 +85,9 @@ export function DashboardHeader() {
               <Link href="/explore">Explore</Link>
             </Button>
             <Button variant="ghost" size="sm" asChild className="hidden lg:flex">
+              <Link href="/dashboard/templates">Templates</Link>
+            </Button>
+            <Button variant="ghost" size="sm" asChild className="hidden lg:flex">
               <Link href="/bridge">Bridge USDC</Link>
             </Button>
             <ThemeToggle />

--- a/frontend/components/templates/create-template-dialog.tsx
+++ b/frontend/components/templates/create-template-dialog.tsx
@@ -1,0 +1,366 @@
+"use client"
+
+import { useState } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { FieldError } from "@/components/ui/form"
+import { Loader2 } from "lucide-react"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { toastManager } from "@/lib/toast"
+import {
+  type PoolTemplateConfig,
+  type TemplatePoolType,
+  validateTemplateName,
+  validateTemplateDescription,
+  TEMPLATE_NAME_MAX_LENGTH,
+  TEMPLATE_DESCRIPTION_MAX_LENGTH,
+} from "@/lib/templates"
+
+const POOL_TYPE_LABELS: Record<TemplatePoolType, string> = {
+  rotational: "Rotational Savings",
+  target: "Target Pool",
+  flexible: "Flexible Pool",
+}
+
+const FREQUENCIES = [
+  { value: "daily", label: "Daily" },
+  { value: "weekly", label: "Weekly" },
+  { value: "biweekly", label: "Bi-weekly" },
+  { value: "monthly", label: "Monthly" },
+]
+
+/**
+ * "Create Template" dialog on the templates page (issue #226). Lets a user
+ * build a reusable template from scratch without first creating a pool.
+ */
+export function CreateTemplateDialog({
+  open,
+  onOpenChange,
+  address,
+  onSaved,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  address: string | null
+  onSaved: () => void
+}) {
+  const [name, setName] = useState("")
+  const [description, setDescription] = useState("")
+  const [poolType, setPoolType] = useState<TemplatePoolType>("rotational")
+  const [amount, setAmount] = useState("")
+  const [targetAmount, setTargetAmount] = useState("")
+  const [minimumDeposit, setMinimumDeposit] = useState("")
+  const [frequency, setFrequency] = useState("weekly")
+  const [withdrawalFee, setWithdrawalFee] = useState("1")
+  const [enableYield, setEnableYield] = useState(false)
+  const [deadlineDays, setDeadlineDays] = useState("")
+  const [membersText, setMembersText] = useState("")
+  const [isPublic, setIsPublic] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [errors, setErrors] = useState<{ name?: string; description?: string }>({})
+
+  const handleSave = async () => {
+    if (!address) {
+      toastManager.error("Connect your wallet before creating a template")
+      return
+    }
+    const nameResult = validateTemplateName(name)
+    const descriptionResult = validateTemplateDescription(description)
+    setErrors({
+      name: nameResult.valid ? "" : nameResult.message,
+      description: descriptionResult.valid ? "" : descriptionResult.message,
+    })
+    if (!nameResult.valid || !descriptionResult.valid) return
+
+    const members = membersText
+      .split(/\n|,/)
+      .map((m) => m.trim())
+      .filter((m) => /^G[A-Z2-7]{55}$/.test(m))
+
+    const config: PoolTemplateConfig = {
+      name: name.trim(),
+      description: description.trim() || null,
+      poolType,
+      members,
+      token: "XLM",
+    }
+    if (poolType === "rotational") {
+      config.amount = amount.trim()
+      config.frequency = frequency
+    } else if (poolType === "target") {
+      config.targetAmount = targetAmount.trim()
+      config.deadlineDays = deadlineDays.trim()
+    } else {
+      config.minimumDeposit = minimumDeposit.trim()
+      config.withdrawalFee = withdrawalFee.trim()
+      config.enableYield = enableYield
+    }
+
+    setSaving(true)
+    try {
+      const res = await fetch("/api/templates", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-wallet-address": address,
+        },
+        body: JSON.stringify({
+          creator_address: address,
+          name: name.trim(),
+          description: description.trim() || null,
+          pool_type: poolType,
+          config,
+          is_public: isPublic,
+        }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => null)
+        throw new Error(data?.error || "Failed to save template")
+      }
+      toastManager.success("Template created")
+      onOpenChange(false)
+      onSaved()
+    } catch (error) {
+      toastManager.error((error as Error).message || "Failed to save template")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-xl max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Create Template</DialogTitle>
+          <DialogDescription>
+            Build a reusable pool configuration from scratch. You can pre-fill the creation form
+            with it at any time.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <Label htmlFor="create-template-name">Template Name</Label>
+            <div className="flex items-center gap-2">
+              <Input
+                id="create-template-name"
+                maxLength={TEMPLATE_NAME_MAX_LENGTH}
+                placeholder="e.g., Monthly Family Tanda"
+                value={name}
+                onChange={(e) => {
+                  setName(e.target.value)
+                  if (errors.name) setErrors((prev) => ({ ...prev, name: "" }))
+                }}
+              />
+              <span
+                className={`text-xs tabular-nums shrink-0 ${name.length > 45 ? "text-destructive" : "text-muted-foreground"}`}
+              >
+                {name.length}/{TEMPLATE_NAME_MAX_LENGTH}
+              </span>
+            </div>
+            {errors.name && <FieldError message={errors.name} />}
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="create-template-description">Description (optional)</Label>
+            <Textarea
+              id="create-template-description"
+              maxLength={TEMPLATE_DESCRIPTION_MAX_LENGTH}
+              placeholder="Describe what this template is for"
+              rows={2}
+              value={description}
+              onChange={(e) => {
+                setDescription(e.target.value)
+                if (errors.description) setErrors((prev) => ({ ...prev, description: "" }))
+              }}
+            />
+            {errors.description && <FieldError message={errors.description} />}
+          </div>
+
+          <div className="space-y-1">
+            <Label>Pool Type</Label>
+            <Select value={poolType} onValueChange={(v) => setPoolType(v as TemplatePoolType)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {Object.entries(POOL_TYPE_LABELS).map(([value, label]) => (
+                  <SelectItem key={value} value={value}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {poolType === "rotational" && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="space-y-1">
+                <Label htmlFor="create-template-amount">Contribution Amount (XLM)</Label>
+                <Input
+                  id="create-template-amount"
+                  type="number"
+                  step="0.01"
+                  min="0.01"
+                  placeholder="100"
+                  value={amount}
+                  onChange={(e) => setAmount(e.target.value)}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label>Payout Frequency</Label>
+                <Select value={frequency} onValueChange={setFrequency}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {FREQUENCIES.map((f) => (
+                      <SelectItem key={f.value} value={f.value}>
+                        {f.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          )}
+
+          {poolType === "target" && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="space-y-1">
+                <Label htmlFor="create-template-target">Target Amount (XLM)</Label>
+                <Input
+                  id="create-template-target"
+                  type="number"
+                  step="0.01"
+                  min="0.01"
+                  placeholder="5000"
+                  value={targetAmount}
+                  onChange={(e) => setTargetAmount(e.target.value)}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="create-template-deadline">Deadline (days)</Label>
+                <Input
+                  id="create-template-deadline"
+                  type="number"
+                  min="1"
+                  step="1"
+                  placeholder="30"
+                  value={deadlineDays}
+                  onChange={(e) => setDeadlineDays(e.target.value)}
+                />
+              </div>
+            </div>
+          )}
+
+          {poolType === "flexible" && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="space-y-1">
+                <Label htmlFor="create-template-minimum">Minimum Deposit (XLM)</Label>
+                <Input
+                  id="create-template-minimum"
+                  type="number"
+                  step="0.01"
+                  min="0.01"
+                  placeholder="50"
+                  value={minimumDeposit}
+                  onChange={(e) => setMinimumDeposit(e.target.value)}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="create-template-fee">Withdrawal Fee (%)</Label>
+                <Input
+                  id="create-template-fee"
+                  type="number"
+                  step="0.1"
+                  min="0"
+                  max="10"
+                  placeholder="1"
+                  value={withdrawalFee}
+                  onChange={(e) => setWithdrawalFee(e.target.value)}
+                />
+              </div>
+              <div className="flex items-center justify-between sm:col-span-2 rounded-lg border border-border p-4">
+                <div className="space-y-0.5">
+                  <Label htmlFor="create-template-yield">Enable Yield Generation</Label>
+                  <p className="text-sm text-muted-foreground">
+                    Stake idle funds in Stellar DeFi protocols for passive income.
+                  </p>
+                </div>
+                <Switch
+                  id="create-template-yield"
+                  checked={enableYield}
+                  onCheckedChange={setEnableYield}
+                  aria-label="Enable yield generation"
+                />
+              </div>
+            </div>
+          )}
+
+          <div className="space-y-1">
+            <Label htmlFor="create-template-members">Member Addresses (optional)</Label>
+            <Textarea
+              id="create-template-members"
+              placeholder={
+                "One Stellar address per line (G…)\nPre-fills the member list when used."
+              }
+              rows={3}
+              value={membersText}
+              onChange={(e) => setMembersText(e.target.value)}
+              className="font-mono text-xs"
+            />
+          </div>
+
+          <div className="flex items-center justify-between rounded-lg border border-border p-4">
+            <div className="space-y-0.5">
+              <Label htmlFor="create-template-public">Share with community</Label>
+              <p className="text-sm text-muted-foreground">
+                Public templates appear in the Community Templates tab.
+              </p>
+            </div>
+            <Switch
+              id="create-template-public"
+              checked={isPublic}
+              onCheckedChange={setIsPublic}
+              aria-label="Make template public"
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={saving || !address}>
+            {saving ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Saving…
+              </>
+            ) : (
+              "Create Template"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/components/templates/edit-template-dialog.tsx
+++ b/frontend/components/templates/edit-template-dialog.tsx
@@ -1,0 +1,324 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { FieldError } from "@/components/ui/form"
+import { Loader2 } from "lucide-react"
+import { toastManager } from "@/lib/toast"
+import {
+  type PoolTemplate,
+  validateTemplateName,
+  validateTemplateDescription,
+  TEMPLATE_NAME_MAX_LENGTH,
+  TEMPLATE_DESCRIPTION_MAX_LENGTH,
+} from "@/lib/templates"
+
+/**
+ * Edit dialog for a template the user owns (issue #226). Updates the name,
+ * description, visibility, and the serialized pool configuration.
+ */
+export function EditTemplateDialog({
+  template,
+  open,
+  onOpenChange,
+  address,
+  onSaved,
+}: {
+  template: PoolTemplate | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  address: string | null
+  onSaved: () => void
+}) {
+  const [name, setName] = useState("")
+  const [description, setDescription] = useState("")
+  const [isPublic, setIsPublic] = useState(false)
+  const [amount, setAmount] = useState("")
+  const [targetAmount, setTargetAmount] = useState("")
+  const [minimumDeposit, setMinimumDeposit] = useState("")
+  const [frequency, setFrequency] = useState("weekly")
+  const [withdrawalFee, setWithdrawalFee] = useState("1")
+  const [enableYield, setEnableYield] = useState(false)
+  const [deadlineDays, setDeadlineDays] = useState("")
+  const [membersText, setMembersText] = useState("")
+  const [saving, setSaving] = useState(false)
+  const [errors, setErrors] = useState<{ name?: string; description?: string }>({})
+
+  useEffect(() => {
+    if (open && template) {
+      const config = template.config
+      setName(config.name || template.name)
+      setDescription(config.description || template.description || "")
+      setIsPublic(template.is_public)
+      setAmount(config.amount || "")
+      setTargetAmount(config.targetAmount || "")
+      setMinimumDeposit(config.minimumDeposit || "")
+      setFrequency(config.frequency || "weekly")
+      setWithdrawalFee(config.withdrawalFee || "1")
+      setEnableYield(config.enableYield || false)
+      setDeadlineDays(config.deadlineDays || "")
+      setMembersText((config.members || []).join("\n"))
+      setErrors({})
+    }
+  }, [open, template])
+
+  if (!template) return null
+
+  const handleSave = async () => {
+    if (!address) {
+      toastManager.error("Connect your wallet before editing a template")
+      return
+    }
+    const nameResult = validateTemplateName(name)
+    const descriptionResult = validateTemplateDescription(description)
+    setErrors({
+      name: nameResult.valid ? "" : nameResult.message,
+      description: descriptionResult.valid ? "" : descriptionResult.message,
+    })
+    if (!nameResult.valid || !descriptionResult.valid) return
+
+    const members = membersText
+      .split(/\n|,/)
+      .map((m) => m.trim())
+      .filter((m) => /^G[A-Z2-7]{55}$/.test(m))
+
+    const config = {
+      ...template.config,
+      name: name.trim(),
+      description: description.trim() || null,
+      members,
+    }
+    if (template.pool_type === "rotational") {
+      config.amount = amount.trim()
+      config.frequency = frequency
+    } else if (template.pool_type === "target") {
+      config.targetAmount = targetAmount.trim()
+      config.deadlineDays = deadlineDays.trim()
+    } else {
+      config.minimumDeposit = minimumDeposit.trim()
+      config.withdrawalFee = withdrawalFee.trim()
+      config.enableYield = enableYield
+    }
+
+    setSaving(true)
+    try {
+      const res = await fetch(`/api/templates/${template.id}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          "x-wallet-address": address,
+        },
+        body: JSON.stringify({
+          wallet: address,
+          name: name.trim(),
+          description: description.trim() || null,
+          config,
+          is_public: isPublic,
+        }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => null)
+        throw new Error(data?.error || "Failed to update template")
+      }
+      toastManager.success("Template updated")
+      onOpenChange(false)
+      onSaved()
+    } catch (error) {
+      toastManager.error((error as Error).message || "Failed to update template")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-xl max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Edit Template</DialogTitle>
+          <DialogDescription>Update this template's details and configuration.</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <Label htmlFor="edit-template-name">Template Name</Label>
+            <div className="flex items-center gap-2">
+              <Input
+                id="edit-template-name"
+                maxLength={TEMPLATE_NAME_MAX_LENGTH}
+                value={name}
+                onChange={(e) => {
+                  setName(e.target.value)
+                  if (errors.name) setErrors((prev) => ({ ...prev, name: "" }))
+                }}
+              />
+              <span
+                className={`text-xs tabular-nums shrink-0 ${name.length > 45 ? "text-destructive" : "text-muted-foreground"}`}
+              >
+                {name.length}/{TEMPLATE_NAME_MAX_LENGTH}
+              </span>
+            </div>
+            {errors.name && <FieldError message={errors.name} />}
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="edit-template-description">Description (optional)</Label>
+            <Textarea
+              id="edit-template-description"
+              maxLength={TEMPLATE_DESCRIPTION_MAX_LENGTH}
+              rows={2}
+              value={description}
+              onChange={(e) => {
+                setDescription(e.target.value)
+                if (errors.description) setErrors((prev) => ({ ...prev, description: "" }))
+              }}
+            />
+            {errors.description && <FieldError message={errors.description} />}
+          </div>
+
+          {template.pool_type === "rotational" && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="space-y-1">
+                <Label htmlFor="edit-template-amount">Contribution Amount (XLM)</Label>
+                <Input
+                  id="edit-template-amount"
+                  type="number"
+                  step="0.01"
+                  min="0.01"
+                  value={amount}
+                  onChange={(e) => setAmount(e.target.value)}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="edit-template-frequency">Payout Frequency</Label>
+                <Input
+                  id="edit-template-frequency"
+                  value={frequency}
+                  onChange={(e) => setFrequency(e.target.value)}
+                />
+              </div>
+            </div>
+          )}
+
+          {template.pool_type === "target" && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="space-y-1">
+                <Label htmlFor="edit-template-target">Target Amount (XLM)</Label>
+                <Input
+                  id="edit-template-target"
+                  type="number"
+                  step="0.01"
+                  min="0.01"
+                  value={targetAmount}
+                  onChange={(e) => setTargetAmount(e.target.value)}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="edit-template-deadline">Deadline (days)</Label>
+                <Input
+                  id="edit-template-deadline"
+                  type="number"
+                  min="1"
+                  step="1"
+                  value={deadlineDays}
+                  onChange={(e) => setDeadlineDays(e.target.value)}
+                />
+              </div>
+            </div>
+          )}
+
+          {template.pool_type === "flexible" && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="space-y-1">
+                <Label htmlFor="edit-template-minimum">Minimum Deposit (XLM)</Label>
+                <Input
+                  id="edit-template-minimum"
+                  type="number"
+                  step="0.01"
+                  min="0.01"
+                  value={minimumDeposit}
+                  onChange={(e) => setMinimumDeposit(e.target.value)}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="edit-template-fee">Withdrawal Fee (%)</Label>
+                <Input
+                  id="edit-template-fee"
+                  type="number"
+                  step="0.1"
+                  min="0"
+                  max="10"
+                  value={withdrawalFee}
+                  onChange={(e) => setWithdrawalFee(e.target.value)}
+                />
+              </div>
+              <div className="flex items-center justify-between sm:col-span-2 rounded-lg border border-border p-4">
+                <Label htmlFor="edit-template-yield">Enable Yield Generation</Label>
+                <Switch
+                  id="edit-template-yield"
+                  checked={enableYield}
+                  onCheckedChange={setEnableYield}
+                  aria-label="Enable yield generation"
+                />
+              </div>
+            </div>
+          )}
+
+          <div className="space-y-1">
+            <Label htmlFor="edit-template-members">Member Addresses (optional)</Label>
+            <Textarea
+              id="edit-template-members"
+              rows={3}
+              value={membersText}
+              onChange={(e) => setMembersText(e.target.value)}
+              className="font-mono text-xs"
+              placeholder="One Stellar address per line (G…)"
+            />
+          </div>
+
+          <div className="flex items-center justify-between rounded-lg border border-border p-4">
+            <div className="space-y-0.5">
+              <Label htmlFor="edit-template-public">Share with community</Label>
+              <p className="text-sm text-muted-foreground">
+                Public templates appear in the Community Templates tab.
+              </p>
+            </div>
+            <Switch
+              id="edit-template-public"
+              checked={isPublic}
+              onCheckedChange={setIsPublic}
+              aria-label="Make template public"
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={saving || !address}>
+            {saving ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Saving…
+              </>
+            ) : (
+              "Save Changes"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/components/templates/save-template-dialog.tsx
+++ b/frontend/components/templates/save-template-dialog.tsx
@@ -1,0 +1,185 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Switch } from "@/components/ui/switch"
+import { Label } from "@/components/ui/label"
+import { FieldError } from "@/components/ui/form"
+import { Loader2 } from "lucide-react"
+import { toastManager } from "@/lib/toast"
+import {
+  type PoolTemplateConfig,
+  validateTemplateName,
+  validateTemplateDescription,
+  TEMPLATE_NAME_MAX_LENGTH,
+  TEMPLATE_DESCRIPTION_MAX_LENGTH,
+} from "@/lib/templates"
+
+/**
+ * "Save as Template" dialog (issue #226). Opened from the pool creation
+ * forms — saves the current pool configuration as a reusable template.
+ */
+export function SaveTemplateDialog({
+  open,
+  onOpenChange,
+  config,
+  creatorAddress,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  config: PoolTemplateConfig
+  creatorAddress: string | null
+}) {
+  const [name, setName] = useState(config.name)
+  const [description, setDescription] = useState(config.description || "")
+  const [isPublic, setIsPublic] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [errors, setErrors] = useState<{ name?: string; description?: string }>({})
+
+  useEffect(() => {
+    if (open) {
+      setName(config.name)
+      setDescription(config.description || "")
+      setIsPublic(false)
+      setErrors({})
+    }
+  }, [open, config])
+
+  const handleSave = async () => {
+    if (!creatorAddress) {
+      toastManager.error("Connect your wallet before saving a template")
+      return
+    }
+    const nameResult = validateTemplateName(name)
+    const descriptionResult = validateTemplateDescription(description)
+    setErrors({
+      name: nameResult.valid ? "" : nameResult.message,
+      description: descriptionResult.valid ? "" : descriptionResult.message,
+    })
+    if (!nameResult.valid || !descriptionResult.valid) return
+
+    setSaving(true)
+    try {
+      const res = await fetch("/api/templates", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-wallet-address": creatorAddress,
+        },
+        body: JSON.stringify({
+          creator_address: creatorAddress,
+          name: name.trim(),
+          description: description.trim() || null,
+          pool_type: config.poolType,
+          config,
+          is_public: isPublic,
+        }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => null)
+        throw new Error(data?.error || "Failed to save template")
+      }
+      toastManager.success("Template saved")
+      onOpenChange(false)
+    } catch (error) {
+      toastManager.error((error as Error).message || "Failed to save template")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Save as Template</DialogTitle>
+          <DialogDescription>
+            Reuse this pool configuration later — or share it with the community — without
+            re-entering every field.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <Label htmlFor="template-name">Template Name</Label>
+            <div className="flex items-center gap-2">
+              <Input
+                id="template-name"
+                maxLength={TEMPLATE_NAME_MAX_LENGTH}
+                placeholder="e.g., Monthly Family Tanda"
+                value={name}
+                onChange={(e) => {
+                  setName(e.target.value)
+                  if (errors.name) setErrors((prev) => ({ ...prev, name: "" }))
+                }}
+              />
+              <span
+                className={`text-xs tabular-nums shrink-0 ${name.length > 45 ? "text-destructive" : "text-muted-foreground"}`}
+              >
+                {name.length}/{TEMPLATE_NAME_MAX_LENGTH}
+              </span>
+            </div>
+            {errors.name && <FieldError message={errors.name} />}
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="template-description">Description (optional)</Label>
+            <Textarea
+              id="template-description"
+              maxLength={TEMPLATE_DESCRIPTION_MAX_LENGTH}
+              placeholder="Describe what this template is for"
+              rows={3}
+              value={description}
+              onChange={(e) => {
+                setDescription(e.target.value)
+                if (errors.description) setErrors((prev) => ({ ...prev, description: "" }))
+              }}
+            />
+            {errors.description && <FieldError message={errors.description} />}
+          </div>
+
+          <div className="flex items-center justify-between rounded-lg border border-border p-4">
+            <div className="space-y-0.5">
+              <Label htmlFor="template-public">Share with community</Label>
+              <p className="text-sm text-muted-foreground">
+                Public templates appear in the Community Templates tab.
+              </p>
+            </div>
+            <Switch
+              id="template-public"
+              checked={isPublic}
+              onCheckedChange={setIsPublic}
+              aria-label="Make template public"
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={saving || !creatorAddress}>
+            {saving ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Saving…
+              </>
+            ) : (
+              "Save Template"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/components/templates/use-template-dialog.tsx
+++ b/frontend/components/templates/use-template-dialog.tsx
@@ -1,0 +1,219 @@
+"use client"
+
+import { useEffect, useState, useCallback } from "react"
+import { useRouter } from "next/navigation"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Users, Repeat, Loader2, LayoutTemplate } from "lucide-react"
+import { toastManager } from "@/lib/toast"
+import { formatRelativeTime } from "@/lib/utils"
+import type { TemplatePoolType } from "@/lib/templates"
+
+interface TemplateListItem {
+  id: string
+  name: string
+  description: string | null
+  pool_type: TemplatePoolType
+  config: { amount?: string; targetAmount?: string; minimumDeposit?: string; members?: string[] }
+  is_public: boolean
+  use_count: number
+  created_at: string
+}
+
+function poolTypeLabel(type: TemplatePoolType) {
+  return type === "rotational" ? "Rotational" : type === "target" ? "Target" : "Flexible"
+}
+
+/**
+ * "Use Template" dialog (issue #226). Opens from the top of the pool creation
+ * form — shows the caller's templates plus community templates for the current
+ * pool type, then navigates to the pre-filled creation form.
+ */
+export function UseTemplateDialog({
+  open,
+  onOpenChange,
+  poolType,
+  address,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  poolType: TemplatePoolType
+  address: string | null
+}) {
+  const router = useRouter()
+  const [mine, setMine] = useState<TemplateListItem[]>([])
+  const [community, setCommunity] = useState<TemplateListItem[]>([])
+  const [loading, setLoading] = useState(false)
+  const [usingId, setUsingId] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const [mineRes, communityRes] = await Promise.all([
+        address
+          ? fetch(`/api/templates?wallet=${encodeURIComponent(address.toLowerCase())}`)
+          : Promise.resolve(null),
+        fetch(`/api/templates/community?pool_type=${poolType}&sort=popular&page=0`),
+      ])
+
+      let mineData: { data: TemplateListItem[] } = { data: [] }
+      if (mineRes) {
+        const parsed = await mineRes.json().catch(() => ({ data: [] }))
+        mineData = parsed ?? { data: [] }
+      }
+      const communityParsed = await communityRes.json().catch(() => ({ data: [] }))
+      const communityData = communityParsed ?? { data: [] }
+
+      const mineList = (mineData.data || []).filter(
+        (t: TemplateListItem) => t.pool_type === poolType
+      )
+      const mineIds = new Set(mineList.map((t) => t.id))
+      const communityList = (communityData.data || []).filter(
+        (t: TemplateListItem) => t.pool_type === poolType && !mineIds.has(t.id)
+      )
+
+      setMine(mineList)
+      setCommunity(communityList)
+    } finally {
+      setLoading(false)
+    }
+  }, [address, poolType])
+
+  useEffect(() => {
+    if (open) load()
+  }, [open, load])
+
+  const handleUse = async (template: TemplateListItem) => {
+    if (!address) {
+      toastManager.error("Connect your wallet to use a template")
+      return
+    }
+    setUsingId(template.id)
+    // Bump the use count (best-effort — never blocks navigation).
+    await fetch(`/api/templates/${template.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", "x-wallet-address": address },
+      body: JSON.stringify({ incrementUse: true }),
+    }).catch(() => {})
+    onOpenChange(false)
+    router.push(`/dashboard/create/${template.pool_type}?template=${template.id}`)
+  }
+
+  const renderCard = (template: TemplateListItem, showUseButton: boolean) => (
+    <li
+      key={template.id}
+      className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 rounded-lg border border-border p-4"
+    >
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <p className="font-medium truncate">{template.name}</p>
+          <Badge variant="secondary" className="text-[10px] capitalize shrink-0">
+            {poolTypeLabel(template.pool_type)}
+          </Badge>
+          {template.is_public && (
+            <Badge variant="outline" className="text-[10px] shrink-0">
+              Community
+            </Badge>
+          )}
+        </div>
+        {template.description && (
+          <p className="text-sm text-muted-foreground truncate mt-0.5">{template.description}</p>
+        )}
+        <div className="flex items-center gap-3 text-xs text-muted-foreground mt-1.5">
+          <span className="flex items-center gap-1">
+            <Users className="h-3 w-3" />
+            {template.config.members?.length ? template.config.members.length + 1 : "—"} members
+          </span>
+          <span className="flex items-center gap-1">
+            <Repeat className="h-3 w-3" />
+            used {template.use_count}×
+          </span>
+          <span className="hidden sm:inline">
+            {formatRelativeTime(new Date(template.created_at))}
+          </span>
+        </div>
+      </div>
+      {showUseButton && (
+        <Button
+          size="sm"
+          variant="outline"
+          className="shrink-0"
+          disabled={usingId === template.id}
+          onClick={() => handleUse(template)}
+        >
+          {usingId === template.id ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Loading…
+            </>
+          ) : (
+            "Use Template"
+          )}
+        </Button>
+      )}
+    </li>
+  )
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <LayoutTemplate className="h-5 w-5 text-primary" />
+            Use a Template
+          </DialogTitle>
+          <DialogDescription>
+            Pick a saved configuration to pre-fill this form. You can edit any value before creating
+            the pool.
+          </DialogDescription>
+        </DialogHeader>
+
+        {loading ? (
+          <div className="space-y-3">
+            {[0, 1, 2].map((i) => (
+              <Skeleton key={i} className="h-20 w-full" />
+            ))}
+          </div>
+        ) : (
+          <div className="max-h-[50vh] overflow-y-auto space-y-6 pr-1">
+            {mine.length > 0 && (
+              <section>
+                <h3 className="text-sm font-medium text-muted-foreground mb-2">My Templates</h3>
+                <ul className="space-y-2">{mine.map((t) => renderCard(t, true))}</ul>
+              </section>
+            )}
+
+            <section>
+              <h3 className="text-sm font-medium text-muted-foreground mb-2">
+                Community Templates
+              </h3>
+              {community.length > 0 ? (
+                <ul className="space-y-2">{community.map((t) => renderCard(t, true))}</ul>
+              ) : (
+                <p className="text-sm text-muted-foreground rounded-lg border border-dashed border-border p-4">
+                  No public templates for {poolTypeLabel(poolType).toLowerCase()} pools yet — save
+                  one from this form and it will appear here.
+                </p>
+              )}
+            </section>
+
+            {mine.length === 0 && community.length === 0 && (
+              <p className="text-sm text-muted-foreground">
+                No templates available yet. Save this configuration as a template using the link
+                below the submit button.
+              </p>
+            )}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/lib/supabase.ts
+++ b/frontend/lib/supabase.ts
@@ -416,6 +416,42 @@ export type Database = {
         }
         Relationships: []
       }
+      pool_templates: {
+        Row: {
+          id: string
+          creator_address: string
+          name: string
+          description: string | null
+          pool_type: "rotational" | "target" | "flexible"
+          config: Record<string, unknown>
+          is_public: boolean
+          use_count: number
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          creator_address: string
+          name: string
+          description?: string | null
+          pool_type: "rotational" | "target" | "flexible"
+          config: Record<string, unknown>
+          is_public?: boolean
+          use_count?: number
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          name?: string
+          description?: string | null
+          pool_type?: "rotational" | "target" | "flexible"
+          config?: Record<string, unknown>
+          is_public?: boolean
+          use_count?: number
+          updated_at?: string
+        }
+        Relationships: []
+      }
     }
     // supabase-js v2 requires these keys on the schema type; without them the
     // client can't match GenericSchema and every table degrades to `never`.

--- a/frontend/lib/templates.ts
+++ b/frontend/lib/templates.ts
@@ -1,0 +1,98 @@
+/**
+ * Pool template system (issue #226).
+ *
+ * Users can save a pool creation configuration as a named template, browse
+ * community-shared templates, and create a pool from a template with one
+ * click. This module holds the shared types, config shape, and validation
+ * used by the API routes, the templates page, and the creation forms.
+ */
+
+export const TEMPLATE_NAME_MAX_LENGTH = 50 as const
+export const TEMPLATE_DESCRIPTION_MAX_LENGTH = 200 as const
+
+export const TEMPLATE_POOL_TYPES = ["rotational", "target", "flexible"] as const
+export type TemplatePoolType = (typeof TEMPLATE_POOL_TYPES)[number]
+
+/**
+ * Serialized pool creation parameters stored in `pool_templates.config`.
+ * Mirrors the fields the pool creation forms submit, keyed the same way the
+ * creation page's `DuplicatePrefill` expects them so a template can pre-fill
+ * a form directly.
+ */
+export interface PoolTemplateConfig {
+  name: string
+  description: string | null
+  poolType: TemplatePoolType
+  /** Rotational: per-round contribution amount (string, matches form input). */
+  amount?: string
+  /** Target: total savings goal (string). */
+  targetAmount?: string
+  /** Flexible: minimum deposit per transaction (string). */
+  minimumDeposit?: string
+  /** Rotational payout frequency: daily | weekly | biweekly | monthly. */
+  frequency?: string
+  /** Flexible withdrawal fee in percent (string, 0–10). */
+  withdrawalFee?: string
+  /** Flexible yield generation toggle. */
+  enableYield?: boolean
+  /** Target deadline in days from creation (string). */
+  deadlineDays?: string
+  /** Member Stellar addresses (creator excluded — always implied). */
+  members: string[]
+  /** "XLM", "USDC", or a SEP-41 contract id. */
+  token: string
+}
+
+export interface PoolTemplate {
+  id: string
+  creator_address: string
+  name: string
+  description: string | null
+  pool_type: TemplatePoolType
+  config: PoolTemplateConfig
+  is_public: boolean
+  use_count: number
+  created_at: string
+  updated_at: string
+}
+
+export function isTemplatePoolType(value: unknown): value is TemplatePoolType {
+  return typeof value === "string" && (TEMPLATE_POOL_TYPES as readonly string[]).includes(value)
+}
+
+/** Template name is required and limited to 50 chars (mirrors pool names). */
+export function validateTemplateName(name: unknown): { valid: boolean; message: string } {
+  if (typeof name !== "string" || name.trim().length === 0) {
+    return { valid: false, message: "Template name is required" }
+  }
+  if (name.length > TEMPLATE_NAME_MAX_LENGTH) {
+    return {
+      valid: false,
+      message: `Template name cannot exceed ${TEMPLATE_NAME_MAX_LENGTH} characters`,
+    }
+  }
+  return { valid: true, message: "" }
+}
+
+/** Template description is optional and limited to 200 chars. */
+export function validateTemplateDescription(description: unknown): {
+  valid: boolean
+  message: string
+} {
+  if (description == null || description === "") return { valid: true, message: "" }
+  if (typeof description !== "string") {
+    return { valid: false, message: "Template description must be text" }
+  }
+  if (description.length > TEMPLATE_DESCRIPTION_MAX_LENGTH) {
+    return {
+      valid: false,
+      message: `Template description cannot exceed ${TEMPLATE_DESCRIPTION_MAX_LENGTH} characters`,
+    }
+  }
+  return { valid: true, message: "" }
+}
+
+/** The config must be a non-null object holding the pool creation parameters. */
+export function isTemplateConfig(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "start": "next start",
-    "test:unit": "tsx --test lib/csv-export.test.ts lib/activity-query.test.ts lib/soroban-event-mapping.test.ts lib/analytics.test.ts lib/pool-health.test.ts lib/form-validation.test.ts lib/member-filters.test.ts lib/contract-version.test.ts lib/error-reporting.test.ts lib/pending-transactions.test.ts hooks/use-keyboard-shortcuts.test.ts app/api/admin/audit-log/route.test.ts app/api/admin/actions/route.test.ts app/api/errors/route.test.ts components/error-boundary.test.ts app/api/notifications/route.test.ts app/api/user-profile/route.test.ts app/api/portfolio/summary/route.test.ts",
+    "test:unit": "tsx --test lib/csv-export.test.ts lib/activity-query.test.ts lib/soroban-event-mapping.test.ts lib/analytics.test.ts lib/pool-health.test.ts lib/form-validation.test.ts lib/member-filters.test.ts lib/contract-version.test.ts lib/error-reporting.test.ts lib/pending-transactions.test.ts hooks/use-keyboard-shortcuts.test.ts app/api/admin/audit-log/route.test.ts app/api/admin/actions/route.test.ts app/api/errors/route.test.ts components/error-boundary.test.ts app/api/notifications/route.test.ts app/api/user-profile/route.test.ts app/api/portfolio/summary/route.test.ts app/api/templates/route.test.ts",
     "test:components": "vitest run",
     "test:components:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",

--- a/supabase/migrations/20260819000000_pool_templates.sql
+++ b/supabase/migrations/20260819000000_pool_templates.sql
@@ -1,0 +1,93 @@
+-- Migration: pool_templates
+-- Reusable pool configurations (issue #226). Users can save the parameters of
+-- a pool creation form as a named template, browse community-shared templates,
+-- and create a new pool from a template with one click.
+
+CREATE TABLE IF NOT EXISTS public.pool_templates (
+  id              uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  creator_address text        NOT NULL,
+  name            text        NOT NULL,
+  description     text,
+  pool_type       text        NOT NULL,
+  config          jsonb       NOT NULL,
+  is_public       boolean     NOT NULL DEFAULT false,
+  use_count       integer     NOT NULL DEFAULT 0,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+
+  -- Enforce the same limits the UI applies (template name max 50 chars,
+  -- description max 200 chars, pool type restricted to the three supported
+  -- savings modes).
+  CONSTRAINT pool_templates_pool_type CHECK (pool_type IN ('rotational', 'target', 'flexible')),
+  CONSTRAINT pool_templates_name_length CHECK (char_length(name) <= 50),
+  CONSTRAINT pool_templates_description_length CHECK (description IS NULL OR char_length(description) <= 200),
+  -- creator_address is always stored lowercase so a direct Supabase client
+  -- write cannot sneak in mixed-case duplicates that bypass ownership checks.
+  CONSTRAINT pool_templates_creator_lowercase CHECK (creator_address = lower(creator_address)),
+  CONSTRAINT pool_templates_use_count_nonnegative CHECK (use_count >= 0)
+);
+
+-- Support "my templates" queries (most recent first per creator)
+CREATE INDEX idx_pool_templates_creator
+  ON public.pool_templates (creator_address, created_at DESC);
+
+-- Support the community feed (public templates, optionally filtered by pool
+-- type and ordered by popularity / recency)
+CREATE INDEX idx_pool_templates_public
+  ON public.pool_templates (is_public, pool_type, use_count DESC, created_at DESC);
+
+CREATE INDEX idx_pool_templates_updated
+  ON public.pool_templates (updated_at DESC);
+
+-- ── Row-Level Security ────────────────────────────────────────────────────────
+-- Ownership identity: the wallet claim on the Supabase JWT, mirroring the
+-- pool_messages RLS policy. Server-side API routes use the service-role key,
+-- which bypasses RLS, so ownership is also verified in the route handlers.
+ALTER TABLE public.pool_templates ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: creators can read their own; everyone can read public templates.
+CREATE POLICY "Pool template owners and public reads"
+  ON public.pool_templates
+  FOR SELECT
+  USING (
+    creator_address = lower(auth.jwt() ->> 'wallet_address')
+    OR is_public = true
+  );
+
+-- INSERT: a user may only create templates in their own name.
+CREATE POLICY "Pool template owners insert"
+  ON public.pool_templates
+  FOR INSERT
+  WITH CHECK (
+    lower(creator_address) = lower(auth.jwt() ->> 'wallet_address')
+  );
+
+-- UPDATE: owners only.
+CREATE POLICY "Pool template owners update"
+  ON public.pool_templates
+  FOR UPDATE
+  USING (creator_address = lower(auth.jwt() ->> 'wallet_address'))
+  WITH CHECK (creator_address = lower(auth.jwt() ->> 'wallet_address'));
+
+-- DELETE: owners only.
+CREATE POLICY "Pool template owners delete"
+  ON public.pool_templates
+  FOR DELETE
+  USING (creator_address = lower(auth.jwt() ->> 'wallet_address'));
+
+-- ── Updated-at trigger ───────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.touch_pool_templates()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS pool_templates_touch_updated ON public.pool_templates;
+CREATE TRIGGER pool_templates_touch_updated
+  BEFORE UPDATE ON public.pool_templates
+  FOR EACH ROW
+  EXECUTE FUNCTION public.touch_pool_templates();


### PR DESCRIPTION
## Overview

This PR adds a **Pool Template System** so users can save a pool creation configuration as a reusable template, browse community-shared templates, and spin up a new pool from a template with one click — no more re-entering every parameter for repeat pools (e.g. a community organizer running monthly tandas).

## Related Issue

Closes #226

## Changes

### 🗄️ Database

* **[ADD]** `supabase/migrations/20260819000000_pool_templates.sql`
  * New `pool_templates` table: `id`, `creator_address`, `name` (≤50), `description` (≤200, nullable), `pool_type` (`rotational`|`target`|`flexible`), `config` (jsonb), `is_public`, `use_count`, `created_at`, `updated_at`.
  * Check constraints enforce name/description limits, allowed pool types, lowercase `creator_address`, and non-negative `use_count`.
  * Indexes for "my templates" (creator, newest first) and the community feed (public, pool type, popularity/recency).
  * RLS: creators can read/write their own; everyone can read public templates; `updated_at` auto-touch trigger.

* **[MODIFY]** `frontend/lib/supabase.ts` — add `pool_templates` Row/Insert/Update types to the generated Database schema.

### 🔌 API

* **[ADD]** `frontend/app/api/templates/route.ts`
  * `POST /api/templates` — create a template (validates name/description/pool_type/config).
  * `GET /api/templates?id=X` — fetch a single template (own or public).
  * `GET /api/templates?wallet=X` — fetch the caller's templates, newest first.

* **[ADD]** `frontend/app/api/templates/community/route.ts`
  * `GET /api/templates/community?pool_type=X&sort=popular|recent&page=N` — public community feed, paginated, sorted by popularity (`use_count`) or recency.

* **[ADD]** `frontend/app/api/templates/[id]/route.ts`
  * `PUT /api/templates/[id]` — owner-only update of name/description/pool_type/config/is_public, plus a public `{ incrementUse: true }` usage bump.
  * `DELETE /api/templates/[id]` — owner-only delete.

* **[ADD]** `frontend/app/api/templates/route.test.ts` — 14 unit tests for name/description/pool-type/config validation.

### 🎨 Frontend

* **[ADD]** `frontend/app/dashboard/templates/page.tsx`
  * Two tabs: **My Templates** and **Community Templates**.
  * Template cards show name, pool type, primary amount, member count, use count, and relative created time.
  * "Use Template" navigates to a pre-filled creation form and bumps the use count; owners can edit/delete their own templates.
  * Community tab filters by pool type and sorts by popularity/recent.

* **[ADD]** `frontend/components/templates/save-template-dialog.tsx`
  * "Save as Template" dialog on all three creation forms — name, description, and community-visibility toggle.

* **[ADD]** `frontend/components/templates/use-template-dialog.tsx`
  * "Use Template" dialog at the top of the creation form — shows the caller's templates plus public templates for the current pool type.

* **[ADD]** `frontend/components/templates/create-template-dialog.tsx` / `edit-template-dialog.tsx`
  * Build/edit a reusable configuration from scratch on the templates page (pool-type-specific fields + members + visibility).

* **[MODIFY]** Pool creation form
  * `frontend/app/dashboard/create/[type]/page.tsx` — reads `?template=<id>`, fetches and pre-fills the matching form; switches pool-type route if needed; renders loading/error states.
  * `frontend/components/create-group/{rotational,target,flexible}-form.tsx` — "Save as Template" link below submit; seed every field (incl. target `deadlineDays` and flexible `withdrawalFee`/`enableYield`) from the prefill.
  * `frontend/components/create-group/token-select.tsx` — `tokenFromPrefill()` + `defaultToken` so a template's XLM/USDC/custom token is reflected in the picker.

* **[MODIFY]** `frontend/components/dashboard/dashboard-header.tsx` — "Templates" nav link.

## Verification Results

```
pnpm exec tsx --test app/api/templates/route.test.ts
# tests 14
# pass 14
# fail 0

pnpm run test:unit
# tests 168
# pass 168
# fail 0

pnpm exec tsc --noEmit  (feature files only — clean)
pnpm exec eslint ...    (0 errors on all feature files)
```

| Acceptance Criteria | Status |
| --- | --- |
| Users can save pool creation configurations as named templates | ✅ "Save as Template" on every creation form + "Create Template" dialog |
| Templates store all pool creation parameters correctly | ✅ `config` jsonb captures amount/goal/min-deposit, frequency, deadline, fee, yield, members, token |
| Public templates appear in the community templates tab | ✅ `/api/templates/community` feed + Community tab |
| Community templates are sorted by popularity (use count) | ✅ `sort=popular` orders by `use_count DESC` (default) |
| "Use Template" pre-fills the pool creation form correctly | ✅ `?template=<id>` loads config and seeds every form field (incl. deadline, fee, yield, token) |
| Users can modify pre-filled values before creating the pool | ✅ All fields remain editable; submit deploys a new independent contract |
| Use count increments each time a template is used | ✅ `{ incrementUse: true }` bump on use, best-effort |
| Users can edit and delete their own templates | ✅ Owner-only PUT/DELETE + edit dialog |
| Templates are fully responsive on mobile | ✅ Cards/dialogs use responsive flex layouts and grid breakpoints |